### PR TITLE
Make `llvm-kompile` the new script

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -1,18 +1,99 @@
 #!/bin/bash
 set -e
 
-if [ $# -lt 3 ]; then
-  echo "Usage: $0 <definition.kore> <dt_dir> [main|library] <clang flags>"
-  echo '"main" means that a main function will be generated that matches the signature "interpreter <input.kore> <depth> <output.kore>"'
-  echo '"library" means that no main function is generated and must be passed via <clang flags>'
+usage() {
+  cat << HERE
+Usage: $0 <definition.kore> <dt_dir> <object type> [options] [clang flags]
+   or: $0 <interpreter.o>            <object type> [options] [clang flags]
+
+Options:
+  -h, --help      Print this message and exit.
+  -v, --verbose   Print commands executed to stderr.
+  --save-temps    Do not delete temporary files on exit.
+
+Any option not listed above will be passed through to clang; use '--' to
+separate additional positional arguments to clang from those for $0.
+
+Valid values for a KLLVM object type are:
+  main:     a main function will be generated. The resulting executable has the
+            signature "interpreter <input.kore> <depth> <output.kore>"
+
+  search:   as "main", but the resulting executable has collects all possible
+            results at each rewrite step.
+
+  static:   as "main", but do not link the resulting binary against the
+            necessary shared libraries. This must be done manually later.
+
+  python:   build a Python bindings module rather than a standalone executable.
+HERE
+}
+
+run () {
+  if [ "$verbose" = true ]; then
+    set -x
+  fi
+  "$@"
+  { set +x; } 2>/dev/null
+}
+
+positional_args=()
+reading_clang_args=false
+kompile_clang_flags=()
+clang_args=()
+
+verbose=false
+save_temps=false
+
+while [[ $# -gt 0 ]]; do
+  if [ "$reading_clang_args" = true ]; then
+    clang_args+=("$1")
+    shift
+    continue
+  fi
+
+  case $1 in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -v|--verbose)
+      verbose=true
+      kompile_clang_flags+=("-v")
+      shift
+      ;;
+    --save-temps)
+      save_temps=true	    
+      kompile_clang_flags+=("-save-temps")
+      shift
+      ;;
+    --)
+      reading_clang_args=true
+      shift
+      ;;
+    -*)
+      kompile_clang_flags+=("$1")
+      shift
+      ;;
+    *)
+      positional_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if ! [[ "${#positional_args[@]}" -eq 2 || "${#positional_args[@]}" -eq 3 ]]; then
+  usage
   exit 1
 fi
+
 mod="$(mktemp tmp.XXXXXXXXXX)"
 modopt_tmp="$(mktemp tmp.XXXXXXXXXX)"
 modopt="$modopt_tmp"
-trap 'rm -rf "$mod" "$modopt_tmp"' INT TERM EXIT
-definition="$1"
-shift
+if [ "$save_temps" = false ]; then
+  trap 'rm -rf "$mod" "$modopt_tmp"' INT TERM EXIT
+fi
+
+definition="${positional_args[0]}"
 compile=true
 case "$definition" in
   *.o)
@@ -22,11 +103,11 @@ case "$definition" in
     ;;
 esac
 
-if $compile; then
-  dt_dir="$1"
-  main="$2"
-  shift; shift
+if [ "$compile" = true ]; then
+  dt_dir="${positional_args[1]}"
+  main="${positional_args[2]}"
   debug=0
+
   for arg in "$@"; do
     case "$arg" in
       -g)
@@ -36,14 +117,18 @@ if $compile; then
         ;;
     esac
   done
-  "$(dirname "$0")"/llvm-kompile-codegen "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug > "$mod"
-  @OPT@ -mem2reg -tailcallelim -tailcallopt "$mod" -o "$modopt"
+  run "$(dirname "$0")"/llvm-kompile-codegen "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug > "$mod"
+  run @OPT@ -mem2reg -tailcallelim -tailcallopt "$mod" -o "$modopt"
 else
-  main="$1"
-  shift
+  main="${positional_args[1]}"
   modopt="$definition"
 fi
+
 if [[ "$OSTYPE" != "darwin"* ]]; then
-  flags=-fuse-ld=lld
+  kompile_clang_flags+=("-fuse-ld=lld")
 fi
-"$(dirname "$0")"/llvm-kompile-clang "$modopt" "$main" @LLVM_KOMPILE_LTO@ -fno-stack-protector $flags "$@"
+
+run "$(dirname "$0")"/llvm-kompile-clang          \
+  "$modopt" "$main"                               \
+  @LLVM_KOMPILE_LTO@ -fno-stack-protector         \
+  "${kompile_clang_flags[@]}" "${clang_args[@]}"


### PR DESCRIPTION
This is the next step in the multi-step migration of `llvm-kompile`.