### PR TITLE
Fix includes for `kore-expand-macros`

### DIFF
--- a/tools/kore-expand-macros/main.cpp
+++ b/tools/kore-expand-macros/main.cpp
@@ -1,7 +1,16 @@
+#include "kllvm/ast/AST.h"
 #include "kllvm/parser/KOREParser.h"
-#include "kllvm/parser/KOREScanner.h"
 
+#include <algorithm>
 #include <iostream>
+#include <list>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 using namespace kllvm;
 using namespace kllvm::parser;


### PR DESCRIPTION
The list of includes for this tool was insufficient, which broke the Arch linux release job when a transitive include changed in a rolling package.

This PR makes the list of required includes explicit.

Fixes https://github.com/runtimeverification/llvm-backend/issues/645