### PR TITLE
Hotfix for shellcheck breaking

### DIFF
--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -10,8 +10,8 @@ parser_file="$(mktemp tmp.parse.XXXXXXXXXX)"
 temp_inputs=()
 
 cleanup () {
-  rm -rf "$input_file" "$expanded_input_file" "$output_file" "$parser_file"
-  rm -rf "${temp_inputs[@]}"
+  # shellcheck disable=SC2317
+  rm -rf "$input_file" "$expanded_input_file" "$output_file" "$parser_file" "${temp_inputs[@]}"
 }
 trap 'cleanup' INT TERM EXIT
 


### PR DESCRIPTION
The recent ubuntu update to CI runners has updated shellcheck, which includes this new check for unreachable code. Our usage is indirect via signal trapping, and so we can safely ignore it.