### PR TITLE
Build LLVM backend Python bindings in flake

### DIFF
--- a/.github/workflows/test-flake.yml
+++ b/.github/workflows/test-flake.yml
@@ -1,0 +1,33 @@
+name: "Test"
+on:
+  pull_request:
+jobs:
+  compile-nix-flake:
+    name: 'Nix flake'
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v2.3.4
+        with:
+          # Check out pull request HEAD instead of merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: 'Install Nix'
+        uses: cachix/install-nix-action@v15
+        with:
+          extra_nix_config: |
+            substituters = http://cache.nixos.org https://cache.iog.io
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+
+      - name: 'Install Cachix'
+        uses: cachix/cachix-action@v10
+        with:
+          name: runtimeverification
+          extraPullNames: kore
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+
+      - name: 'Build LLVM backend'
+        run: GC_DONT_GC=1 nix build .

--- a/.github/workflows/test-flake.yml
+++ b/.github/workflows/test-flake.yml
@@ -24,10 +24,6 @@ jobs:
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v10
-        with:
-          name: runtimeverification
-          extraPullNames: kore
-          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
       - name: 'Build LLVM backend'
         run: GC_DONT_GC=1 nix build .

--- a/.github/workflows/test-flake.yml
+++ b/.github/workflows/test-flake.yml
@@ -24,6 +24,9 @@ jobs:
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v10
+        with:
+          name: runtimeverification
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
       - name: 'Build LLVM backend'
         run: GC_DONT_GC=1 nix build .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,4 @@ jobs:
     - run: nix-build -A llvm-backend-matching
     - run: nix-shell --run "echo OK"
     - run: nix-build test.nix
+    - run: nix build .#llvm-backend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,3 @@ jobs:
     - run: nix-build -A llvm-backend-matching
     - run: nix-shell --run "echo OK"
     - run: nix-build test.nix
-    - run: nix build .#llvm-backend

--- a/bindings/python/package/poetry.lock
+++ b/bindings/python/package/poetry.lock
@@ -1,0 +1,8 @@
+package = []
+
+[metadata]
+lock-version = "1.1"
+python-versions = ">=3.8"
+content-hash = "dedbcc8ad01960ccbef8502c70bda77771c2826a438e1e94ef27a36c71acd91a"
+
+[metadata.files]

--- a/flake.lock
+++ b/flake.lock
@@ -66,6 +66,23 @@
         "type": "github"
       }
     },
+    "pybind11-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1657936673,
+        "narHash": "sha256-/X8DZPFsNrKGbhjZ1GFOj17/NU6p4R+saCW3pLKVNeA=",
+        "owner": "pybind",
+        "repo": "pybind11",
+        "rev": "0ba639d6177659c5dc2955ac06ad7b5b0d22e05c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pybind",
+        "repo": "pybind11",
+        "rev": "0ba639d6177659c5dc2955ac06ad7b5b0d22e05c",
+        "type": "github"
+      }
+    },
     "rapidjson-src": {
       "flake": false,
       "locked": {
@@ -88,6 +105,7 @@
         "immer-src": "immer-src",
         "mavenix": "mavenix",
         "nixpkgs": "nixpkgs_2",
+        "pybind11-src": "pybind11-src",
         "rapidjson-src": "rapidjson-src",
         "utils": "utils_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,16 +12,19 @@
     rapidjson-src.url =
       "github:Tencent/rapidjson/f54b0e47a08782a6131cc3d60f94d038fa6e0a51";
     rapidjson-src.flake = false;
+    pybind11-src.url =
+      "github:pybind/pybind11/0ba639d6177659c5dc2955ac06ad7b5b0d22e05c";
+    pybind11-src.flake = false;
     mavenix.url = "github:nix-community/mavenix";
   };
 
-  outputs = { self, nixpkgs, utils, immer-src, rapidjson-src, mavenix }:
+  outputs = { self, nixpkgs, utils, immer-src, rapidjson-src, pybind11-src, mavenix }:
     let
       # put devShell and any other required packages into local overlay
       # if you have additional overlays, you may add them here
       localOverlay = import ./nix/overlay.nix; # this should expose devShell
       depsOverlay = (final: prev: {
-        inherit immer-src rapidjson-src;
+        inherit immer-src rapidjson-src pybind11-src;
 
         llvm-backend-src = prev.stdenv.mkDerivation {
           name = "llvm-backend-src";
@@ -40,8 +43,10 @@
             chmod -R u+w $out
             mkdir -p $out/deps/immer
             mkdir -p $out/deps/rapidjson
+            mkdir -p $out/deps/pybind11
             cp -rv ${final.immer-src}/* $out/deps/immer
             cp -rv ${final.rapidjson-src}/* $out/deps/rapidjson
+            cp -rv ${final.pybind11-src}/* $out/deps/pybind11
           '';
         };
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -43,6 +43,10 @@ let
     src = prev.llvm-backend-matching-src;
   };
 
+  # This code is a bit of a hack to get Nix to accept the binding library being
+  # defined in terms of the output of the LLVM backend. Using the backend's
+  # lib/python directory directly causes a provenance error when reading the
+  # pyproject file.
   kllvm = prev.poetry2nix.mkPoetryApplication {
     python = prev.python39;
     projectDir = ../bindings/python/package;

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -26,6 +26,11 @@ let
     stdenv = prev.stdenv;
   });
 
+  kllvm = prev.poetry2nix.mkPoetryApplication {
+    python = prev.python39;
+    projectDir = "${prev.llvm-backend}/lib/python";
+  };
+
   llvm-backend = prev.callPackage ./llvm-backend.nix {
     inherit (llvmPackages) llvm libllvm libcxxabi;
     stdenv = if !llvmPackages.stdenv.targetPlatform.isDarwin then
@@ -85,7 +90,7 @@ let
   };
   devShell = prev.callPackage ./devShell.nix { };
 in {
-  inherit llvm-backend llvm-backend-matching integration-tests;
+  inherit kllvm llvm-backend llvm-backend-matching integration-tests;
   inherit (prev) clang; # for compatibility
   inherit devShell; # for CI
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -45,7 +45,10 @@ let
 
   kllvm = prev.poetry2nix.mkPoetryApplication {
     python = prev.python39;
-    projectDir = ../lib/python;
+    projectDir = ../bindings/python/package;
+    postInstall = "
+      cp ${llvm-backend}/lib/python/kllvm/* $out/lib/python3.9/site-packages/kllvm/
+    ";
   };
 
   llvm-kompile-testing = let

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -26,11 +26,6 @@ let
     stdenv = prev.stdenv;
   });
 
-  kllvm = prev.poetry2nix.mkPoetryApplication {
-    python = prev.python39;
-    projectDir = "${prev.llvm-backend}/lib/python";
-  };
-
   llvm-backend = prev.callPackage ./llvm-backend.nix {
     inherit (llvmPackages) llvm libllvm libcxxabi;
     stdenv = if !llvmPackages.stdenv.targetPlatform.isDarwin then
@@ -46,6 +41,11 @@ let
   llvm-backend-matching = import ./llvm-backend-matching.nix {
     inherit (prev) buildMaven;
     src = prev.llvm-backend-matching-src;
+  };
+
+  kllvm = prev.poetry2nix.mkPoetryApplication {
+    python = prev.python39;
+    projectDir = "${prev.llvm-backend}/lib/python";
   };
 
   llvm-kompile-testing = let

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -45,7 +45,7 @@ let
 
   kllvm = prev.poetry2nix.mkPoetryApplication {
     python = prev.python39;
-    projectDir = "${prev.llvm-backend}/lib/python";
+    projectDir = ../lib/python;
   };
 
   llvm-kompile-testing = let


### PR DESCRIPTION
This PR makes sure that we include `pybind11` as a pseudo-submodule in the same way as we do for immer and rapidjson. It also adds the flake build as a step in the nix testing workflow.