### PR TITLE
Fix llvm build on Arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,9 +125,6 @@ find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories (${PROJECT_SOURCE_DIR}/include)
 
-# Find the libraries that correspond to the LLVM components
-# that we wish to use
-
 macro(kllvm_add_tool name)
   add_executable(${name} ${ARGN})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,10 +127,15 @@ include_directories (${PROJECT_SOURCE_DIR}/include)
 
 # Find the libraries that correspond to the LLVM components
 # that we wish to use
-llvm_map_components_to_libnames(llvm_libs core irreader)
 
 macro(kllvm_add_tool name)
   add_executable(${name} ${ARGN})
+
+  llvm_config(${name}
+    USE_SHARED true
+    core irreader
+  )
+
   if(APPLE)
     if(NOT USE_NIX)
       target_link_libraries(${name} PUBLIC "-ljemalloc" "-Wl,-rpath ${BREW_PREFIX}/lib" "-ldl")

--- a/tools/kore-arity/CMakeLists.txt
+++ b/tools/kore-arity/CMakeLists.txt
@@ -3,7 +3,7 @@ kllvm_add_tool(kore-arity
 )
 
 target_link_libraries(kore-arity
-  PUBLIC BinaryKore ${llvm_libs}
+  PUBLIC BinaryKore
 )
 
 install(

--- a/tools/kore-convert/CMakeLists.txt
+++ b/tools/kore-convert/CMakeLists.txt
@@ -3,7 +3,7 @@ kllvm_add_tool(kore-convert
 )
 
 target_link_libraries(kore-convert
-  PUBLIC Parser AST ${llvm_libs}
+  PUBLIC Parser AST
 )
 
 install(

--- a/tools/kore-strip/CMakeLists.txt
+++ b/tools/kore-strip/CMakeLists.txt
@@ -3,7 +3,7 @@ kllvm_add_tool(kore-strip
 )
 
 target_link_libraries(kore-strip
-  PUBLIC BinaryKore ${llvm_libs}
+  PUBLIC BinaryKore
 )
 
 install(

--- a/tools/llvm-kompile-codegen/CMakeLists.txt
+++ b/tools/llvm-kompile-codegen/CMakeLists.txt
@@ -2,7 +2,7 @@ kllvm_add_tool(llvm-kompile-codegen
   main.cpp
 )
 
-target_link_libraries(llvm-kompile-codegen PUBLIC Codegen Parser AST gmp mpfr yaml ${llvm_libs})
+target_link_libraries(llvm-kompile-codegen PUBLIC Codegen Parser AST gmp mpfr yaml)
 
 install(
   TARGETS llvm-kompile-codegen

--- a/unittests/compiler/CMakeLists.txt
+++ b/unittests/compiler/CMakeLists.txt
@@ -10,5 +10,4 @@ target_link_libraries(compiler-tests
   gmp
   yaml
   ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES}
-  ${llvm_libs}
 )


### PR DESCRIPTION
We were relying on a [somewhat outdated CMake command](https://bugzilla.opensuse.org/show_bug.cgi?id=1096168#c2) to identify the LLVM libraries we need to link against.

This PR replaces uses of `map_llvm_components_to_libnames` with the more up-to-date `llvm_config` macro.