### PR TITLE
Make python output relative

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -186,7 +186,7 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 fi
 
 if [[ "${python_output_dir}" == "" ]]; then
-  python_output_dir="$(dirname ${definition})"
+  python_output_dir="$(dirname "${definition}")"
 fi
 kompile_clang_flags+=("--python-output-dir" "${python_output_dir}")
 

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -8,13 +8,16 @@ Usage: $0 <definition.kore> <dt_dir> <object type> [options] [clang flags]
    or: $0 <interpreter.o>            <object type> [options] [clang flags]
 
 Options:
-  -h, --help      Print this message and exit.
-  -v, --verbose   Print commands executed to stderr.
-  --save-temps    Do not delete temporary files on exit.
-  --bindings-path Print the absolute path of the compiled Python bindings for
-                  the LLVM backend, then exit.
-  --python PATH   The path to a Python interpreter with Pybind installed. Only
-                  meaningful in "python" or "pythonast" mode.
+  -h, --help                Print this message and exit.
+  -v, --verbose             Print commands executed to stderr.
+  --save-temps              Do not delete temporary files on exit.
+  --bindings-path           Print the absolute path of the compiled Python bindings for
+                            the LLVM backend, then exit.
+  --python PATH             The path to a Python interpreter with Pybind installed. Only
+                            meaningful in "python" or "pythonast" mode.
+  --python-output-dir PATH  Output directory to place automatically-named Python
+                            modules. Only meaningful in "python" or "pythonast"
+                            mode.
 
 Any option not listed above will be passed through to clang; use '--' to
 separate additional positional arguments to clang from those for $0.

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -179,7 +179,9 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
   kompile_clang_flags+=("-fuse-ld=lld")
 fi
 
+kompile_clang_flags+=("--definition" "$(dirname "${definition}")")
+
 run "$(dirname "$0")"/llvm-kompile-clang          \
   "$modopt" "$main"                               \
   @LLVM_KOMPILE_LTO@ -fno-stack-protector         \
-  "${kompile_clang_flags[@]}" "${clang_args[@]}"
+  "${kompile_clang_flags[@]}" "${clang_args[@]}"  \

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -59,6 +59,7 @@ reading_clang_args=false
 kompile_clang_flags=()
 clang_args=()
 python_cmd=python3
+python_output_dir=""
 
 verbose=false
 save_temps=false
@@ -93,6 +94,10 @@ while [[ $# -gt 0 ]]; do
       python_cmd="$2"
       shift; shift
       ;;
+    --python-output-dir)
+      python_output_dir="$2"
+      shift; shift
+      ;;
     --)
       reading_clang_args=true
       shift
@@ -117,6 +122,7 @@ if [[ "${#positional_args[@]}" -lt 1 || "${#positional_args[@]}" -gt 3 ]]; then
   usage
   exit 1
 fi
+
 
 mod="$(mktemp tmp.XXXXXXXXXX)"
 modopt_tmp="$(mktemp tmp.XXXXXXXXXX)"
@@ -179,7 +185,10 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
   kompile_clang_flags+=("-fuse-ld=lld")
 fi
 
-kompile_clang_flags+=("--definition" "$(dirname "${definition}")")
+if [[ "${python_output_dir}" == "" ]]; then
+  python_output_dir="$(dirname ${definition})"
+fi
+kompile_clang_flags+=("--python-output-dir" "${python_output_dir}")
 
 run "$(dirname "$0")"/llvm-kompile-clang          \
   "$modopt" "$main"                               \

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -13,7 +13,7 @@ output=false
 output_file="definition.o"
 compile=true
 python_cmd=python3
-definition_dir="."
+python_output_dir="."
 
 python_extension() {
   "$1" <<HERE
@@ -58,9 +58,9 @@ while [[ $# -gt 0 ]]; do
       python_cmd="$2"
       shift; shift
       ;;
-    --definition)
+    --python-output-dir)
       keep_arg=false
-      definition_dir="$2";
+      python_output_dir="$2";
       shift; shift;
       ;;
     *)
@@ -181,7 +181,7 @@ elif [[ "$main" =~ "python" ]]; then
   # If we didn't pass a filename explicitly as output, then we enforce the
   # blessed filename format that Python can understand.
   if [ "$output_file" = "definition.o" ]; then
-    flags+=("-o" "${definition_dir}/_kllvm${suffix}$(python_extension ${python_cmd})")
+    flags+=("-o" "${python_output_dir}/_kllvm${suffix}$(python_extension ${python_cmd})")
   fi
 elif [ "$main" = "c" ]; then
   # Avoid jemalloc for similar reasons as Python; we don't know who is loading

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -170,7 +170,9 @@ elif [[ "$main" =~ "python" ]]; then
   # pymalloc implementation that Python expects you to use.
   all_libraries=("${libraries[@]}" "-lgmp" "-lmpfr" "-lpthread" "-ldl" "-lffi")
   flags+=("-fPIC" "-shared" "-I${INCDIR}" "-std=c++17")
-  flags+=($(${python_cmd} -m pybind11 --includes))
+
+  read -r -a python_include_flags <<< "$("${python_cmd}" -m pybind11 --includes)"
+  flags+=("${python_include_flags[@]}")
 
   if [ "$main" = "python" ]; then
     suffix="_runtime"
@@ -181,7 +183,7 @@ elif [[ "$main" =~ "python" ]]; then
   # If we didn't pass a filename explicitly as output, then we enforce the
   # blessed filename format that Python can understand.
   if [ "$output_file" = "definition.o" ]; then
-    flags+=("-o" "${python_output_dir}/_kllvm${suffix}$(python_extension ${python_cmd})")
+    flags+=("-o" "${python_output_dir}/_kllvm${suffix}$(python_extension "${python_cmd}")")
   fi
 elif [ "$main" = "c" ]; then
   # Avoid jemalloc for similar reasons as Python; we don't know who is loading

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -13,6 +13,7 @@ output=false
 output_file="definition.o"
 compile=true
 python_cmd=python3
+definition_dir="."
 
 python_extension() {
   "$1" <<HERE
@@ -56,6 +57,11 @@ while [[ $# -gt 0 ]]; do
       keep_arg=false
       python_cmd="$2"
       shift; shift
+      ;;
+    --definition)
+      keep_arg=false
+      definition_dir="$2";
+      shift; shift;
       ;;
     *)
       ;;
@@ -175,7 +181,7 @@ elif [[ "$main" =~ "python" ]]; then
   # If we didn't pass a filename explicitly as output, then we enforce the
   # blessed filename format that Python can understand.
   if [ "$output_file" = "definition.o" ]; then
-    flags+=("-o" "_kllvm${suffix}$(python_extension ${python_cmd})")
+    flags+=("-o" "${definition_dir}/_kllvm${suffix}$(python_extension ${python_cmd})")
   fi
 elif [ "$main" = "c" ]; then
   # Avoid jemalloc for similar reasons as Python; we don't know who is loading

--- a/test/python/test_construct.py
+++ b/test/python/test_construct.py
@@ -1,6 +1,6 @@
 # RUN: mkdir -p %t
 # RUN: export IN=$(realpath Inputs/test_labels.kore)
-# RUN: cd %t && %kompile "$IN" python --python %py-interpreter
+# RUN: cd %t && %kompile "$IN" python --python %py-interpreter --python-output-dir .
 # RUN: KLLVM_DEFINITION=%t %python %s
 
 from test_bindings import kllvm, input_path

--- a/test/python/test_steps.py
+++ b/test/python/test_steps.py
@@ -1,6 +1,6 @@
 # RUN: mkdir -p %t
 # RUN: export IN=$(realpath Inputs/test_steps.kore)
-# RUN: cd %t && %kompile "$IN" python --python %py-interpreter
+# RUN: cd %t && %kompile "$IN" python --python %py-interpreter --python-output-dir .
 # RUN: KLLVM_DEFINITION=%t %python -u %s
 
 from test_bindings import kllvm


### PR DESCRIPTION
Related to https://github.com/runtimeverification/k/issues/3165, https://github.com/runtimeverification/k/pull/3171

The Python bindings build process chooses an output filename by running the Python configuration module, rather than having one passed through the kompilation pipeline. This means that we need to special-case the handling of relative output paths in a couple of places when generating Python modules:
* Setting the output directory for Python modules rather than automatically dumping them in the CWD. This directory defaults to the parent of the `definition.kore` argument to `llvm-kompile`.
* Allowing this directory to be overridden when running the Nix test suite, which separates input definitions and the generated modules.

`llvm-kompile ... python[ast]` has not had its _default_ behaviour changed by this PR.

The existing test suite ensures that this is not a breaking change; the Python and non-Python code paths are both executed.