### PR TITLE
Missing escape sequence in test

### DIFF
--- a/test/c/test_bytes.kore
+++ b/test/c/test_bytes.kore
@@ -3,7 +3,7 @@
 // RUN: clang -I %include-path Inputs/bytes.c -o %t
 
 // RUN: %t %t.dir/libtest.so %t.foo.bin
-// RUN: %kore-convert %t.foo.bin | grep -q '\dv{SortBytes{}}("\\x00\\x01\\x00\\x02")'
+// RUN: %kore-convert %t.foo.bin | grep -q '\\dv{SortBytes{}}("\\x00\\x01\\x00\\x02")'
 
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/test.k)")]
 


### PR DESCRIPTION
This missing escape causes the test to break in some shells but not others, hence it not being picked up previously.