### PR TITLE
Add support to `total` like `functional`

### DIFF
--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1234,9 +1234,8 @@ bool KOREAxiomDeclaration::isRequired() {
   return !attributes.count(ASSOC) && !attributes.count(COMM)
          && !attributes.count(IDEM) && !attributes.count(UNIT)
          && !attributes.count(FUNCTIONAL) && !attributes.count(CONSTRUCTOR)
-         && !attributes.count(TOTAL) && !attributes.count(CONSTRUCTOR)
-         && !attributes.count(SUBSORT) && !attributes.count(CEIL)
-         && !attributes.count(NON_EXECUTABLE)
+         && !attributes.count(TOTAL) && !attributes.count(SUBSORT) 
+         && !attributes.count(CEIL) && !attributes.count(NON_EXECUTABLE)
          && !attributes.count(SIMPLIFICATION);
 }
 

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1234,7 +1234,7 @@ bool KOREAxiomDeclaration::isRequired() {
   return !attributes.count(ASSOC) && !attributes.count(COMM)
          && !attributes.count(IDEM) && !attributes.count(UNIT)
          && !attributes.count(FUNCTIONAL) && !attributes.count(CONSTRUCTOR)
-         && !attributes.count(TOTAL) && !attributes.count(SUBSORT) 
+         && !attributes.count(TOTAL) && !attributes.count(SUBSORT)
          && !attributes.count(CEIL) && !attributes.count(NON_EXECUTABLE)
          && !attributes.count(SIMPLIFICATION);
 }

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1223,6 +1223,7 @@ static const std::string COMM = "comm";
 static const std::string IDEM = "idem";
 static const std::string UNIT = "unit";
 static const std::string FUNCTIONAL = "functional";
+static const std::string TOTAL = "total";
 static const std::string SUBSORT = "subsort";
 static const std::string CONSTRUCTOR = "constructor";
 static const std::string CEIL = "ceil";
@@ -1233,6 +1234,7 @@ bool KOREAxiomDeclaration::isRequired() {
   return !attributes.count(ASSOC) && !attributes.count(COMM)
          && !attributes.count(IDEM) && !attributes.count(UNIT)
          && !attributes.count(FUNCTIONAL) && !attributes.count(CONSTRUCTOR)
+         && !attributes.count(TOTAL) && !attributes.count(CONSTRUCTOR)
          && !attributes.count(SUBSORT) && !attributes.count(CEIL)
          && !attributes.count(NON_EXECUTABLE)
          && !attributes.count(SIMPLIFICATION);

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
@@ -139,7 +139,7 @@ object Generator {
   def mkDecisionTree(symlib: Parser.SymLib, mod: Definition, axioms: IndexedSeq[AxiomInfo], sorts: Seq[Sort], name: SymbolOrAlias, kem: KException => scala.Unit) : DecisionTree = {
     val matrix = genClauseMatrix(symlib, mod, axioms, sorts)
     matrix.checkUsefulness(kem)
-    if (!symlib.isHooked(name) && Parser.hasAtt(symlib.signatures(name)._3, "functional") && Parser.hasAtt(symlib.signatures(name)._3, "function")) {
+    if (!symlib.isHooked(name) && (Parser.hasAtt(symlib.signatures(name)._3, "functional") || Parser.hasAtt(symlib.signatures(name)._3, "total")) && Parser.hasAtt(symlib.signatures(name)._3, "function")) {
       matrix.checkExhaustiveness(name, kem)
     }
     matrix.compile


### PR DESCRIPTION
Fixes: #667 

Create support for the `[total]` attribute to replace `[functional]` in the future.