### PR TITLE
Migrate use of `sprintf`

### DIFF
--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -510,7 +510,7 @@ std::string floatToString(const floating *f) {
     suffix[0] = 'f';
     suffix[1] = 0;
   } else {
-    sprintf(suffix, "p%" PRIu64 "x%" PRIu64, prec, exp);
+    snprintf(suffix, sizeof(suffix), "p%" PRIu64 "x%" PRIu64, prec, exp);
   }
   return floatToString(f, suffix);
 }


### PR DESCRIPTION
The `sprintf` function is deprecated on macOS, so we replace it with a straightforward use of `snprintf` using the size of the stack buffer.

Fixes #589 