### PR TITLE
Don't strip LLVM backend libraries

### DIFF
--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation {
     boost fmt gmp jemalloc libffi mpfr ncurses python-env
   ] ++ lib.optional stdenv.isDarwin libiconv;
 
+  dontStrip = true;
+
   postPatch = ''
     sed -i bin/llvm-kompile \
       -e '2a export PATH="${lib.getBin host.clang}/bin:''${PATH}"'


### PR DESCRIPTION
Fixes #668 - the underlying issue is that the binary section we embed the Python script into is stripped by default when built under Nix. This PR leaves debug information in the backend libraries, which is a more general solution in any case.