### PR TITLE
Rename clashing IDs

### DIFF
--- a/include/kllvm/binary/deserializer.h
+++ b/include/kllvm/binary/deserializer.h
@@ -231,11 +231,11 @@ sptr<KOREPattern> deserialize_pattern(It begin, It end) {
     detail::read<char>(begin, end);
   }
 
-  auto major = detail::read<int16_t>(begin, end);
-  auto minor = detail::read<int16_t>(begin, end);
-  auto patch = detail::read<int16_t>(begin, end);
+  auto v_major = detail::read<int16_t>(begin, end);
+  auto v_minor = detail::read<int16_t>(begin, end);
+  auto v_patch = detail::read<int16_t>(begin, end);
 
-  return detail::read(begin, end, binary_version(major, minor, patch));
+  return detail::read(begin, end, binary_version(v_major, v_minor, v_patch));
 }
 
 bool has_binary_kore_header(std::string const &filename);

--- a/include/kllvm/binary/version.h
+++ b/include/kllvm/binary/version.h
@@ -11,19 +11,19 @@ namespace kllvm {
  * format.
  */
 struct binary_version {
-  constexpr binary_version(int16_t maj, int16_t min, int16_t patch)
-      : major(maj)
-      , minor(min)
-      , patch(patch) { }
+  constexpr binary_version(int16_t maj, int16_t min, int16_t v_patch)
+      : v_major(maj)
+      , v_minor(min)
+      , v_patch(v_patch) { }
 
-  int16_t major;
-  int16_t minor;
-  int16_t patch;
+  int16_t v_major;
+  int16_t v_minor;
+  int16_t v_patch;
 };
 
 constexpr bool operator==(binary_version a, binary_version b) {
-  return std::tie(a.major, a.minor, a.patch)
-         == std::tie(b.major, b.minor, b.patch);
+  return std::tie(a.v_major, a.v_minor, a.v_patch)
+         == std::tie(b.v_major, b.v_minor, b.v_patch);
 }
 
 constexpr bool operator!=(binary_version a, binary_version b) {
@@ -31,11 +31,11 @@ constexpr bool operator!=(binary_version a, binary_version b) {
 }
 
 /**
- * Two versions are compatible if they have identical major and minor
- * components; they may differ in the patch component.
+ * Two versions are compatible if they have identical v_major and v_minor
+ * components; they may differ in the v_patch component.
  */
 constexpr bool are_compatible(binary_version a, binary_version b) {
-  return std::tie(a.major, a.minor) == std::tie(b.major, b.minor);
+  return std::tie(a.v_major, a.v_minor) == std::tie(b.v_major, b.v_minor);
 }
 
 } // namespace kllvm

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -26,9 +26,9 @@ serializer::serializer()
     emit(std::byte(b));
   }
 
-  emit(version.major);
-  emit(version.minor);
-  emit(version.patch);
+  emit(version.v_major);
+  emit(version.v_minor);
+  emit(version.v_patch);
 }
 
 void serializer::emit(std::byte b) {

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -251,12 +251,12 @@ block *parseConfiguration(const char *filename) {
       detail::read<char>(ptr, end);
     }
 
-    auto major = detail::read<int16_t>(ptr, end);
-    auto minor = detail::read<int16_t>(ptr, end);
-    auto patch = detail::read<int16_t>(ptr, end);
+    auto v_major = detail::read<int16_t>(ptr, end);
+    auto v_minor = detail::read<int16_t>(ptr, end);
+    auto v_patch = detail::read<int16_t>(ptr, end);
 
     return reinterpret_cast<block *>(deserializeInitialConfiguration(
-        ptr, data.end(), binary_version(major, minor, patch)));
+        ptr, data.end(), binary_version(v_major, v_minor, v_patch)));
   } else {
     auto InitialConfiguration = parser::KOREParser(filename).pattern();
     // InitialConfiguration->print(std::cout);


### PR DESCRIPTION
Fixes #499 - simple rename of major, minor etc. so as not to conflict with the stdlib.