### PR TITLE
Variable-size lengths

### DIFF
--- a/docs/binary_kore.md
+++ b/docs/binary_kore.md
@@ -31,10 +31,10 @@ no more to follow
 another   byte follows
 ```
 
-The first represents a length of 1, while the second represents `(3 << 7) + 1`,
-or 385. Because the continuation bit in the first byte is set, its data value
-(low 7 bits of value 3) should be shifted left by 7 places, and the following
-byte's value considered additionally.
+The first represents a length of 1, while the second represents `3 + (1 << 7)`,
+or 131. Because the continuation bit in the first byte is set, the data value of
+the next byte (low 7 bits of value 1) should be shifted left by 7 places, and
+its continuation bit considered additionally.
 
 The maximum value that can be encoded using this scheme is `2^63`, which
 corresponds to 9 bytes with all possible data bits set. Sequences of more than 9

--- a/docs/binary_kore.md
+++ b/docs/binary_kore.md
@@ -1,6 +1,6 @@
 # Binary KORE Format
 
-This document specifies version `1.0.0` of the binary format for KORE patterns.
+This document specifies version `1.1.0` of the binary format for KORE patterns.
 Note that in places, the format is slightly redundant to allow for a future
 extension to entire KORE definitions.
 
@@ -12,6 +12,33 @@ output of `xxd`. For example, `ABCD EFGH` represents the byte sequence `0xAB`,
 
 The serialization format assumes little-endianness throughout. For example, the
 32-bit integer 1 would be serialized as `0100 0000`.
+
+## Length Fields
+
+Lengths and arities are encoded as variable-length sequences of bytes. Each byte
+in the sequence uses its highest bit as a continuation marker if it is set, and
+the low 7 bits as a component of the length data.
+
+For example, consider the following sequences of bits:
+```
+0000 0001
+^
+no more to follow
+
+
+1000 0011 0000 0001
+^         ^
+another   byte follows
+```
+
+The first represents a length of 1, while the second represents `(3 << 7) + 1`,
+or 385. Because the continuation bit in the first byte is set, its data value
+(low 7 bits of value 3) should be shifted left by 7 places, and the following
+byte's value considered additionally.
+
+The maximum value that can be encoded using this scheme is `2^63`, which
+corresponds to 9 bytes with all possible data bits set. Sequences of more than 9
+bytes are malformed.
 
 ## Header
 
@@ -28,24 +55,25 @@ For example, a file of version `1.0.0` should begin:
 
 Two representations for strings are available: direct and interned.
 
-Directly-encoded strings are the byte `01`, followed by a 4-byte length, then
+Directly-encoded strings are the byte `01`, followed by a length field, then
 the bytes of the string.
 
-Interned strings are the byte `02`, followed by a 4-byte integer value. This
-value represents the number of bytes to count _backwards_ in the buffer (from
+Interned strings are the byte `02`, followed by a length field. This
+field represents the number of bytes to count _backwards_ in the buffer (from
 the byte immediately following the backreference count) to find the _first
 byte of the length_ of a directly-encoded string.
 
 For example, consider the following sequence of bytes:
 ```
-0104 0000 0056 7856 7802 0d00 0000 ff
+0104 5678 5678 0207 ff
 ```
 
-First, the string `wVwV` is encoded directly with its length (splitting the
-prefix and length from the characters, `01 0400 0000 5678 5678`). Then, a
-backreference of 13 bytes is encoded (`02 0d00 0000`). This backreference is
-counted from the byte `ff`, and therefore points to the `04` byte at the start
-of the directly-encoded string's length.
+First, the string `wVwV` is encoded directly with its length (the single
+uncontinued byte `04`). Splitting the prefix and length from the characters,
+this is `0104 5678 5678`). Then, a variable-length backreference of 7 bytes is
+encoded (`0207`). This backreference is counted from the byte `ff`, and
+therefore points to the `04` byte at the start of the directly-encoded string's
+length.
 
 ## KORE
 
@@ -57,16 +85,16 @@ Sort variables are encoded as the byte `07` followed by the variable name as a
 string.
 
 Composite sorts first encode each of their arguments (recursively, following
-this schema), then the byte `06`. This is followed by a 2-byte arity, then the
-sort name as a string.
+this schema), then the byte `06`. This is followed by a length field
+representing the sort arity, then the sort name as a string.
 
 ### Symbols
 
 First, the formal sort arguments to the symbol are serialized in sequence
 following the sort schema above.
 
-Then, the byte `08` is emitted, followed by the number of formal arguments (as a
-16-bit integer).
+Then, the byte `08` is emitted, followed by the number of formal arguments as a
+length field.
 
 Finally, the name of the symbol is emitted as a string following the
 representation above.
@@ -77,7 +105,7 @@ KORE string patterns are encoded as the byte `05`, then the string data.
 
 Composite patterns encode each of their arguments (recursively, following this
 schema), then the constructor symbol (as described above). These are followed by
-the byte `04`, and a 2-byte arity for the pattern.
+the byte `04`, and a variable-length arity for the pattern.
 
 ## Manipulating Binary Terms
 
@@ -89,7 +117,7 @@ To apply a constructor to a list of arguments (after stripping their prefixes):
 1. Begin with a new header and version prefix.
 1. Concatenate the serialized argument terms to the header.
 2. Concatenate the serialized constructor with no arguments.
-3. Drop the last 2 bytes of the file, and append the appropriate arity bytes.
+3. Drop the arity at the end of the file, and append the appropriate arity bytes.
 
 This representation may be less compact than if it had been constructed from the
 equivalent textual KORE (due to missed opportunities for string interning across

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1852,10 +1852,6 @@ void KOREVariablePattern::serialize_to(serializer &s) const {
 }
 
 void KORECompositePattern::serialize_to(serializer &s) const {
-  assert(
-      arguments.size() <= std::numeric_limits<int16_t>::max()
-      && "Composite pattern has too many arguments to serialize");
-
   for (auto const &arg : arguments) {
     arg->serialize_to(s);
   }
@@ -1863,7 +1859,7 @@ void KORECompositePattern::serialize_to(serializer &s) const {
   constructor->serialize_to(s);
 
   s.emit(header_byte<KORECompositePattern>);
-  s.emit(int16_t(arguments.size()));
+  s.emit_length(arguments.size());
 }
 
 void KOREStringPattern::serialize_to(serializer &s) const {
@@ -1877,30 +1873,22 @@ void KORESortVariable::serialize_to(serializer &s) const {
 }
 
 void KORECompositeSort::serialize_to(serializer &s) const {
-  assert(
-      arguments.size() <= std::numeric_limits<int16_t>::max()
-      && "Composite sort has too many arguments to serialize");
-
   for (auto const &arg : arguments) {
     arg->serialize_to(s);
   }
 
   s.emit(header_byte<KORECompositeSort>);
-  s.emit(int16_t(arguments.size()));
+  s.emit_length(arguments.size());
   s.emit_string(name);
 }
 
 void KORESymbol::serialize_to(serializer &s) const {
-  assert(
-      formalArguments.size() <= std::numeric_limits<int16_t>::max()
-      && "Symbol has too many arguments to serialize");
-
   for (auto const &arg : formalArguments) {
     arg->serialize_to(s);
   }
 
   s.emit(header_byte<KORESymbol>);
-  s.emit(int16_t(formalArguments.size()));
+  s.emit_length(formalArguments.size());
   s.emit_string(name);
 }
 

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -1,6 +1,7 @@
 #include <kllvm/binary/serializer.h>
 
 #include <cassert>
+#include <iostream>
 #include <limits>
 
 namespace kllvm {
@@ -54,30 +55,30 @@ void serializer::emit_string(std::string const &s) {
 
 int serializer::emit_length(uint64_t len) {
   auto emitted = 0;
+  auto req = required_chunks(len);
 
   do {
     uint8_t chunk = len & 0x7F;
     len >>= 7;
 
     if (len > 0) {
-      chunk = chunk & 0x80;
+      std::cerr << "len " << len << '\n';
+      chunk = chunk | 0x80;
     }
 
-    emit(std::byte(chunk));
+    emit(chunk);
     emitted++;
   } while (len > 0);
 
-  assert(
-      emitted == required_chunks(len)
-      && "Internal error when emitting length fields");
+  assert(emitted == req && "Internal error when emitting length fields");
   return emitted;
 }
 
 int serializer::required_chunks(uint64_t len) const {
   auto ret = 0;
-  while (len >>= 7) {
+  do {
     ++ret;
-  }
+  } while (len >>= 7);
   return ret;
 }
 

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -62,7 +62,6 @@ int serializer::emit_length(uint64_t len) {
     len >>= 7;
 
     if (len > 0) {
-      std::cerr << "len " << len << '\n';
       chunk = chunk | 0x80;
     }
 

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -159,7 +159,7 @@ static void *deserializeInitialConfiguration(It ptr, It end) {
 
     case header_byte<KORECompositePattern>: {
       ++ptr;
-      auto arity = read<int16_t>(ptr, end);
+      auto arity = read_length(ptr, end);
 
       assert(symbol && "No symbol set when reaching composite pattern");
       assert(

--- a/test/binary/concat/test-concat.kore
+++ b/test/binary/concat/test-concat.kore
@@ -3,8 +3,8 @@
 // RUN: %kore-convert %S/Inputs/ctor.kore -o %t_ctor
 // RUN: tail -c +12 %t_b >> %t_a
 // RUN: tail -c +12 %t_ctor >> %t_a
-// RUN: head -c -2  %t_a > %t_term
-// RUN: echo -ne '\x02\x00' >> %t_term
+// RUN: head -c -1  %t_a > %t_term
+// RUN: echo -ne '\x02' >> %t_term
 // RUN: %kore-convert %t_term -o %t_term.kore
 // RUN: %kore-convert %s --to=text -o %t_ref
 // RUN: diff %t_term.kore %t_ref


### PR DESCRIPTION
This PR implements the variable-size lengths change as discussed last week.

All fixed-size length and arity fields in the binary KORE format have been replaced with a simple representation where the highest bit in a byte is a continuation flag, and the lower 7 bits are chunks of the length itself.

This representation is a bit more complex to encode and decode, but should save space compared to the previous version.