### PR TITLE
Fix GDB on Ubuntu Jammy

### DIFF
--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -27,8 +27,20 @@ void initDebugInfo(llvm::Module *module, std::string filename) {
       llvm::Module::Warning, "Debug Info Version",
       (uint32_t)llvm::DEBUG_METADATA_VERSION);
   module->addModuleFlag(llvm::Module::Warning, "Dwarf Version", DWARF_VERSION);
+
+  // There are no overloads for this method in DIBuilder, so we need to
+  // re-specify lots of the default arguments to get to the DebugNameTableKind
+  // one; for DWARFv5 objects, we don't emit a global name table to avoid
+  // trampling the existing one.
+  //
+  // See these links for the original issue context and a reference for the
+  // arguments to createCompileUnit:
+  //   https://github.com/runtimeverification/k/issues/2637
+  //   https://llvm.org/doxygen/classllvm_1_1DIBuilder.html
   DbgCU = Dbg->createCompileUnit(
-      llvm::dwarf::DW_LANG_C, DbgFile, "llvm-kompile-codegen", 0, "", 0);
+      llvm::dwarf::DW_LANG_C, DbgFile, "llvm-kompile-codegen", false, "", 0, "",
+      llvm::DICompileUnit::DebugEmissionKind::FullDebug, 0, false, false,
+      llvm::DICompileUnit::DebugNameTableKind::None);
 }
 
 void finalizeDebugInfo(void) {


### PR DESCRIPTION
Fixes https://github.com/runtimeverification/k/issues/2637.

The actual change here is pretty small - it adds some extra global flags to the debug metadata we emit to match the behaviour of clang when emitting DWARF v5 files.