### PR TITLE
Fix subtle bug in map/set choice algorithm

### DIFF
--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/Pattern.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/Pattern.scala
@@ -205,7 +205,7 @@ case class MapP[T](keys: Seq[Pattern[T]], values: Seq[Pattern[T]], frame: Option
       case (HasKey(_, _, Some(p)), None) => keys.map(_.canonicalize(clause)).exists(Pattern.mightUnify(p, _))
       case (HasNoKey(_, Some(p)), _) => !keys.map(_.canonicalize(clause)).contains(p)
       case (HasKey(_, _, None), None) => keys.nonEmpty && clause.action.priority <= maxPriority
-      case (HasNoKey(_, None), _) => keys.nonEmpty && clause.action.priority > maxPriority
+      case (HasNoKey(_, None), _) => (keys.nonEmpty && clause.action.priority > maxPriority) || isWildcard
     }
   }
   def score(h: Heuristic, f: Fringe, c: Clause, key: Option[Pattern[Option[Occurrence]]], isEmpty: Boolean): Double = h.scoreMap(this, f, c, key, isEmpty)
@@ -322,7 +322,7 @@ case class SetP[T](elements: Seq[Pattern[T]], frame: Option[Pattern[T]], ctr: Sy
       case (HasKey(_, _, Some(p)), None) => elements.map(_.canonicalize(clause)).exists(Pattern.mightUnify(p, _))
       case (HasNoKey(_, Some(p)), _) => !elements.map(_.canonicalize(clause)).contains(p)
       case (HasKey(_, _, None), None) => elements.nonEmpty && clause.action.priority <= maxPriority
-      case (HasNoKey(_, None), _) => elements.nonEmpty && clause.action.priority > maxPriority
+      case (HasNoKey(_, None), _) => (elements.nonEmpty && clause.action.priority > maxPriority) || isWildcard
     }
   }
   def score(h: Heuristic, f: Fringe, c: Clause, key: Option[Pattern[Option[Occurrence]]], isEmpty: Boolean): Double = h.scoreSet(this, f, c, key, isEmpty)


### PR DESCRIPTION
When we wrote the code for the decision tree generation, we hadn't yet fully cleaned up the pattern matching algorithm, so we didn't enforce the invariant that map/set patterns with a map/set variable had to have at least one element. As a result, variable patterns in the code can have multiple representations: as a VariableP, or as a MapP or SetP with no elements and a variable. Unfortunately, we were not treating these two cases as functionally equivalent in all cases; in particular, if we do a map/set choice operation and the collection at runtime happens to be empty, we were discarding rows even if the pattern in that row ought to match the empty collection.

This code change ought to address that issue, but I have not fully tested it to determine if there are any further changes that will need to be made as a result of this change. I'm away from my computer at the moment, so I'm just kicking off some testing at this point. I will add an integration test to this PR before marking it as ready for review.