### PR TITLE
disable gc during hooks

### DIFF
--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -25,6 +25,8 @@ private:
       std::string name, KORECompositePattern *pattern, bool sret, bool tailcc);
   llvm::Value *
   notInjectionCase(KORECompositePattern *constructor, llvm::Value *val);
+  llvm::Value *disableGC(void);
+  void enableGC(llvm::Value *was_enabled);
 
 public:
   CreateTerm(

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -108,6 +108,8 @@ size_t hash_k(block *);
 void k_hash(block *, void *);
 bool hash_enter(void);
 void hash_exit(void);
+
+extern bool gc_enabled;
 }
 
 class KElem {
@@ -124,8 +126,6 @@ public:
 
   block *elem;
 };
-
-extern bool gc_enabled;
 
 struct kore_alloc_heap {
 


### PR DESCRIPTION
Many hooks can handle garbage collection happening during their allocations just fine, but some definitely can't, because the call frames corresponding to hooks do not generate stack maps. As a result, for simplicity's sake and to fix the cases where collection cannot happen safely, we simply disable garbage collection before calling a hook and re-enable it afterwards.