### PR TITLE
Rename map, set to avoid clashes with typedefs

### DIFF
--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -167,12 +167,12 @@ using set
 
 typedef struct mapiter {
   map::iterator curr;
-  map *map;
+  map *map_item;
 } mapiter;
 
 typedef struct setiter {
   set::iterator curr;
-  set *set;
+  set *set_item;
 } setiter;
 
 typedef floating *SortFloat;

--- a/runtime/collections/maps.cpp
+++ b/runtime/collections/maps.cpp
@@ -8,7 +8,7 @@ mapiter map_iterator(map *map) {
 }
 
 block *map_iterator_next(mapiter *iter) {
-  if (iter->curr == iter->map->end()) {
+  if (iter->curr == iter->map_item->end()) {
     return nullptr;
   }
   return (iter->curr++)->first;

--- a/runtime/collections/sets.cpp
+++ b/runtime/collections/sets.cpp
@@ -8,7 +8,7 @@ setiter set_iterator(set *set) {
 }
 
 block *set_iterator_next(setiter *iter) {
-  if (iter->curr == iter->set->end()) {
+  if (iter->curr == iter->set_item->end()) {
     return nullptr;
   }
   return *(iter->curr++);


### PR DESCRIPTION
This PR applies a minor renaming to these variables to avoid a clash with typedefs elsewhere in the file; the clash causes an error on some compiler versions.