### PR TITLE
use maven batch mode so we don't spam stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN    pip3 install --user --upgrade pip  \
 
 ADD matching/pom.xml /home/user/.tmp-maven/
 RUN    cd /home/user/.tmp-maven \
-    && mvn dependency:go-offline
+    && mvn -B dependency:go-offline
 
 # Set $PATH to refer to LLVM's lit correctly
 ENV PATH "$PATH:/home/user/.local/bin"


### PR DESCRIPTION
The llvm-backend master build timed out, but it's hard to tell exactly why this happened because the log was being spammed with progress bar updates to maven downloads. We pass -B to mvn in the dockerfile now so that it will not do this and the log will be more readable.