### PR TITLE
Correct typo in binary docs

### DIFF
--- a/docs/binary-kore.md
+++ b/docs/binary-kore.md
@@ -68,7 +68,7 @@ For example, consider the following sequence of bytes:
 0104 5678 5678 0207 ff
 ```
 
-First, the string `wVwV` is encoded directly with its length (the single
+First, the string `VxVx` is encoded directly with its length (the single
 uncontinued byte `04`). Splitting the prefix and length from the characters,
 this is `0104 5678 5678`). Then, a variable-length backreference of 7 bytes is
 encoded (`0207`). This backreference is counted from the byte `ff`, and


### PR DESCRIPTION
Addresses a typo in the binary KORE documentation:
```
0x56 == 'V'
0x78 == 'w'
```