### PR TITLE
Generalise argument parsing in interpreters

### DIFF
--- a/runtime/main/main.ll
+++ b/runtime/main/main.ll
@@ -12,8 +12,47 @@ declare void @finish_rewriting(%block*, i1) #0
 
 declare void @initStaticObjects()
 
+@statistics.flag = private constant [13 x i8] c"--statistics\00"
+
 @output_file = external global i8*
 @statistics = external global i1
+
+declare i32 @strcmp(i8* %a, i8* %b)
+
+define void @parse_flags(i32 %argc, i8** %argv) {
+entry:
+  store i1 0, i1* @statistics
+  br label %header
+
+header:
+  %idx = phi i32 [ 4, %entry ], [ %idx.inc, %inc ]
+  %continue = icmp slt i32 %idx, %argc
+  br i1 %continue, label %body, label %exit
+
+body:
+  %argv.idx = getelementptr inbounds i8*, i8** %argv, i32 %idx
+  %arg = load i8*, i8** %argv.idx
+  br label %body.stats
+
+body.stats:
+  %stats.cmp = call i32 @strcmp(i8* %arg, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @statistics.flag, i64 0, i64 0))
+  %stats.eq = icmp eq i32 %stats.cmp, 0
+  br i1 %stats.eq, label %set.stats, label %body.tail
+
+set.stats:
+  store i1 1, i1* @statistics
+  br label %body.tail
+
+body.tail:
+  br label %inc
+
+inc:
+  %idx.inc = add i32 %idx, 1
+  br label %header
+
+exit:
+  ret void
+}
 
 define i32 @main(i32 %argc, i8** %argv) {
 entry:
@@ -25,8 +64,8 @@ entry:
   %output_ptr = getelementptr inbounds i8*, i8** %argv, i64 3
   %output_str = load i8*, i8** %output_ptr
   store i8* %output_str, i8** @output_file
-  %hasStatistics = icmp ne i32 %argc, 4
-  store i1 %hasStatistics, i1* @statistics
+  
+  call void @parse_flags(i32 %argc, i8** %argv)
 
   call void @initStaticObjects()
 

--- a/runtime/main/search.cpp
+++ b/runtime/main/search.cpp
@@ -12,11 +12,22 @@ take_search_steps(int64_t depth, block *subject);
 void printConfigurations(
     const char *filename, std::unordered_set<block *, HashBlock, KEq> results);
 
+static bool hasStatistics = false;
+
+void parse_flags(int argc, char **argv) {
+  for (int i = 4; i < argc; ++i) {
+    if (str_eq(argv[i], "--statistics")) {
+      hasStatistics = true;
+    }
+  }
+}
+
 int main(int argc, char **argv) {
   char *filename = argv[1];
   int64_t depth = atol(argv[2]);
   char *output = argv[3];
-  bool hasStatistics = argc != 4;
+
+  parse_flags(argc, argv);
 
   initStaticObjects();
 


### PR DESCRIPTION
Currently, compiled interpreters set the `@statistics` global option if `argc != 4` (i.e. there is a 4th positional argument supplied to the interpreter).

At some point we'll need to add a flag to interpreters that causes them to emit binary output rather than textual KORE; doing so will need a slightly more sophisticated argument parsing implementation than the above.

This PR does the initial generalisation work towards this, and should hopefully highlight any potential issues before we add additional flags.

The proposed new behaviour is to silently ignore any unknown flags; this will break anyone using the statistics option by passing a flag other than `--statistics` (which `krun` does when invoking the interpreter), so it's worth testing this PR carefully.

Adding new flags to the interpreter once this PR is merged is simply a case of adding new blocks to `parse_flags`.