### PR TITLE
Don't delete `dt_dir` in `llvm-kompile`

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -9,7 +9,7 @@ if [ $# -lt 3 ]; then
 fi
 mod="$(mktemp tmp.XXXXXXXXXX)"
 modopt="$(mktemp tmp.XXXXXXXXXX)"
-trap 'rm -rf "$dt_dir" "$mod" "$modopt"' INT TERM EXIT
+trap 'rm -rf "$mod" "$modopt"' INT TERM EXIT
 definition="$1"
 shift
 compile=true


### PR DESCRIPTION
In #501, I made the following change to `llvm-kompile`:

```diff
-trap "rm -rf $dt_dir $mod $modopt" INT TERM EXIT
+trap 'rm -rf "$dt_dir" "$mod" "$modopt"' INT TERM EXIT
```

This is because `trap` invocations shouldn't usually be expanded when set (i.e. double-quoted); rather, they should be single quoted so that variables take on their appropriate values at exit.

Making this change causes the script to delete `$dt_dir` at the end of execution, which presumably isn't the intended behaviour (previously, it would have been expanded to `""` when the trap was first set).