### PR TITLE
Install Python bindings outside of `lib/`

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -27,8 +27,8 @@ install(FILES $<TARGET_FILE:kllvm-static>
   RENAME libkllvmruntime.a)
 
 install(DIRECTORY package/
-  DESTINATION lib/python)
+  DESTINATION bindings/python)
 
 install(TARGETS _kllvm
-  DESTINATION lib/python/kllvm
+  DESTINATION bindings/python/kllvm
   LIBRARY)


### PR DESCRIPTION
This prevents the bindings from ending up at `/usr/lib/python` when the K package is built and installed. Will be followed by a frontend PR to install the bindings with `pip` as we currently do for Pyk.