### PR TITLE
Fix argument count check for `object.o` case in `llvm-kompile`

### DIFF
--- a/bin/llvm-kompilex
+++ b/bin/llvm-kompilex
@@ -81,7 +81,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [ "${#positional_args[@]}" -ne 3 ]; then
+if ! [[ "${#positional_args[@]}" -eq 2 || "${#positional_args[@]}" -eq 3 ]]; then
   usage
   exit 1
 fi


### PR DESCRIPTION
This code path is exercised directly (as far as I know) only in the C semantics, and so previous testing didn't identify a bug whereby the two-argument case isn't accepted.

The code change here is small, and you can see that the documentation in the script already indicates that two positional arguments should be valid.