### PR TITLE
Update flags definition and naming of `llvm-kompile-testing`

### DIFF
--- a/bin/llvm-kompile-testing
+++ b/bin/llvm-kompile-testing
@@ -8,8 +8,8 @@ if [ $# -lt 2 ]; then
 fi
 dt_dir="$(mktemp -d)"
 trap 'rm -rf "$dt_dir"' INT TERM EXIT
-definition="$1"
-main="$2"
+definition=$(realpath "$1")
+mode="$2"
 shift; shift
 ( cd "@PROJECT_SOURCE_DIR@"/matching && mvn exec:java -Dexec.args="$definition qbaL $dt_dir 1" -q )
-llvm-kompile "$definition" "$dt_dir" "$main" -- "$@" -g
+llvm-kompile "$definition" "$dt_dir" "$mode" -- "$@" -g


### PR DESCRIPTION
In this PR, I propose the following modifications:
- Get the full path of the definition file: The idea is to enable the use of `llvm-kompile-testing` from any directory without the need to pass the absolute path of a file.

- Renaming variable `main` to `mode`: The idea is to make this variable naming more meaningful as we have different modes to generate the interpreter besides the `main` one.