### PR TITLE
Cleanup old directory

### DIFF
--- a/include/kllvm/hello/hello.h
+++ b/include/kllvm/hello/hello.h
@@ -1,1 +1,0 @@
-extern int compute_sample(int a);


### PR DESCRIPTION
This simple PR deletes the hello directory and the hello.h from the include/kllvm include directory.
This folder and file were included at the begging of the project and today isn't used by or as a dependency for any other file, so it's safe to delete them.

Same as #662