### PR TITLE
Re-enable arch CI

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -1,7 +1,7 @@
 FROM archlinux:base
 
 RUN pacman -Syyu --noconfirm && \
-    pacman -S --noconfirm base-devel git cmake clang llvm lld flex boost gmp mpfr libyaml jemalloc curl maven pkg-config
+    pacman -S --noconfirm base-devel git cmake clang llvm lld flex boost gmp mpfr libyaml jemalloc curl maven pkg-config python3
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,10 +10,6 @@ pipeline {
     }
     stage('Build and Test on Arch Linux') {
       options { timeout(time: 25, unit: 'MINUTES') }
-      when {
-        expression { return false }
-        beforeAgent true
-      }
       agent {
         dockerfile {
           filename 'Dockerfile.arch'

--- a/ciscript
+++ b/ciscript
@@ -1,4 +1,6 @@
 #!/bin/bash -ex
+ulimit -s 400000
+
 export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
 
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
This PR installs python 3 explicitly, and increases the stack size available for release builds in the CI script - these seem to be the only changes needed to get the backend building on Arch again.

I've also made the OS build matrix parallel given we'll be running 3x as many of them once Jammy support (#517) is merged as well.