### PR TITLE
Expose 'free all' function to C bindings

### DIFF
--- a/bindings/c/include/kllvm-c/kllvm-c.h
+++ b/bindings/c/include/kllvm-c/kllvm-c.h
@@ -106,6 +106,10 @@ void kore_symbol_free(kore_symbol const *);
 
 void kore_symbol_add_formal_argument(kore_symbol *, kore_sort const *);
 
+/* Memory management */
+
+void kllvm_free_all_memory(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/bindings/c/lib.cpp
+++ b/bindings/c/lib.cpp
@@ -5,6 +5,8 @@
 
 #include <kllvm-c/kllvm-c.h>
 
+#include <runtime/arena.h>
+
 // This header needs to be included last because it pollutes a number of macro
 // definitions into the global namespace.
 #include <runtime/header.h>
@@ -256,6 +258,12 @@ char *kore_symbol_dump(kore_symbol const *sym) {
 
 void kore_symbol_add_formal_argument(kore_symbol *sym, kore_sort const *sort) {
   sym->ptr_->addFormalArgument(sort->ptr_);
+}
+
+/* Memory management */
+
+void kllvm_free_all_memory(void) {
+  freeAllMemory();
 }
 }
 

--- a/test/c/Inputs/simplify.c
+++ b/test/c/Inputs/simplify.c
@@ -9,6 +9,7 @@
 typedef kore_pattern *new_comp_t(char const *);
 typedef kore_sort *new_sort_t(char const *);
 typedef void simplify_t(kore_pattern *, kore_sort *, char **, size_t *);
+typedef void free_all_t(void);
 
 int main(int argc, char **argv) {
   if (argc <= 3) {
@@ -23,8 +24,9 @@ int main(int argc, char **argv) {
   new_comp_t *new_comp = (new_comp_t *)dlsym(lib, "kore_composite_pattern_new");
   new_sort_t *new_sort = (new_sort_t *)dlsym(lib, "kore_composite_sort_new");
   simplify_t *simplify = (simplify_t *)dlsym(lib, "kore_simplify");
+  free_all_t *free_all = (free_all_t *)dlsym(lib, "kllvm_free_all_memory");
 
-  if (!new_comp || !new_sort || !simplify) {
+  if (!new_comp || !new_sort || !simplify || !free_all) {
     return 3;
   }
 
@@ -47,6 +49,8 @@ int main(int argc, char **argv) {
   char *data;
   size_t size;
   simplify(pat, sort, &data, &size);
+
+  free_all();
 
   FILE *f = fopen(argv[2], "wb");
   if (!f) {


### PR DESCRIPTION
This is a small change that exposes the backend's "free all runtime memory" function to the C bindings. It can safely be called at the end of an RPC request to make sure that no memory is hanging around after the request finishes (leaks).

A call to the function is added to the simplification test.

Fixes #636 