### PR TITLE
Fix compiler warnings

### DIFF
--- a/lib/parser/KOREParser.cpp
+++ b/lib/parser/KOREParser.cpp
@@ -58,6 +58,7 @@ static std::string str(token tok) {
   case token::ID: return "<identifier>";
   case token::STRING: return "<string>";
   case token::TOKEN_EOF: return "<EOF>";
+  default: abort();
   }
 }
 
@@ -362,7 +363,7 @@ ptr<KOREPattern> KOREParser::applicationPattern(std::string name) {
     consume(token::RIGHTPAREN);
     if (name == "\\left-assoc") {
       ptr<KOREPattern> accum = std::move(pats[0]);
-      for (int i = 1; i < pats.size(); i++) {
+      for (auto i = 1u; i < pats.size(); i++) {
         auto newAccum = KORECompositePattern::Create(pat->getConstructor());
         newAccum->addArgument(std::move(accum));
         newAccum->addArgument(std::move(pats[i]));


### PR DESCRIPTION
This fixes two warnings-as-errors experienced by a Nethermind developer on:
> ubuntu 22.04.1 with clang12.0.1-19ubuntu3

I'm not sure why this doesn't happen in CI, but there is no harm in fixing the issues:
* Explicitly make a loop variable unsigned
* Add a default-case abort to a switch; we do this elsewhere to generate unreachable code, and error-handling elsewhere in the parser will catch bad tokens