### PR TITLE
Revert "Use opaque pointers when they're available (#586)"

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-LLVM_MAJOR_VERSION=$(echo "@LLVM_PACKAGE_VERSION@" | cut -d'.' -f1)
-
 usage() {
   cat << HERE
 Usage: $0 <definition.kore> <dt_dir> <object type> [options] [clang flags]
@@ -133,14 +131,8 @@ if [ "$compile" = true ]; then
         ;;
     esac
   done
-
-  opt_flags=("-mem2reg" "-tailcallelim" "-tailcallopt")
-  if [ "$LLVM_MAJOR_VERSION" -ge 14 ]; then
-    opt_flags+=("--opaque-pointers")
-  fi
-
   run "$(dirname "$0")"/llvm-kompile-codegen "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug > "$mod"
-  run @OPT@ "${opt_flags[@]}" "$mod" -o "$modopt"
+  run @OPT@ -mem2reg -tailcallelim -tailcallopt "$mod" -o "$modopt"
 else
   main="${positional_args[1]}"
   modopt="$definition"

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -1,7 +1,4 @@
 #!/bin/bash -e
-
-LLVM_MAJOR_VERSION=$(echo "@LLVM_PACKAGE_VERSION@" | cut -d'.' -f1)
-
 modopt="$1"
 main="$2"
 lto="$3"
@@ -74,11 +71,6 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
   libraries=("-ltinfo")
   flags=("-Wl,-u,sort_table")
-fi
-
-if [ "$LLVM_MAJOR_VERSION" -ge 14 ]; then
-  llc_flags+=("--opaque-pointers")
-  flags+=("-mllvm" "--opaque-pointers")
 fi
 
 llc_flags+=("--relocation-model=pic")


### PR DESCRIPTION
This reverts commit 791487a8c9196d8093f4c06aa60ad201847fc2b5.

This is a temporary fix to get the KPlutus K update job to go through; we will want to reinstate some form of this change later when we better understand what's going on.