### PR TITLE
Make InternalTerm module_local

### DIFF
--- a/bindings/python/runtime.cpp
+++ b/bindings/python/runtime.cpp
@@ -51,7 +51,7 @@ void bind_runtime(py::module_ &m) {
   // that we get from the Pybind wrappers make it really easy to break things.
   // We therefore have to wrap it up in some external Python code; see
   // package/kllvm/__init__.py for the details of the external class.
-  py::class_<block, raw_ptr<block>>(m, "InternalTerm")
+  py::class_<block, raw_ptr<block>>(m, "InternalTerm", py::module_local())
       .def(py::init([](KOREPattern const *init) {
         return static_cast<block *>(constructInitialConfiguration(init));
       }))


### PR DESCRIPTION
With a global class binding, importing two runtime modules in the same interpreter seems to lead to an error: [failing job](https://github.com/runtimeverification/pyk/actions/runs/3522001551/jobs/5904519405#step:4:183)

([pybind11 docs](https://github.com/pybind/pybind11/blob/master/docs/advanced/classes.rst#module-local-class-bindings))