### PR TITLE
move koreClear call prior to first call to koreAllocAlwaysGC in step

### DIFF
--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -791,7 +791,6 @@ llvm::BasicBlock *stepFunctionHeader(
       module->getContext(), "step", block->getParent());
   llvm::BranchInst::Create(stuck, merge, isFinished, block);
 
-  insertCallToClear(merge);
   return merge;
 }
 
@@ -850,6 +849,11 @@ void makeStepFunction(
     resultCapacity = new llvm::AllocaInst(
         llvm::Type::getInt64Ty(module->getContext()), 0, "resultCapacity",
         block);
+  }
+
+  insertCallToClear(block);
+
+  if (search) {
     llvm::Value *initialBuffer = allocateTerm(
         {SortCategory::Symbol, 0}, blockType, block, "koreAllocAlwaysGC");
     new llvm::StoreInst(initialBuffer, resultBuffer, block);
@@ -1057,6 +1061,7 @@ void makeStepFunction(
   }
   auto header = stepFunctionHeader(
       axiom->getOrdinal(), module, definition, block, stuck, args, types);
+  insertCallToClear(header);
   i = 0;
   Decision codegen(
       definition, header, fail, jump, choiceBuffer, choiceDepth, module,


### PR DESCRIPTION
function

This was a pretty obvious bug once I spotted it, but it took forever to track down. Basically, if are doing search, then we are calling `koreAllocAlwaysGC` once /prior/ to calling `koreClear` at the top of the stepAll function. This means that the memory we allocate for the result buffer of search results is immediately garbage collected and then written to after being freed, thus leading to memory corruption the next time the user writes to something that was allocated with `koreAllocAlwaysGC`.

It's a pretty simple fix; we just move the call to koreClear sooner in the function. Since it is a function that returns void and takes no arguments, this is pretty easy to do.