### PR TITLE
The stages for building and testing different OSes are serialized

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,57 +10,55 @@ pipeline {
     }
     stage('Build and test') {
       options { timeout(time: 30, unit: 'MINUTES') }
-      parallel {
-        stage('Arch Linux') {
-          agent {
-            dockerfile {
-              filename 'Dockerfile.arch'
-              additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --pull'
-            }
-          }
-          steps {
-            sh '''
-              ./ciscript Debug
-              ./ciscript Release
-              ./ciscript RelWithDebInfo
-              ./ciscript FastBuild
-              ./ciscript GcStats
-            '''
+      stage('Arch Linux') {
+        agent {
+          dockerfile {
+            filename 'Dockerfile.arch'
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --pull'
           }
         }
-        stage('Ubuntu Focal') {
-          agent {
-            dockerfile {
-              additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg BASE_IMAGE=ubuntu:focal --build-arg LLVM_VERSION=10'
-              reuseNode true
-            }
-          }
-          steps {
-            sh '''
-              ./ciscript Debug
-              ./ciscript Release
-              ./ciscript RelWithDebInfo
-              ./ciscript FastBuild
-              ./ciscript GcStats
-            '''
+        steps {
+          sh '''
+            ./ciscript Debug
+            ./ciscript Release
+            ./ciscript RelWithDebInfo
+            ./ciscript FastBuild
+            ./ciscript GcStats
+          '''
+        }
+      }
+      stage('Ubuntu Focal') {
+        agent {
+          dockerfile {
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg BASE_IMAGE=ubuntu:focal --build-arg LLVM_VERSION=10'
+            reuseNode true
           }
         }
-        stage('Ubuntu Jammy') {
-          agent {
-            dockerfile {
-              additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg BASE_IMAGE=ubuntu:jammy --build-arg LLVM_VERSION=14'
-              reuseNode true
-            }
+        steps {
+          sh '''
+            ./ciscript Debug
+            ./ciscript Release
+            ./ciscript RelWithDebInfo
+            ./ciscript FastBuild
+            ./ciscript GcStats
+          '''
+        }
+      }
+      stage('Ubuntu Jammy') {
+        agent {
+          dockerfile {
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg BASE_IMAGE=ubuntu:jammy --build-arg LLVM_VERSION=14'
+            reuseNode true
           }
-          steps {
-            sh '''
-              ./ciscript Debug
-              ./ciscript Release
-              ./ciscript RelWithDebInfo
-              ./ciscript FastBuild
-              ./ciscript GcStats
-            '''
-          }
+        }
+        steps {
+          sh '''
+            ./ciscript Debug
+            ./ciscript Release
+            ./ciscript RelWithDebInfo
+            ./ciscript FastBuild
+            ./ciscript GcStats
+          '''
         }
       }
     }


### PR DESCRIPTION
This PR ensures that no more than one executors will be assigned to single CI job. It does that by making sure that the stages that build and test on different OSes (which require different agents) are not run in parallel but rather sequentially hence being able to reuse the same executor.