### PR TITLE
add flag to parseFunctionAxioms to keep simplification rules

### DIFF
--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matching.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matching.scala
@@ -37,7 +37,7 @@ object Matching {
         dt.serializeToYaml(new File(outputFolder, filename))
       }
     }
-    val funcAxioms = Parser.parseFunctionAxioms(allAxioms)
+    val funcAxioms = Parser.parseFunctionAxioms(allAxioms, false)
     val dts = symlib.functions.map(f => {
       if (logging) {
         System.out.println("Compiling " + f)

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -183,6 +183,10 @@ object Parser {
       case Implies(_, And(_, Not(_, _), And (_, Equals(_, _, pat, _), args)), Equals(i, o, Application(symbol, _), And(_, rhs, _))) => Some(Some(symbol), B.Equals(i, o, B.Application(symbol, getPatterns(args)), rhs), Some(pat))
       case Implies(_, And(_, Not(_, _), And (_, Top(_), args)), Equals(i, o, Application(symbol, _), And(_, rhs, _))) => Some(Some(symbol), B.Equals(i, o, B.Application(symbol, getPatterns(args)), rhs), None)
       case Implies(_, And(_, Top(_), args), Equals(i, o, Application(symbol, _), And(_, rhs, _))) => Some(Some(symbol), B.Equals(i, o, B.Application(symbol, getPatterns(args)), rhs), None)
+      case Implies(_, Top(_), Equals(i, o, app @ Application(symbol, _), And(_, rhs, Top(_)))) => Some(Some(symbol), B.Equals(i, o, app, rhs), None)
+      case Implies(_, Equals(_, _, pat, _), Equals(i, o, app @ Application(symbol, _), And(_, rhs, Top(_)))) => Some(Some(symbol), B.Equals(i, o, app, rhs), Some(pat))
+      case Implies(_, Top(_), eq @ Equals(_, _, Application(symbol, _), _)) => Some(Some(symbol), eq, None)
+      case Implies(_, Equals(_, _, pat, _), eq @ Equals(_, _, Application(symbol, _), _)) => Some(Some(symbol), eq, Some(pat))
       case eq @ Equals(_, _, Application(symbol, _), _) => Some(Some(symbol), eq, None)
       case _ => None
     }


### PR DESCRIPTION
This is another change that doesn't affect the LLVM backend directly but exposes some functionality to the Maude backend which consumes the scala code in this module as a library.

What this change does is add a boolean flag to `parseFunctionAxioms` which specifies whether the function should keep simplification rules or discard them. When set to true, simplification rules are kept and not discarded. The default value the llvm backend uses is false, which is the previous behavior.

In order for this to work, we also have to add the pattern match cases for the structure of simplification rules to the pattern match case present in the code that destructures axioms, otherwise, we will silently discard these rules.