### PR TITLE
Propagate `fmt` as a build input to consumers

### DIFF
--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -1,4 +1,4 @@
-{ lib, src, cmake, flex, pkgconfig, llvm, libllvm, libcxxabi, stdenv, boost, gmp
+{ lib, src, cmake, flex, fmt, pkgconfig, llvm, libllvm, libcxxabi, stdenv, boost, gmp
 , jemalloc, libffi, libiconv, libyaml, mpfr, ncurses, python3,
 # Runtime dependencies:
 host,
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake flex llvm pkgconfig python3 ];
   buildInputs = [ boost libyaml ];
-  propagatedBuildInputs = [ gmp jemalloc libffi mpfr ncurses ]
+  propagatedBuildInputs = [ fmt gmp jemalloc libffi mpfr ncurses ]
     ++ lib.optional stdenv.isDarwin libiconv;
 
   postPatch = ''


### PR DESCRIPTION
The new fmt dependency was missing from the set of propagated build inputs for the backend; this PR adds it to that set.