### PR TITLE
Include `<set>` in AST.h

### DIFF
--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <list>
 #include <map>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
This header was being pulled in transitively before somehow, which causes a build failure on macOS because the structure of the upstream headers changed and `<set>` was no longer available.