### PR TITLE
frame pointer workaround

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -49,7 +49,7 @@ if $compile; then
   "$(dirname "$0")"/llvm-kompile-codegen "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug > "$mod"
 
   # optimization
-  @OPT@ -load "$(dirname "$0")"/../lib/kllvm/libLLVMPass.so -mem2reg -tailcallelim $opt_flags -mark-tail-calls-as-gc-leaf -rewrite-statepoints-for-gc -dce -emit-gc-layout-info "$mod" -o "$modopt"
+  @OPT@ -load "$(dirname "$0")"/../lib/kllvm/libLLVMPass.so -mem2reg -tailcallelim $opt_flags -mark-tail-calls-as-gc-leaf -no-omit-frame-pointer-for-tailcc -rewrite-statepoints-for-gc -dce -emit-gc-layout-info "$mod" -o "$modopt"
   @LLVM_LINK@ "$modopt" "$(dirname "$0")"/../lib/kllvm/llvm/opaque/opaque.ll -o "$modcombined"
   @OPT@ "$modcombined" -always-inline -o "$modcombinedopt"
 else

--- a/lib/llvm/CMakeLists.txt
+++ b/lib/llvm/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(LLVMPass MODULE
   EmitGCLayoutInfo.cpp
   MarkTailCallsAsGCLeaf.cpp
+  NoOmitFramePointerForTailcc.cpp
 )
 
 target_link_libraries(LLVMPass PUBLIC AST)

--- a/lib/llvm/NoOmitFramePointerForTailcc.cpp
+++ b/lib/llvm/NoOmitFramePointerForTailcc.cpp
@@ -1,0 +1,31 @@
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "NoOmitFramePointerForTailcc"
+
+namespace {
+struct NoOmitFramePointerForTailcc : public FunctionPass {
+  static char ID;
+  NoOmitFramePointerForTailcc()
+      : FunctionPass(ID) { }
+
+  bool runOnFunction(Function &F) override {
+    if (F.getCallingConv() != CallingConv::Tail) {
+      return false;
+    }
+
+    F.addFnAttr("frame-pointer", "all");
+    return true;
+  }
+};
+} // namespace
+
+char NoOmitFramePointerForTailcc::ID = 0;
+
+static RegisterPass<NoOmitFramePointerForTailcc>
+    X("no-omit-frame-pointer-for-tailcc",
+      "Mark tailcc functions with \"frame-pointer\"=\"all\" attribute",
+      false /* Only looks at CFG */, false /* Analysis Pass */);

--- a/lib/llvm/NoOmitFramePointerForTailcc.cpp
+++ b/lib/llvm/NoOmitFramePointerForTailcc.cpp
@@ -17,7 +17,7 @@ struct NoOmitFramePointerForTailcc : public FunctionPass {
       return false;
     }
 
-    F.addFnAttr("frame-pointer", "all");
+    F.addFnAttr("frame-pointer", "non-leaf");
     return true;
   }
 };


### PR DESCRIPTION
This PR adds the `"frame-pointer"="all"` attribute to all functions with the `tailcc` calling convention. This is a workaround to avoid a bug in LLVM 13 related to incorrect unwind info generation for such functions: https://github.com/llvm/llvm-project/issues/52758