### PR TITLE
Use `unordered_map` to store attributes

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -9,7 +9,6 @@ jobs:
     - name: Check that C and C++ code is correctly formatted
       uses: jidicula/clang-format-action@v4.0.0
       with:
-        clang-format-version: '12'
         exclude-regex: '(build|config|deps)'
 
   shell-check:

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Check that C and C++ code is correctly formatted
-      uses: jidicula/clang-format-action@v4.0.0
+      uses: jidicula/clang-format-action@v4.8.0
       with:
         exclude-regex: '(build|config|deps)'
 

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -605,14 +605,14 @@ private:
 // KOREDeclaration
 class KOREDeclaration {
 protected:
-  std::map<std::string, ptr<KORECompositePattern>> attributes;
+  std::unordered_map<std::string, ptr<KORECompositePattern>> attributes;
   std::vector<sptr<KORESortVariable>> objectSortVariables;
 
 public:
   void addAttribute(ptr<KORECompositePattern> Attribute);
   void addObjectSortVariable(sptr<KORESortVariable> SortVariable);
   virtual void print(std::ostream &Out, unsigned indent = 0) const = 0;
-  const std::map<std::string, ptr<KORECompositePattern>> &
+  const std::unordered_map<std::string, ptr<KORECompositePattern>> &
   getAttributes() const {
     return attributes;
   }
@@ -764,7 +764,7 @@ class KOREModule {
 private:
   std::string name;
   std::vector<ptr<KOREDeclaration>> declarations;
-  std::map<std::string, ptr<KORECompositePattern>> attributes;
+  std::unordered_map<std::string, ptr<KORECompositePattern>> attributes;
 
 public:
   static ptr<KOREModule> Create(const std::string &Name) {
@@ -827,7 +827,7 @@ private:
   KOREAxiomMapType ordinals;
 
   std::vector<ptr<KOREModule>> modules;
-  std::map<std::string, ptr<KORECompositePattern>> attributes;
+  std::unordered_map<std::string, ptr<KORECompositePattern>> attributes;
   /* an automatically computed list of all the axioms in the definition */
   std::list<KOREAxiomDeclaration *> axioms;
 
@@ -870,7 +870,7 @@ public:
   KOREAxiomDeclaration *getAxiomByOrdinal(size_t ordinal) const {
     return ordinals.at(ordinal);
   }
-  const std::map<std::string, ptr<KORECompositePattern>> &
+  const std::unordered_map<std::string, ptr<KORECompositePattern>> &
   getAttributes() const {
     return attributes;
   }

--- a/include/kllvm/codegen/Debug.h
+++ b/include/kllvm/codegen/Debug.h
@@ -17,7 +17,7 @@ void initDebugFunction(
     KOREDefinition *definition, llvm::Function *func);
 
 void initDebugAxiom(
-    std::map<std::string, ptr<KORECompositePattern>> const &att);
+    std::unordered_map<std::string, ptr<KORECompositePattern>> const &att);
 void initDebugParam(
     llvm::Function *func, unsigned argNo, std::string name, ValueType type,
     std::string typeName);

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1726,7 +1726,8 @@ void KOREStringPattern::print(std::ostream &Out, unsigned indent) const {
 
 static void printAttributeList(
     std::ostream &Out,
-    const std::map<std::string, ptr<KORECompositePattern>> &attributes,
+    const std::unordered_map<std::string, ptr<KORECompositePattern>>
+        &attributes,
     unsigned indent = 0) {
 
   std::string Indent(indent, ' ');

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -83,7 +83,7 @@ static std::string LOCATION_ATT
     = "org'Stop'kframework'Stop'attributes'Stop'Location";
 
 void initDebugAxiom(
-    std::map<std::string, ptr<KORECompositePattern>> const &att) {
+    std::unordered_map<std::string, ptr<KORECompositePattern>> const &att) {
   if (!Dbg)
     return;
   if (!att.count(SOURCE_ATT)) {

--- a/tools/kore-expand-macros/main.cpp
+++ b/tools/kore-expand-macros/main.cpp
@@ -72,8 +72,11 @@ int main(int argc, char **argv) {
     }
   }
 
-  sptr<KOREPattern> expanded
-      = config->expandMacros(subsorts, overloads, axioms, false);
+  auto expanded
+      = axioms.empty()
+            ? config
+            : config->expandMacros(subsorts, overloads, axioms, false);
+
   expanded->print(std::cout);
   std::cout << std::endl;
 


### PR DESCRIPTION
This provides a slight speedup for `kore-expand-macros` on inputs where there are macros in the definition, but none are used in the input term.

My intuition is that the unordered map is a better fit given that we don't ever actually modify the sets of attributes that AST nodes have, but do a lot of `count` lookups to see if an attribute is present; with an ordered map this is guaranteed `O(log n)` but with an unordered one it's average `O(1)`.

There are a couple of other small changes:
* Upgrade the version of the clang-format action we use; the old one was breaking
* Prevent any recursive building of terms when there are no macros present in the definition.