### PR TITLE
Change bindings install path

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -40,7 +40,7 @@ run () {
 
 print_bindings_path () {
   bin_dir=$(dirname "$0")
-  bindings_dir=$(realpath "$bin_dir/../bindings/python")
+  bindings_dir=$(realpath "$bin_dir/../lib/kllvm/python")
   echo "$bindings_dir"
 }
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -32,8 +32,8 @@ install(FILES $<TARGET_FILE:kllvm-static>
   RENAME libkllvmruntime.a)
 
 install(DIRECTORY package/
-  DESTINATION bindings/python)
+  DESTINATION lib/kllvm/python)
 
 install(TARGETS _kllvm
-  DESTINATION bindings/python/kllvm
+  DESTINATION lib/kllvm/python/kllvm
   LIBRARY)

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -82,7 +82,7 @@ let
     buildPhase = ''
       runHook preBuild
 
-      BINDINGS_INSTALL_PATH=${llvm-backend}/bindings/python \
+      BINDINGS_INSTALL_PATH=${llvm-backend}/lib/kllvm/python \
         LIT_USE_NIX=1 lit -v test
 
       runHook postBuild

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -16,7 +16,7 @@ ROOT_PATH = os.path.realpath(os.path.join(
 # allow it to be set in the environment as an option.
 BINDINGS_INSTALL_PATH = os.environ.get(
     'BINDINGS_INSTALL_PATH',
-    os.path.join(ROOT_PATH, "build", "install", "bindings", "python"))
+    os.path.join(ROOT_PATH, "build", "install", "lib", "kllvm", "python"))
 
 config.name = 'llvm-backend'
 config.test_source_root = os.path.join(ROOT_PATH, "test")


### PR DESCRIPTION
Installing the bindings under a non-standard path (which we only used temporarily previously) was going to make it much harder to fix the debian packaging script for K; this PR puts them under `lib/kllvm` instead.