### PR TITLE
Fix Nix / maven Github job

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,13 +16,18 @@ jobs:
       - name: 'Check out code'
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.JENKINS_GITHUB_PAT }}
           submodules: recursive
+      - run: |
+          git config --global user.name rv-jenkins
+          git config --global user.email devops@runtimeverification.com
 
       - name: 'Install Nix'
         uses: cachix/install-nix-action@v15
         with:
           install_url: "https://releases.nixos.org/nix/nix-2.7.0/install"
           extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             substituters = http://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
@@ -31,7 +36,6 @@ jobs:
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
-          skipPush: true
 
       - name: 'Update Maven dependencies'
         run: ./nix/update-maven.sh


### PR DESCRIPTION
[This dependency update PR](https://github.com/runtimeverification/llvm-backend/pull/615) demonstrates that the current Nix / Maven CI scripts are broken if something actually changes in the Maven dependencies, because the workflow is not configured to authenticate as the RV-Jenkins user when it tries to commit.

This PR changes the workflow to reflect what K does in the [equivalent workflow](https://github.com/runtimeverification/k/blob/master/.github/workflows/update-deps.yml).