### PR TITLE
Better error messages from hooks

### DIFF
--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -5,8 +5,6 @@
 #include <cstdint>
 #include <limits>
 
-#include <iostream>
-
 #include <gmp.h>
 #include <mpfr.h>
 

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <limits>
 
+#include <iostream>
+
 #include <gmp.h>
 #include <mpfr.h>
 
@@ -272,5 +274,12 @@ block *strip_injection(block *);
 
 std::string floatToString(const floating *);
 void init_float2(floating *, std::string);
+
+#define KLLVM_HOOK_INVALID_ARGUMENT(msg)                                       \
+  do {                                                                         \
+    auto err_msg = std::string("[") + std::string(__func__)                    \
+                   + std::string("]: ") + std::string(msg);                    \
+    throw std::invalid_argument(err_msg);                                      \
+  } while (false)
 
 #endif // RUNTIME_HEADER_H

--- a/runtime/arithmetic/float.cpp
+++ b/runtime/arithmetic/float.cpp
@@ -55,7 +55,7 @@ floating *move_float(floating *);
 mpz_ptr move_int(mpz_t);
 void add_hash64(void *, uint64_t);
 void *move_mint(mpz_t, uint64_t) {
-  throw std::invalid_argument("not yet implemented");
+  KLLVM_HOOK_INVALID_ARGUMENT("not yet implemented");
 }
 
 SortFloat hook_FLOAT_ceil(SortFloat a) {
@@ -84,11 +84,11 @@ SortFloat hook_FLOAT_trunc(SortFloat a) {
 
 SortFloat hook_FLOAT_round(SortFloat a, SortInt prec, SortInt exp) {
   if (!mpz_fits_ulong_p(prec)) {
-    throw std::invalid_argument("Precision out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Precision out of range");
   }
   unsigned long uprec = mpz_get_ui(prec);
   if (!mpz_fits_ulong_p(exp)) {
-    throw std::invalid_argument("Exponent out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Exponent out of range");
   }
   unsigned long uexp = mpz_get_ui(exp);
   floating result[1];
@@ -100,7 +100,7 @@ SortFloat hook_FLOAT_round(SortFloat a, SortInt prec, SortInt exp) {
 
 mpz_ptr hook_FLOAT_float2int(SortFloat a) {
   if (!mpfr_number_p(a->f)) {
-    throw std::invalid_argument("Not a finite number");
+    KLLVM_HOOK_INVALID_ARGUMENT("Not a finite number");
   }
   mpz_t result;
   mpz_init(result);
@@ -110,11 +110,11 @@ mpz_ptr hook_FLOAT_float2int(SortFloat a) {
 
 SortFloat hook_FLOAT_int2float(SortInt a, SortInt prec, SortInt exp) {
   if (!mpz_fits_ulong_p(prec)) {
-    throw std::invalid_argument("Precision out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Precision out of range");
   }
   unsigned long uprec = mpz_get_ui(prec);
   if (!mpz_fits_ulong_p(exp)) {
-    throw std::invalid_argument("Exponent out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Exponent out of range");
   }
   unsigned long uexp = mpz_get_ui(exp);
   floating result[1];
@@ -237,7 +237,7 @@ mpz_ptr hook_FLOAT_exponent(SortFloat a) {
 
 void *hook_FLOAT_significand(SortFloat a) {
   if (mpfr_nan_p(a->f)) {
-    throw std::invalid_argument("NaN payload is undefined");
+    KLLVM_HOOK_INVALID_ARGUMENT("NaN payload is undefined");
   }
   mpfr_prec_t prec = mpfr_get_prec(a->f);
   uint64_t len = (prec + 7) / 8;
@@ -263,11 +263,11 @@ bool hook_FLOAT_isNaN(SortFloat a) {
 
 SortFloat hook_FLOAT_maxValue(SortInt prec, SortInt exp) {
   if (!mpz_fits_ulong_p(prec)) {
-    throw std::invalid_argument("Precision out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Precision out of range");
   }
   unsigned long uprec = mpz_get_ui(prec);
   if (!mpz_fits_ulong_p(exp)) {
-    throw std::invalid_argument("Exponent out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Exponent out of range");
   }
   unsigned long uexp = mpz_get_ui(exp);
   floating result[1];
@@ -280,11 +280,11 @@ SortFloat hook_FLOAT_maxValue(SortInt prec, SortInt exp) {
 
 SortFloat hook_FLOAT_minValue(SortInt prec, SortInt exp) {
   if (!mpz_fits_ulong_p(prec)) {
-    throw std::invalid_argument("Precision out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Precision out of range");
   }
   unsigned long uprec = mpz_get_ui(prec);
   if (!mpz_fits_ulong_p(exp)) {
-    throw std::invalid_argument("Exponent out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Exponent out of range");
   }
   unsigned long uexp = mpz_get_ui(exp);
   floating result[1];
@@ -423,7 +423,7 @@ SortFloat hook_FLOAT_pow(SortFloat a, SortFloat b) {
 
 SortFloat hook_FLOAT_root(SortFloat a, SortInt b) {
   if (!mpz_fits_ulong_p(b)) {
-    throw std::invalid_argument("Root out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Root out of range");
   }
   unsigned long root = mpz_get_ui(b);
   floating result[1];
@@ -456,11 +456,11 @@ bool hook_FLOAT_sign(SortFloat a) {
 SortFloat hook_FLOAT_rat2float(
     SortInt numerator, SortInt denominator, SortInt prec, SortInt exp) {
   if (!mpz_fits_ulong_p(prec)) {
-    throw std::invalid_argument("Precision out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Precision out of range");
   }
   unsigned long uprec = mpz_get_ui(prec);
   if (!mpz_fits_ulong_p(exp)) {
-    throw std::invalid_argument("Exponent out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Exponent out of range");
   }
   unsigned long uexp = mpz_get_ui(exp);
 

--- a/runtime/arithmetic/int.cpp
+++ b/runtime/arithmetic/int.cpp
@@ -13,7 +13,7 @@ void add_hash64(void *, uint64_t);
 SortInt hook_INT_tmod(SortInt a, SortInt b) {
   mpz_t result;
   if (mpz_sgn(b) == 0) {
-    throw std::invalid_argument("Modulus by zero");
+    KLLVM_HOOK_INVALID_ARGUMENT("Modulus by zero");
   }
   mpz_init(result);
   mpz_tdiv_r(result, a, b);
@@ -23,7 +23,7 @@ SortInt hook_INT_tmod(SortInt a, SortInt b) {
 SortInt hook_INT_emod(SortInt a, SortInt b) {
   mpz_t result;
   if (mpz_sgn(b) == 0) {
-    throw std::invalid_argument("Modulus by zero");
+    KLLVM_HOOK_INVALID_ARGUMENT("Modulus by zero");
   }
   mpz_init(result);
   mpz_tdiv_r(result, a, b);
@@ -81,7 +81,7 @@ SortInt hook_INT_sub(SortInt a, SortInt b) {
 SortInt hook_INT_tdiv(SortInt a, SortInt b) {
   mpz_t result;
   if (mpz_sgn(b) == 0) {
-    throw std::invalid_argument("Division by zero");
+    KLLVM_HOOK_INVALID_ARGUMENT("Division by zero");
   }
   mpz_init(result);
   mpz_tdiv_q(result, a, b);
@@ -91,7 +91,7 @@ SortInt hook_INT_tdiv(SortInt a, SortInt b) {
 SortInt hook_INT_ediv(SortInt a, SortInt b) {
   mpz_t result;
   if (mpz_sgn(b) == 0) {
-    throw std::invalid_argument("Division by zero");
+    KLLVM_HOOK_INVALID_ARGUMENT("Division by zero");
   }
   mpz_init(result);
   if (mpz_sgn(b) >= 0) {
@@ -105,7 +105,7 @@ SortInt hook_INT_ediv(SortInt a, SortInt b) {
 SortInt hook_INT_shl(SortInt a, SortInt b) {
   mpz_t result;
   if (!mpz_fits_ulong_p(b)) {
-    throw std::invalid_argument("Shift amount out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Shift amount out of range");
   }
   mpz_init(result);
   unsigned long blong = mpz_get_ui(b);
@@ -126,7 +126,7 @@ SortInt hook_INT_shr(SortInt a, SortInt b) {
   mpz_init(result);
   if (!mpz_fits_ulong_p(b)) {
     if (mpz_sgn(b) < 0) {
-      throw std::invalid_argument("Negative shift amount");
+      KLLVM_HOOK_INVALID_ARGUMENT("Negative shift amount");
     }
     if (mpz_sgn(a) < 0) {
       mpz_set_si(result, -1);
@@ -145,7 +145,7 @@ bool hook_INT_gt(SortInt a, SortInt b) {
 SortInt hook_INT_pow(SortInt a, SortInt b) {
   mpz_t result;
   if (!mpz_fits_ulong_p(b)) {
-    throw std::invalid_argument("Exponent out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Exponent out of range");
   }
   mpz_init(result);
   unsigned long blong = mpz_get_ui(b);
@@ -160,7 +160,7 @@ SortInt hook_INT_powmod(SortInt a, SortInt b, SortInt mod) {
     mpz_gcd(result, a, mod);
     if (mpz_cmp_ui(result, 1) != 0) {
       mpz_clear(result);
-      throw std::invalid_argument("Modular inverse not defined");
+      KLLVM_HOOK_INVALID_ARGUMENT("Modular inverse not defined");
     }
   }
   mpz_powm(result, a, b, mod);
@@ -220,7 +220,7 @@ SortInt hook_INT_min(SortInt a, SortInt b) {
 SortInt hook_INT_log2(SortInt a) {
   mpz_t result;
   if (mpz_sgn(a) <= 0) {
-    throw std::invalid_argument("Logarithm of nonpositive integer");
+    KLLVM_HOOK_INVALID_ARGUMENT("Logarithm of nonpositive integer");
   }
   mpz_init(result);
   size_t log = mpz_sizeinbase(a, 2) - 1;
@@ -278,12 +278,12 @@ SortInt hook_INT_bitRange(SortInt i, SortInt off, SortInt len) {
     return move_int(result);
   }
   if (!mpz_fits_ulong_p(len)) {
-    throw std::invalid_argument("Length out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Length out of range");
   }
   unsigned long lenlong = mpz_get_ui(len);
   if (!mpz_fits_ulong_p(off)) {
     if (mpz_sgn(off) < 0) {
-      throw std::invalid_argument("Negative offset");
+      KLLVM_HOOK_INVALID_ARGUMENT("Negative offset");
     }
     mpz_init(result);
     if (mpz_sgn(i) < 0) {
@@ -324,7 +324,7 @@ SortInt hook_INT_signExtendBitRange(SortInt i, SortInt off, SortInt len) {
   mpz_t result;
   if (!mpz_fits_ulong_p(off)) {
     if (mpz_sgn(off) < 0) {
-      throw std::invalid_argument("Negative offset");
+      KLLVM_HOOK_INVALID_ARGUMENT("Negative offset");
     }
     mpz_init(result);
     if (mpz_sgn(i) < 0) {
@@ -333,7 +333,7 @@ SortInt hook_INT_signExtendBitRange(SortInt i, SortInt off, SortInt len) {
     return move_int(result);
   }
   if (!mpz_fits_ulong_p(len)) {
-    throw std::invalid_argument("Length out of range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Length out of range");
   }
   unsigned long offlong = mpz_get_ui(off);
   unsigned long lenlong = mpz_get_ui(len);

--- a/runtime/collections/lists.cpp
+++ b/runtime/collections/lists.cpp
@@ -36,7 +36,7 @@ bool hook_LIST_in(SortKItem value, SortList list) {
 
 bool hook_LIST_in_keys(SortInt index, SortList list) {
   if (!mpz_fits_ulong_p(index)) {
-    throw std::invalid_argument("Index is too large for in_keys");
+    KLLVM_HOOK_INVALID_ARGUMENT("Index is too large for in_keys");
   }
   size_t idx = mpz_get_ui(index);
   return idx < list->size();
@@ -50,7 +50,7 @@ SortKItem hook_LIST_get_long(SortList list, ssize_t idx) {
 
 SortKItem hook_LIST_get(SortList list, SortInt index) {
   if (!mpz_fits_slong_p(index)) {
-    throw std::invalid_argument("Index is too large for get");
+    KLLVM_HOOK_INVALID_ARGUMENT("Index is too large for get");
   }
   ssize_t idx = mpz_get_si(index);
   return hook_LIST_get_long(list, idx);
@@ -75,7 +75,7 @@ list hook_LIST_range_long(SortList list, size_t front, size_t back) {
 
 list hook_LIST_range(SortList list, SortInt from_front, SortInt from_back) {
   if (!mpz_fits_ulong_p(from_front) || !mpz_fits_ulong_p(from_back)) {
-    throw std::invalid_argument("Range index too large for range");
+    KLLVM_HOOK_INVALID_ARGUMENT("Range index too large for range");
   }
 
   size_t front = mpz_get_ui(from_front);
@@ -96,7 +96,7 @@ SortInt hook_LIST_size(SortList list) {
 
 list hook_LIST_make(SortInt len, SortKItem value) {
   if (!mpz_fits_ulong_p(len)) {
-    throw std::invalid_argument("Length is too large for make");
+    KLLVM_HOOK_INVALID_ARGUMENT("Length is too large for make");
   }
 
   size_t length = mpz_get_ui(len);
@@ -105,12 +105,12 @@ list hook_LIST_make(SortInt len, SortKItem value) {
 
 list hook_LIST_update(SortList list, SortInt index, SortKItem value) {
   if (!mpz_fits_ulong_p(index)) {
-    throw std::invalid_argument("Length is too large for update");
+    KLLVM_HOOK_INVALID_ARGUMENT("Length is too large for update");
   }
 
   size_t idx = mpz_get_ui(index);
   if (idx >= list->size()) {
-    throw std::invalid_argument("Index out of range for update");
+    KLLVM_HOOK_INVALID_ARGUMENT("Index out of range for update");
   }
 
   return list->set(idx, value);
@@ -118,7 +118,7 @@ list hook_LIST_update(SortList list, SortInt index, SortKItem value) {
 
 list hook_LIST_updateAll(SortList l1, SortInt index, SortList l2) {
   if (!mpz_fits_ulong_p(index)) {
-    throw std::invalid_argument("Length is too large for updateAll");
+    KLLVM_HOOK_INVALID_ARGUMENT("Length is too large for updateAll");
   }
 
   size_t idx = mpz_get_ui(index);
@@ -126,7 +126,7 @@ list hook_LIST_updateAll(SortList l1, SortInt index, SortList l2) {
   size_t size2 = l2->size();
   if (idx != 0 && size2 != 0) {
     if (idx + size2 - 1 >= size) {
-      throw std::invalid_argument("Index out of range for updateAll");
+      KLLVM_HOOK_INVALID_ARGUMENT("Index out of range for updateAll");
     }
   }
 
@@ -151,11 +151,11 @@ list hook_LIST_updateAll(SortList l1, SortInt index, SortList l2) {
 
 list hook_LIST_fill(SortList l, SortInt index, SortInt len, SortKItem val) {
   if (!mpz_fits_ulong_p(index)) {
-    throw std::invalid_argument("Index is too large for fill");
+    KLLVM_HOOK_INVALID_ARGUMENT("Index is too large for fill");
   }
 
   if (!mpz_fits_ulong_p(len)) {
-    throw std::invalid_argument("Length is too large for fill");
+    KLLVM_HOOK_INVALID_ARGUMENT("Length is too large for fill");
   }
 
   size_t idx = mpz_get_ui(index);

--- a/runtime/collections/maps.cpp
+++ b/runtime/collections/maps.cpp
@@ -28,7 +28,7 @@ map hook_MAP_concat(SortMap m1, SortMap m2) {
   for (auto iter = from->begin(); iter != from->end(); ++iter) {
     auto entry = *iter;
     if (to.find(entry.first)) {
-      throw std::invalid_argument("Duplicate keys in map concatenation");
+      KLLVM_HOOK_INVALID_ARGUMENT("Duplicate keys in map concatenation");
     }
     to = to.insert(*iter);
   }
@@ -45,7 +45,7 @@ SortKItem hook_MAP_lookup_null(SortMap m, SortKItem key) {
 SortKItem hook_MAP_lookup(SortMap m, SortKItem key) {
   auto res = hook_MAP_lookup_null(m, key);
   if (!res) {
-    throw std::invalid_argument("Key not found for map lookup");
+    KLLVM_HOOK_INVALID_ARGUMENT("Key not found for map lookup");
   }
   return res;
 }
@@ -116,7 +116,7 @@ list hook_MAP_values(SortMap m) {
 
 SortKItem hook_MAP_choice(SortMap m) {
   if (m->empty()) {
-    throw std::invalid_argument("Cannot choose from an empty map");
+    KLLVM_HOOK_INVALID_ARGUMENT("Cannot choose from an empty map");
   }
   return m->begin()->first;
 }

--- a/runtime/collections/sets.cpp
+++ b/runtime/collections/sets.cpp
@@ -77,7 +77,7 @@ set hook_SET_intersection(SortSet s1, SortSet s2) {
 
 SortKItem hook_SET_choice(SortSet s) {
   if (s->empty()) {
-    throw std::invalid_argument("Set is empty");
+    KLLVM_HOOK_INVALID_ARGUMENT("Set is empty");
   }
   return *s->begin();
 }

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -266,7 +266,7 @@ SortIOInt hook_IO_open(SortString filename, SortString control) {
 
 SortIOInt hook_IO_tell(SortInt i) {
   if (!mpz_fits_sint_p(i)) {
-    throw std::invalid_argument("Arg too large for int");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large for int");
   }
 
   int fd = mpz_get_si(i);
@@ -288,7 +288,7 @@ SortIOInt hook_IO_tell(SortInt i) {
 
 SortIOInt hook_IO_getc(SortInt i) {
   if (!mpz_fits_sint_p(i)) {
-    throw std::invalid_argument("Arg too large for int");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large for int");
   }
 
   int fd = mpz_get_si(i);
@@ -318,7 +318,7 @@ SortIOInt hook_IO_getc(SortInt i) {
 
 SortIOString hook_IO_read(SortInt i, SortInt len) {
   if (!mpz_fits_sint_p(i) || !mpz_fits_ulong_p(len)) {
-    throw std::invalid_argument("Arg too large");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large");
   }
 
   int fd = mpz_get_si(i);
@@ -343,7 +343,7 @@ SortIOString hook_IO_read(SortInt i, SortInt len) {
 
 SortK hook_IO_close(SortInt i) {
   if (!mpz_fits_sint_p(i)) {
-    throw std::invalid_argument("Arg too large for int");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large for int");
   }
 
   int fd = mpz_get_si(i);
@@ -358,7 +358,7 @@ SortK hook_IO_close(SortInt i) {
 
 SortK hook_IO_seek(SortInt i, SortInt loc) {
   if (!mpz_fits_sint_p(i) || !mpz_fits_slong_p(loc)) {
-    throw std::invalid_argument("Arg too large");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large");
   }
 
   int fd = mpz_get_si(i);
@@ -374,7 +374,7 @@ SortK hook_IO_seek(SortInt i, SortInt loc) {
 
 SortK hook_IO_seekEnd(SortInt i, SortInt loc) {
   if (!mpz_fits_sint_p(i) || !mpz_fits_slong_p(loc)) {
-    throw std::invalid_argument("Arg too large");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large");
   }
 
   int fd = mpz_get_si(i);
@@ -390,7 +390,7 @@ SortK hook_IO_seekEnd(SortInt i, SortInt loc) {
 
 SortK hook_IO_putc(SortInt i, SortInt c) {
   if (!mpz_fits_sint_p(i) || !mpz_fits_sint_p(c)) {
-    throw std::invalid_argument("Arg too large");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large");
   }
 
   int fd = mpz_get_si(i);
@@ -406,7 +406,7 @@ SortK hook_IO_putc(SortInt i, SortInt c) {
 
 SortK hook_IO_write(SortInt i, SortString str) {
   if (!mpz_fits_sint_p(i)) {
-    throw std::invalid_argument("Arg too large for int");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large for int");
   }
 
   int fd = mpz_get_si(i);
@@ -421,7 +421,7 @@ SortK hook_IO_write(SortInt i, SortString str) {
 
 SortK hook_IO_lock(SortInt i, SortInt len) {
   if (!mpz_fits_sint_p(i) || !mpz_fits_slong_p(len)) {
-    throw std::invalid_argument("Arg too large");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large");
   }
 
   int fd = mpz_get_si(i);
@@ -443,7 +443,7 @@ SortK hook_IO_lock(SortInt i, SortInt len) {
 
 SortK hook_IO_unlock(SortInt i, SortInt len) {
   if (!mpz_fits_sint_p(i) || !mpz_fits_slong_p(len)) {
-    throw std::invalid_argument("Arg too large");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large");
   }
 
   int fd = mpz_get_si(i);
@@ -476,7 +476,7 @@ SortK hook_IO_remove(SortString path) {
 
 SortIOInt hook_IO_accept(SortInt sock) {
   if (!mpz_fits_sint_p(sock)) {
-    throw std::invalid_argument("Arg too large");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large");
   }
 
   int fd = mpz_get_si(sock);
@@ -499,7 +499,7 @@ SortIOInt hook_IO_accept(SortInt sock) {
 
 SortK hook_IO_shutdownWrite(SortInt sock) {
   if (!mpz_fits_sint_p(sock)) {
-    throw std::invalid_argument("Arg too large");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large");
   }
 
   int fd = mpz_get_si(sock);
@@ -567,27 +567,27 @@ SortK hook_IO_logString(SortString msg) {
 }
 
 block *hook_KREFLECTION_parseKAST(string *kast) {
-  throw std::invalid_argument("not implemented: KREFLECTION.parseKast");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: KREFLECTION.parseKast");
 }
 
 block *hook_KREFLECTION_configuration() {
-  throw std::invalid_argument("not implemented: KREFLECTION.configuration");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: KREFLECTION.configuration");
 }
 
 string *hook_KREFLECTION_getenv(string *str) {
-  throw std::invalid_argument("not implemented: KREFLECTION.getenv");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: KREFLECTION.getenv");
 }
 
 string *hook_KREFLECTION_sort(block *K) {
-  throw std::invalid_argument("not implemented: KREFLECTION.sort");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: KREFLECTION.sort");
 }
 
 block *hook_KREFLECTION_getKLabel(block *K) {
-  throw std::invalid_argument("not implemented: KREFLECTION.getKLabel");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: KREFLECTION.getKLabel");
 }
 
 block *hook_KREFLECTION_fresh(string *str) {
-  throw std::invalid_argument("not implemented: KREFLECTION.fresh");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: KREFLECTION.fresh");
 }
 
 string *hook_KREFLECTION_kompiledDir(void) {
@@ -604,7 +604,7 @@ char const **llvm_backend_argv = nullptr;
 
 list hook_KREFLECTION_argv() {
   if (!llvm_backend_argv)
-    throw std::invalid_argument("KREFLECTION.argv: no arguments given");
+    KLLVM_HOOK_INVALID_ARGUMENT("KREFLECTION.argv: no arguments given");
 
   list l{};
 
@@ -741,15 +741,15 @@ SortKItem hook_IO_system(SortString cmd) {
 }
 
 block *hook_IO_stat(string *path) {
-  throw std::invalid_argument("not implemented: IO.stat");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: IO.stat");
 }
 
 block *hook_IO_lstat(string *path) {
-  throw std::invalid_argument("not implemented: IO.lstat");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: IO.lstat");
 }
 
 block *hook_IO_opendir(string *path) {
-  throw std::invalid_argument("not implemented: IO.opendir");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: IO.opendir");
 }
 
 SortInt hook_IO_time() {

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -71,7 +71,7 @@ SortInt hook_BYTES_bytes2int(
 
 unsigned long get_ui(mpz_t i) {
   if (!mpz_fits_ulong_p(i)) {
-    throw std::invalid_argument("Integer overflow");
+    KLLVM_HOOK_INVALID_ARGUMENT("Integer overflow");
   }
   return mpz_get_ui(i);
 }
@@ -148,7 +148,7 @@ SortBytes hook_BYTES_substr(SortBytes input, SortInt start, SortInt end) {
 SortInt hook_BYTES_get(SortBytes b, SortInt off) {
   unsigned long off_long = get_ui(off);
   if (off_long >= len(b)) {
-    throw std::invalid_argument("Buffer overflow on get");
+    KLLVM_HOOK_INVALID_ARGUMENT("Buffer overflow on get");
   }
   mpz_t result;
   mpz_init_set_ui(result, (unsigned char)b->data[off_long]);
@@ -158,11 +158,11 @@ SortInt hook_BYTES_get(SortBytes b, SortInt off) {
 SortBytes hook_BYTES_update(SortBytes b, SortInt off, SortInt val) {
   unsigned long off_long = get_ui(off);
   if (off_long >= len(b)) {
-    throw std::invalid_argument("Buffer overflow on update");
+    KLLVM_HOOK_INVALID_ARGUMENT("Buffer overflow on update");
   }
   unsigned long val_long = get_ui(val);
   if (val_long >= 256) {
-    throw std::invalid_argument("Not a valid value for a byte in update");
+    KLLVM_HOOK_INVALID_ARGUMENT("Not a valid value for a byte in update");
   }
   b->data[off_long] = (unsigned char)val_long;
   return b;
@@ -171,7 +171,7 @@ SortBytes hook_BYTES_update(SortBytes b, SortInt off, SortInt val) {
 SortBytes hook_BYTES_replaceAt(SortBytes b, SortInt start, SortBytes b2) {
   unsigned long start_long = get_ui(start);
   if (start_long + len(b2) > len(b)) {
-    throw std::invalid_argument("Buffer overflow on replaceAt");
+    KLLVM_HOOK_INVALID_ARGUMENT("Buffer overflow on replaceAt");
   }
   memcpy(b->data + start_long, b2->data, len(b2));
   return b;
@@ -190,7 +190,7 @@ SortBytes hook_BYTES_padRight(SortBytes b, SortInt len, SortInt v) {
   }
   unsigned long uv = get_ui(v);
   if (uv > 255) {
-    throw std::invalid_argument("Integer overflow on value");
+    KLLVM_HOOK_INVALID_ARGUMENT("Integer overflow on value");
   }
   string *result = static_cast<string *>(koreAllocToken(sizeof(string) + ulen));
   set_len(result, ulen);
@@ -206,7 +206,7 @@ SortBytes hook_BYTES_padLeft(SortBytes b, SortInt len, SortInt v) {
   }
   unsigned long uv = get_ui(v);
   if (uv > 255) {
-    throw std::invalid_argument("Integer overflow on value");
+    KLLVM_HOOK_INVALID_ARGUMENT("Integer overflow on value");
   }
   string *result = static_cast<string *>(koreAllocToken(sizeof(string) + ulen));
   set_len(result, ulen);

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -74,7 +74,7 @@ SortInt hook_STRING_length(SortString a) {
 
 static inline uint64_t gs(mpz_t i) {
   if (!mpz_fits_ulong_p(i)) {
-    throw std::invalid_argument("Arg too large for int64_t");
+    KLLVM_HOOK_INVALID_ARGUMENT("Arg too large for int64_t");
   }
   return mpz_get_ui(i);
 }
@@ -82,7 +82,7 @@ static inline uint64_t gs(mpz_t i) {
 SortString hook_STRING_chr(SortInt ord) {
   uint64_t uord = gs(ord);
   if (uord > 255) {
-    throw std::invalid_argument("Ord must be <= 255");
+    KLLVM_HOOK_INVALID_ARGUMENT("Ord must be <= 255");
   }
   auto ret
       = static_cast<string *>(koreAllocToken(sizeof(string) + sizeof(KCHAR)));
@@ -94,7 +94,7 @@ SortString hook_STRING_chr(SortInt ord) {
 SortInt hook_STRING_ord(SortString input) {
   mpz_t result;
   if (len(input) != 1) {
-    throw std::invalid_argument("Input must a string of length 1");
+    KLLVM_HOOK_INVALID_ARGUMENT("Input must a string of length 1");
   }
   mpz_init_set_ui(result, static_cast<unsigned char>(input->data[0]));
   return move_int(result);
@@ -226,7 +226,7 @@ SortInt hook_STRING_string2base_long(SortString input, uint64_t base) {
   memcpy(copy, dataStart, length);
   copy[length] = 0;
   if (mpz_init_set_str(result, copy, base)) {
-    throw std::invalid_argument("Not a valid integer");
+    KLLVM_HOOK_INVALID_ARGUMENT("Not a valid integer");
   }
   return move_int(result);
 }
@@ -271,7 +271,7 @@ SortString hook_STRING_token2string(string *input) {
   }
 
   if (layout(input) != 0) {
-    throw std::invalid_argument("token2string: input is not a string token");
+    KLLVM_HOOK_INVALID_ARGUMENT("token2string: input is not a string token");
   }
   return input;
 }
@@ -368,26 +368,26 @@ SortString hook_STRING_transcode(
   size_t result
       = iconv(converter, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
   if (result < 0) {
-    throw std::invalid_argument("transcoding failed: STRING.transcode");
+    KLLVM_HOOK_INVALID_ARGUMENT("transcoding failed: STRING.transcode");
   }
   *outbuf = 0;
   return makeString(buf, len(input) * 4 - outbytesleft);
 }
 
 string *hook_STRING_uuid() {
-  throw std::invalid_argument("not implemented: STRING.uuid");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: STRING.uuid");
 }
 
 string *hook_STRING_category(string *str) {
-  throw std::invalid_argument("not implemented: STRING.category");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: STRING.category");
 }
 
 string *hook_STRING_directionality(string *str) {
-  throw std::invalid_argument("not implemented: STRING.directionality");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: STRING.directionality");
 }
 
 string *hook_STRING_floatFormat(string *str, string *fmt) {
-  throw std::invalid_argument("not implemented: STRING.floatFormat");
+  KLLVM_HOOK_INVALID_ARGUMENT("not implemented: STRING.floatFormat");
 }
 
 SortStringBuffer hook_BUFFER_empty() {
@@ -468,7 +468,7 @@ void init_float2(floating *result, std::string contents) {
     retValue = mpfr_set_str(result->f, str_value.c_str(), 10, MPFR_RNDN);
   }
   if (retValue != 0) {
-    throw std::invalid_argument("Can't convert to float");
+    KLLVM_HOOK_INVALID_ARGUMENT("Can't convert to float");
   }
 }
 


### PR DESCRIPTION
This PR adds a generic identifier to every exception thrown by hooked function symbols in the LLVM backend.

The new output looks like this:
```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  [hook_STRING_string2base_long]: Not a valid integer
```

Note that the exact hook name printed each time may not precisely match the source of the error (because some hooks are implemented in terms of each other - e.g. `int2string` in terms of `base2string`), but this change will at least make it slightly easier to track down what the problem is.

Closes #593 