### PR TITLE
Improve hiding of LLVM options

### DIFF
--- a/tools/kore-arity/main.cpp
+++ b/tools/kore-arity/main.cpp
@@ -10,9 +10,13 @@
 
 using namespace llvm;
 
-cl::opt<uint64_t> Arity(cl::Positional, cl::desc("<arity>"), cl::Required);
+cl::OptionCategory KoreArityCat("kore-arity options");
+
+cl::opt<uint64_t> Arity(
+    cl::Positional, cl::desc("<arity>"), cl::Required, cl::cat(KoreArityCat));
 
 int main(int argc, char **argv) {
+  cl::HideUnrelatedOptions({&KoreArityCat});
   cl::ParseCommandLineOptions(argc, argv);
 
   auto s = kllvm::serializer(kllvm::serializer::DROP_HEADER);

--- a/tools/kore-convert/main.cpp
+++ b/tools/kore-convert/main.cpp
@@ -1,8 +1,8 @@
-#include "kllvm/ast/AST.h"
-#include "kllvm/binary/deserializer.h"
-#include "kllvm/binary/serializer.h"
-#include "kllvm/parser/KOREParser.h"
-#include "kllvm/parser/location.h"
+#include <kllvm/ast/AST.h>
+#include <kllvm/binary/deserializer.h>
+#include <kllvm/binary/serializer.h>
+#include <kllvm/parser/KOREParser.h>
+#include <kllvm/parser/location.h>
 
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
@@ -26,38 +26,44 @@ enum kore_file_format {
   binary,
 };
 
-cl::opt<std::string>
-    InputFilename(cl::Positional, cl::desc("<input file>"), cl::Required);
+cl::OptionCategory KoreConvertCat("kore-convert options");
+
+cl::opt<std::string> InputFilename(
+    cl::Positional, cl::desc("<input file>"), cl::Required,
+    cl::cat(KoreConvertCat));
 
 cl::opt<kore_file_format> InputFormat(
     "from", cl::desc("Specify input file format"),
     cl::values(
         clEnumVal(detect, "Detect input format automatically"),
         clEnumVal(text, "Textual KORE"), clEnumVal(binary, "Binary KORE")),
-    cl::init(detect));
+    cl::init(detect), cl::cat(KoreConvertCat));
 
 cl::opt<std::string> OutputFilename(
     "o", cl::desc("Specify output filename"), cl::value_desc("filename"),
-    cl::init("-"));
+    cl::init("-"), cl::cat(KoreConvertCat));
 
 cl::opt<kore_file_format> OutputFormat(
     "to", cl::desc("Specify output file format"),
     cl::values(
         clEnumVal(detect, "Convert binary <=> text"),
         clEnumVal(text, "Textual KORE"), clEnumVal(binary, "Binary KORE")),
-    cl::init(detect));
+    cl::init(detect), cl::cat(KoreConvertCat));
 
-cl::opt<bool> ForceBinary("F", cl::desc("Force binary output on stdout"));
+cl::opt<bool> ForceBinary(
+    "F", cl::desc("Force binary output on stdout"), cl::cat(KoreConvertCat));
 
 cl::opt<bool> NoHeader(
     "k",
     cl::desc(
-        "Don't add the KORE header and version at the start of binary output"));
+        "Don't add the KORE header and version at the start of binary output"),
+    cl::cat(KoreConvertCat));
 
 cl::opt<bool> NoArity(
     "a",
     cl::desc(
-        "Don't add the topmost constructor arity at the end of binary output"));
+        "Don't add the topmost constructor arity at the end of binary output"),
+    cl::cat(KoreConvertCat));
 
 sptr<KOREPattern> get_input_pattern() {
   auto get_text = [&]() { return KOREParser(InputFilename).pattern(); };
@@ -107,6 +113,7 @@ serializer::flags get_flags() {
 }
 
 int main(int argc, char **argv) {
+  cl::HideUnrelatedOptions({&KoreConvertCat});
   cl::ParseCommandLineOptions(argc, argv);
 
   auto input = get_input_pattern();

--- a/tools/kore-strip/main.cpp
+++ b/tools/kore-strip/main.cpp
@@ -13,23 +13,27 @@
 
 using namespace llvm;
 
+cl::OptionCategory KoreStripCat("kore-strip options");
+
 cl::opt<bool> StripArity(
     "a",
     cl::desc(
-        "Strip a single sequence of arity bytes from the end of the input"));
+        "Strip a single sequence of arity bytes from the end of the input"),
+    cl::cat(KoreStripCat));
 
 cl::opt<bool> StripHeader(
     "k",
     cl::desc(
-        "Strip the leading 11 bytes (header and version) from the input file"));
+        "Strip the leading 11 bytes (header and version) from the input file"),
+    cl::cat(KoreStripCat));
 
 cl::opt<std::string> InputFilename(
     "i", cl::desc("Specify input filename"), cl::value_desc("filename"),
-    cl::Required);
+    cl::Required, cl::cat(KoreStripCat));
 
 cl::opt<std::string> OutputFilename(
     "o", cl::desc("Specify output filename"), cl::value_desc("filename"),
-    cl::init("-"));
+    cl::init("-"), cl::cat(KoreStripCat));
 
 std::FILE *check_fopen(char const *name, char const *mode) {
   auto f = std::fopen(name, mode);
@@ -44,6 +48,7 @@ std::FILE *check_fopen(char const *name, char const *mode) {
 }
 
 int main(int argc, char **argv) {
+  cl::HideUnrelatedOptions({&KoreStripCat});
   cl::ParseCommandLineOptions(argc, argv);
 
   auto input = check_fopen(InputFilename.c_str(), "rb");

--- a/tools/kprint/main.cpp
+++ b/tools/kprint/main.cpp
@@ -1,6 +1,7 @@
-#include "kllvm/ast/AST.h"
-#include "kllvm/printer/printer.h"
-#include "llvm/Support/CommandLine.h"
+#include <kllvm/ast/AST.h>
+#include <kllvm/printer/printer.h>
+
+#include <llvm/Support/CommandLine.h>
 
 #include <iostream>
 #include <string>
@@ -9,22 +10,26 @@
 using namespace kllvm;
 using namespace llvm;
 
+cl::OptionCategory KPrintCat("kprint options");
+
 cl::opt<std::string> DefinitionFilename(
-    cl::Positional, cl::desc("<definition.kore>"), cl::Required);
+    cl::Positional, cl::desc("<definition.kore>"), cl::Required,
+    cl::cat(KPrintCat));
 
-cl::opt<std::string>
-    PatternFilename(cl::Positional, cl::desc("<pattern.kore>"), cl::Required);
+cl::opt<std::string> PatternFilename(
+    cl::Positional, cl::desc("<pattern.kore>"), cl::Required,
+    cl::cat(KPrintCat));
 
-cl::opt<std::string>
-    ArgColor(cl::Positional, cl::desc("[true|false|auto]"), cl::init("auto"));
+cl::opt<std::string> ArgColor(
+    cl::Positional, cl::desc("[true|false|auto]"), cl::init("auto"),
+    cl::cat(KPrintCat));
 
-cl::opt<bool>
-    FilterSubst(cl::Positional, cl::desc("[true|false]"), cl::init(true));
+cl::opt<bool> FilterSubst(
+    cl::Positional, cl::desc("[true|false]"), cl::init(true),
+    cl::cat(KPrintCat));
 
 int main(int argc, char **argv) {
-  auto map = cl::getRegisteredOptions();
-  map["color"]->setHiddenFlag(cl::Hidden);
-
+  cl::HideUnrelatedOptions({&KPrintCat});
   cl::ParseCommandLineOptions(argc, argv);
 
   bool has_color = ArgColor == "true" || (ArgColor == "auto" && isatty(1));


### PR DESCRIPTION
This PR fixes two issues with one stone:
* For some reason, accessing the registered options to hide `--color` in `kprint` causes a segfault when running the backend on arm64/macOS Nix, when it's built as part of K. I noticed because it was breaking the submodule update, but I can reproduce this locally.
* We get a lot of LLVM options from `--help` for the LLVM backend tools; we can give our options an explicit category and hide the rest.

I have verified locally that these changes will allow the K submodule update to go through.