### PR TITLE
filter out unit axioms

### DIFF
--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -138,7 +138,7 @@ object Parser {
     val splitted = split(axiom._1.pattern)
     if (splitted.isDefined) {
       val s = axiom._1
-      if (hasAtt(s, "comm") || hasAtt(s, "assoc") || hasAtt(s, "idem") || hasAtt(s, "non-executable") || hasAtt(s, "simplification")) {
+      if (hasAtt(s, "comm") || hasAtt(s, "assoc") || hasAtt(s, "idem") || hasAtt(s, "unit") || hasAtt(s, "non-executable") || hasAtt(s, "simplification")) {
         Seq()
       } else {
         Seq((splitted.get._1, AxiomInfo(rulePriority(s), axiom._2, splitted.get._2, splitted.get._3, source(s), location(s))))


### PR DESCRIPTION
This doesn't actually affect the llvm backend because the llvm backend never actually processes the decision trees generated for hooked symbols, but if we don't filter out these axioms, then the maude backend will generate the following axioms:

```
rule L:List .List => L
rule .List L:List => L
```

which will not terminate since maude performs ACUI matching.