### PR TITLE
Build on LLVM 15

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1668524829,
-        "narHash": "sha256-ndjSiWzHZK5NTOrSfQ6QUQhtlSZdNoaDA3Jws58bITo=",
+        "lastModified": 1675425829,
+        "narHash": "sha256-Fc3pfIbtn9oQjCY2zFzEf5z3qaYbxAbchWBM8anc7is=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b2444828a1a6682a3976d8ab9758b26bca9a7592",
+        "rev": "31f4fa4f207388c858f90b38e5f2896f94d06203",
         "type": "github"
       },
       "original": {
@@ -144,11 +144,11 @@
     },
     "utils_2": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -92,7 +92,7 @@
           builtins.listToAttrs (lib.imap0 (i: v: { name = "check_${toString i}"; value = v; }) checks);
 
         matrix = builtins.listToAttrs (lib.forEach (lib.cartesianProductOfSets {
-          llvm-version = [11 12 13 14];
+          llvm-version = [11 12 13 14 15];
           build-type = ["Debug" "Release" "RelWithDebInfo" "FastBuild" "GcStats"];
         }) (
           args:
@@ -106,9 +106,9 @@
         ));
       in with matrix; {
         packages = utils.lib.flattenTree {
-          inherit (llvm-backend-14-FastBuild) llvm-backend llvm-backend-matching;
-          default = llvm-backend-14-FastBuild.llvm-backend;
-          llvm-backend-release = llvm-backend-14-Release.llvm-backend;
+          inherit (llvm-backend-15-FastBuild) llvm-backend llvm-backend-matching;
+          default = llvm-backend-15-FastBuild.llvm-backend;
+          llvm-backend-release = llvm-backend-15-Release.llvm-backend;
         };
         checks = listToChecks [
           # Check that the backend compiles on each supported version of LLVM,
@@ -130,9 +130,11 @@
           # llvm-backend-14-FastBuild.integration-tests
           # llvm-backend-14-GcStats.integration-tests
 
-          llvm-backend-14-FastBuild.integration-tests
+          llvm-backend-14-FastBuild.llvm-backend
+
+          llvm-backend-15-FastBuild.integration-tests
         ];
-        devShells.default = llvm-backend-14-FastBuild.devShell;
+        devShells.default = llvm-backend-15-FastBuild.devShell;
       }) // {
         # non-system suffixed items should go here
         overlays.default = llvm-backend-overlay;

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -6,7 +6,7 @@ let
   };
 
   clang = if !llvmPackages.stdenv.targetPlatform.isDarwin then
-    prev.llvmPackages_14.clangNoLibcxx.override (attrs: {
+    llvmPackages.clangNoLibcxx.override (attrs: {
       extraBuildCommands = ''
         ${attrs.extraBuildCommands}
         sed -i $out/nix-support/cc-cflags -e '/^-nostdlib/ d'

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -6,14 +6,14 @@ let
   };
 
   clang = if !llvmPackages.stdenv.targetPlatform.isDarwin then
-    llvmPackages.clangNoLibcxx.override (attrs: {
+    prev.llvmPackages_14.clangNoLibcxx.override (attrs: {
       extraBuildCommands = ''
         ${attrs.extraBuildCommands}
         sed -i $out/nix-support/cc-cflags -e '/^-nostdlib/ d'
       '';
     })
   else
-    llvmPackages.libcxxClang.overrideAttrs (old: {
+    prev.llvmPackages_14.libcxxClang.overrideAttrs (old: {
       # Hack from https://github.com/NixOS/nixpkgs/issues/166205 for macOS
       postFixup = old.postFixup + ''
         echo "-lc++abi" >> $out/nix-support/libcxx-ldflags

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,9 +1,11 @@
 final: prev:
 let
-  llvmPackages = prev."llvmPackages_${toString prev.llvm-version}".override {
+  mkLlvmPackages = (packages: packages.override {
     bootBintoolsNoLibc = null;
     bootBintools = null;
-  };
+  });
+
+  llvmPackages = mkLlvmPackages prev."llvmPackages_${toString prev.llvm-version}";
 
   clang = if !llvmPackages.stdenv.targetPlatform.isDarwin then
     llvmPackages.clangNoLibcxx.override (attrs: {
@@ -13,7 +15,13 @@ let
       '';
     })
   else
-    prev.llvmPackages_14.libcxxClang.overrideAttrs (old: {
+    # In llvmPackages_15, libcxx is broken, so we use clang 14 as our compiler
+    # for C code etc, but still use LLVM 15 to build the backend properly. This
+    # is a workaround until the underlying package is more stable on macOS.
+    let clangPackages = if prev.llvm-version == 15
+      then mkLlvmPackages prev.llvmPackages_14
+      else llvmPackages; in
+    clangPackages.libcxxClang.overrideAttrs (old: {
       # Hack from https://github.com/NixOS/nixpkgs/issues/166205 for macOS
       postFixup = old.postFixup + ''
         echo "-lc++abi" >> $out/nix-support/libcxx-ldflags


### PR DESCRIPTION
This PR updates Nixpkgs so that we can get `llvmPackages_15`, and bumps our integration tests to run on 15 rather than 14 (while still building on 11-15).

There is one hack added (to compile with Clang 14 / LLVM 15 on macOS) because `libcxx` is still a bit broken in LLVM 15; I'll revisit this down the line when the Nixpkgs version is more stable.