### PR TITLE
run kore-convert if needed in llvm-krun --dry-run

### DIFF
--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -359,7 +359,7 @@ if $dryRun; then
     if [ -n "$verbose" ]; then
       set -x
     fi
-    "$(dirname "$0")/kore-convert" "$expanded_input_file"
+    "$(dirname "$0")/kore-convert" -F "$expanded_input_file"
     )
   elif [ -n "$real_output_file" ]; then
     cat "$expanded_input_file" > "$real_output_file"

--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -347,7 +347,21 @@ else
 fi
 
 if $dryRun; then
-  if [ -n "$real_output_file" ]; then
+  if [ $binary_input != $binary_output ] && [ -n "$real_output_file" ]; then
+    (
+    if [ -n "$verbose" ]; then
+      set -x
+    fi
+    "$(dirname "$0")/kore-convert" "$expanded_input_file" > "$real_output_file"
+    )
+  elif [ $binary_input != $binary_output ]; then
+    (
+    if [ -n "$verbose" ]; then
+      set -x
+    fi
+    "$(dirname "$0")/kore-convert" "$expanded_input_file"
+    )
+  elif [ -n "$real_output_file" ]; then
     cat "$expanded_input_file" > "$real_output_file"
   else
     cat "$expanded_input_file"

--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -352,7 +352,7 @@ if $dryRun; then
     if [ -n "$verbose" ]; then
       set -x
     fi
-    "$(dirname "$0")/kore-convert" "$expanded_input_file" > "$real_output_file"
+    "$(dirname "$0")/kore-convert" "$expanded_input_file" -o "$real_output_file"
     )
   elif [ $binary_input != $binary_output ]; then
     (


### PR DESCRIPTION
If you run `llvm-krun --dry-run --binary-input` or `llvm-krun --dry-run --binary-output`, it will not respect the presence or absence of the `--binary-output` flag because it is copying the input file verbatim to the output. In this case, we want the script to run `kore-convert` on the input file before providing it back to the user. This PR implements this change.