### PR TITLE
Fix `-g` flag propagation

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -93,6 +93,11 @@ while [[ $# -gt 0 ]]; do
       python_cmd="$2"
       shift; shift
       ;;
+    -g)
+      debug=true
+      kompile_clang_flags+=("-g")
+      shift
+      ;;
     --)
       reading_clang_args=true
       shift

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -93,11 +93,6 @@ while [[ $# -gt 0 ]]; do
       python_cmd="$2"
       shift; shift
       ;;
-    -g)
-      debug=true
-      kompile_clang_flags+=("-g")
-      shift
-      ;;
     --)
       reading_clang_args=true
       shift
@@ -148,7 +143,7 @@ if [ "$compile" = "default" ]; then
   main="${positional_args[2]}"
   debug=0
 
-  for arg in "$@"; do
+  for arg in "${clang_args[@]}"; do
     case "$arg" in
       -g)
         debug=1

--- a/debug/kgdb.py
+++ b/debug/kgdb.py
@@ -694,7 +694,7 @@ class KStart(gdb.Command):
 
     def invoke(self, arg, from_tty):
         gdb.execute("start", from_tty)
-        gdb.execute("advance definition.kore:step", from_tty)
+        gdb.execute("advance definition.kore:k_step", from_tty)
 
 start = KStart()
 
@@ -711,7 +711,7 @@ class KStep(gdb.Command):
         if arg != "":
             times = int(arg)
         if times > 0:
-            bp = gdb.Breakpoint("definition.kore:step", internal=True, temporary=True)
+            bp = gdb.Breakpoint("definition.kore:k_step", internal=True, temporary=True)
             bp.ignore_count = times-1
             gdb.execute("c", from_tty)
         else:


### PR DESCRIPTION
Some recent changes to the backend had caused the GDB scripts to drift:
* The new `llvm-kompile` script wasn't setting the debug `1` flag for codegen properly.
* Because `step` is a function somewhere in `libc`, we had to rename our step function to `k_step` to support dynamic loading. The GDB script didn't reflect that.

Fixes #661