### PR TITLE
Document undocumented option in `llvm-kompile`

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -20,6 +20,8 @@ Valid values for a KLLVM object type are:
   main:     a main function will be generated. The resulting executable has the
             signature "interpreter <input.kore> <depth> <output.kore>"
 
+  library:  generate an interpreter with no main function linked.
+
   search:   as "main", but the resulting executable has collects all possible
             results at each rewrite step.
 


### PR DESCRIPTION
This flag always worked correctly, it just relied on an implicit fallthrough case in `llvm-kompile-clang` to work. This PR makes the option explicit.