### PR TITLE
Add missing headers when running llvm-kompile with the search flag

### DIFF
--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -20,8 +20,8 @@ stdenv.mkDerivation {
       -e '2a export PATH="${lib.getBin host.clang}/bin:''${PATH}"'
 
     substituteInPlace bin/llvm-kompile-clang \
-      --replace '"-lgmp"' '"-L${gmp}/lib" "-lgmp"' \
-      --replace '"-lmpfr"' '"-L${mpfr}/lib" "-lmpfr"' \
+      --replace '"-lgmp"' '"-I${gmp.dev}/include" "-L${gmp}/lib" "-lgmp"' \
+      --replace '"-lmpfr"' '-I${mpfr.dev}/include "-L${mpfr}/lib" "-lmpfr"' \
       --replace '"-lffi"' '"-L${libffi}/lib" "-lffi"' \
       --replace '"-ljemalloc"' '"-L${jemalloc}/lib" "-ljemalloc"' \
       --replace '"-liconv"' '"-L${libiconv}/lib" "-liconv"' \


### PR DESCRIPTION
Currently, when trying to compile with the search functionality via nix, we fail with the following error:

```bash
kompile --enable-search --md-selector 'k&!noio' --no-exc-wrap --backend llvm  simple-untyped.md -d .
In file included from /nix/store/p4jsvspx6w81j706rcl10pia6zdfc4la-k-5.5.8-dirty-maven/lib/kframework/../../bin/../lib/kllvm//llvm/main/search.cpp:4:
/nix/store/p4jsvspx6w81j706rcl10pia6zdfc4la-k-5.5.8-dirty-maven/lib/kframework/../../bin/../include/kllvm/runtime/header.h:8:10: fatal error: 'gmp.h' file not found
#include <gmp.h>
         ^~~~~~~
1 error generated.
[Error] Critical: llvm-kompile returned nonzero exit code: 1
```

This is because we do not include the `gmp.h`/`mpfr.h` headers found in the `gmp.dev`/`mpfr.dev` nix packages