### PR TITLE
Split Type 1 / Type 2 bindings

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -10,11 +10,10 @@
 # llvm-kompile to produce a shared library that Python can dynamically load.
 
 pybind11_add_module(kllvm-static STATIC NO_EXTRAS
-  ast.cpp
   runtime.cpp
 )
 
-pybind11_add_module(_kllvm       SHARED
+pybind11_add_module(_kllvm       SHARED NO_EXTRAS
   ast.cpp
 )
 
@@ -23,18 +22,9 @@ target_link_libraries(_kllvm PUBLIC
   Parser
 )
 
-target_link_libraries(kllvm-static PUBLIC
-  Ast
-  Parser
-  Util
-)
-
-target_compile_definitions(kllvm-static
-  PRIVATE KLLVM_BUILD_RUNTIME)
-
 install(FILES $<TARGET_FILE:kllvm-static>
   DESTINATION lib/kllvm
-  RENAME libkllvm.a)
+  RENAME libkllvmruntime.a)
 
 install(DIRECTORY package/
   DESTINATION lib/python)

--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -78,9 +78,5 @@ void bind_ast(py::module_ &m) {
 }
 
 PYBIND11_MODULE(_kllvm, m) {
-#ifdef KLLVM_BUILD_RUNTIME
-  bind_runtime(m);
-#endif
-
   bind_ast(m);
 }

--- a/bindings/python/runtime.cpp
+++ b/bindings/python/runtime.cpp
@@ -2,4 +2,10 @@
 
 namespace py = pybind11;
 
-void bind_runtime(py::module_ &mod) { }
+void bind_runtime(py::module_ &m) {
+  auto runtime = m.def_submodule("runtime", "K LLVM backend runtime");
+}
+
+PYBIND11_MODULE(kllvm_static, m) {
+  bind_runtime(m);
+}


### PR DESCRIPTION
This PR makes a small change to how we build the Python bindings; it allows the Type 1 and Type 2 components (#544) to be split when they are both implemented. There is no actual change to the Type 1 binding already being tested in K as a result of this PR..