### PR TITLE
Don't `cat` huge files in `llvm-krun`

### DIFF
--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -172,7 +172,15 @@ for name in "${params[@]}"; do
     KItem)
     ;;
     *)
-    printf -v "$var_name" %s "inj{Sort$sort{}, SortKItem{}}(${!var_name})"
+    if [ -z "${!file_name}" ]; then
+      printf -v "$var_name" %s "inj{Sort$sort{}, SortKItem{}}(${!var_name})"
+    else
+      temp_file="$(mktemp tmp.interpolate.XXXXXXXXXX)"
+      echo "inj{Sort$sort{}, SortKItem{}}(" >> "$temp_file"
+      cat "${!file_name}" >> "$temp_file"
+      echo ")" >> "$temp_file"
+      mv "$temp_file" "${!file_name}"
+    fi
     ;;
   esac
 done

--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -167,6 +167,7 @@ done
 for name in "${params[@]}"; do
   sort_name="sort_$name"
   var_name="params_$name"
+  file_name="file_$name"
   sort="${!sort_name}"
   case $sort in
     KItem)

--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -63,6 +63,7 @@ do
     name="$2"
     value="$3"
     var_name="params_$name"
+    file_name="file_$name"
     pretty_name="pretty_$name"
     sort_name="sort_$name"
     params+=("$name")
@@ -74,7 +75,7 @@ do
       printf -v "$var_name" %s "$value"
       ;;
       korefile)
-      printf -v "$var_name" %s "`cat "$value"`"
+      printf -v "$file_name" %s "$value"
       ;;
       pretty)
       printf -v "$pretty_name" %s "$value"
@@ -206,7 +207,13 @@ HERE
 )),
 HERE
   var_name="params_$param"
-  echo "${!var_name}" >> $input_file
+  file_name="file_$param"
+
+  if [ -z "${!file_name}" ]; then
+    echo "${!var_name}" >> $input_file
+  else
+    cat "${!file_name}" >> $input_file
+  fi
 
   cat <<HERE >> $input_file
 ))


### PR DESCRIPTION
This is a partial fix for the C semantics linking problems. Instead of storing file contents directly in a variable, we change the logic to read from the file on disk instead.

~~Testing this will probably need to be done in the frontend so that a definition is available for `llvm-krun`; I'll do so in a separate PR before this can be merged. Informally, the C semantics test suite (which makes heavy use of `llvm-krun`) passes when built with this change.~~

This can be reviewed now, but should only be merged once https://github.com/runtimeverification/k/pull/2459 has been merged; any breakages should be caught by the backend submodule update.