### PR TITLE
Add support to `--binary-output` on search interpreter

### DIFF
--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -18,6 +18,7 @@
 #include <immer/flex_vector.hpp>
 #include <immer/map.hpp>
 #include <immer/set.hpp>
+#include <unordered_set>
 
 // the actual length is equal to the block header with the gc bits masked out.
 
@@ -209,6 +210,8 @@ void printConfigurationInternal(
     writer *file, block *subject, const char *sort, bool, void *);
 mpz_ptr move_int(mpz_t);
 
+void serializeConfigurations(
+    const char *filename, std::unordered_set<block *, HashBlock, KEq> results);
 void serializeConfiguration(
     block *subject, char const *sort, char **data_out, size_t *size_out);
 void serializeConfigurationToFile(const char *filename, block *subject);

--- a/runtime/main/search.cpp
+++ b/runtime/main/search.cpp
@@ -13,13 +13,20 @@ take_search_steps(int64_t depth, int64_t bound, block *subject);
 void printConfigurations(
     const char *filename, std::unordered_set<block *, HashBlock, KEq> results);
 
+void serializeConfigurations(
+    const char *filename, std::unordered_set<block *, HashBlock, KEq> results);
+
 static bool hasStatistics = false;
+static bool binaryOutput = false;
 static int64_t bound = -1;
 
 void parse_flags(int argc, char **argv) {
   for (int i = 4; i < argc; ++i) {
     if (strcmp(argv[i], "--statistics") == 0) {
       hasStatistics = true;
+    }
+    if (strcmp(argv[i], "--binary-output") == 0) {
+      binaryOutput = true;
     }
     if (strcmp(argv[i], "--bound") == 0) {
       bound = std::stoll(argv[i + 1]);
@@ -43,6 +50,10 @@ int main(int argc, char **argv) {
   if (hasStatistics) {
     printStatistics(output, get_steps());
   }
-  printConfigurations(output, results);
+  if (binaryOutput) {
+    serializeConfigurations(output, results);
+  } else {
+    printConfigurations(output, results);
+  }
   return 0;
 }

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -335,7 +335,7 @@ void serializeConfigurations(
   auto state = serialization_state();
 
   writer w = {file, nullptr};
-  ssize_t size = results.size();
+  auto size = results.size();
   if (size == 0) {
     emitConstantSort(state.instance, "SortGeneratedTopCell");
     emitSymbol(state.instance, "\\bottom{}", size, 1);
@@ -343,12 +343,12 @@ void serializeConfigurations(
     auto result = *results.begin();
     serializeConfigurationInternal(&w, result, nullptr, false, &state);
   } else {
-    for (const auto &subject : results) {
+    for (auto const&subject : results) {
       serializeConfigurationInternal(&w, subject, nullptr, false, &state);
     }
 
     emitConstantSort(state.instance, "SortGeneratedTopCell");
-    emitSymbol(state.instance, "\\or{}", results.size(), 1);
+    emitSymbol(state.instance, "\\or{}", size, 1);
   }
 
   auto buf_size = state.instance.data().size();

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -339,6 +339,9 @@ void serializeConfigurations(
   if (size == 0) {
     emitConstantSort(state.instance, "SortGeneratedTopCell");
     emitSymbol(state.instance, "\\bottom{}", size, 1);
+  } if (size == 1) {
+    auto result = *results.begin();
+    serializeConfigurationInternal(&w, result, nullptr, false, &state);
   } else {
     for (const auto &subject : results) {
       serializeConfigurationInternal(&w, subject, nullptr, false, &state);

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -339,11 +339,11 @@ void serializeConfigurations(
   if (size == 0) {
     emitConstantSort(state.instance, "SortGeneratedTopCell");
     emitSymbol(state.instance, "\\bottom{}", size, 1);
-  } if (size == 1) {
+  } else if (size == 1) {
     auto result = *results.begin();
     serializeConfigurationInternal(&w, result, nullptr, false, &state);
   } else {
-    for (auto const&subject : results) {
+    for (auto const &subject : results) {
       serializeConfigurationInternal(&w, subject, nullptr, false, &state);
     }
 

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -334,7 +334,7 @@ void serializeConfigurations(
   FILE *file = fopen(filename, "w");
   auto state = serialization_state();
 
-  writer w = {file, nullptr};
+  auto w = writer{file, nullptr};
   auto size = results.size();
   if (size == 0) {
     emitConstantSort(state.instance, "SortGeneratedTopCell");

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -100,6 +100,16 @@ config.substitutions.extend([
             %t.interpreter $in -1 /dev/stdout | diff - $out || (echo $in && exit 1)
         done
     ''')),
+    
+    ('%check-search-convert-test', one_line('''
+        for out in %test-dir-out/*.out.diff; do
+            in=%test-dir-in/`basename $out .out.diff`.in
+            %t.interpreter $in 3 /dev/stdout | diff - $out
+            %kore-convert $in -o %t.bin && %t.interpreter %t.bin 3 /dev/stdout | diff - $out
+            %t.interpreter $in 3 %t.bin --binary-output
+            %kore-convert %t.bin -o %t.kore && %kore-convert $out --to=text | diff - %t.kore
+        done
+    ''')),
 
     ('%run-binary-out', '%t.interpreter %test-input -1 %t.out.bin --binary-output'),
     ('%run-binary', '%convert-input && %t.interpreter %t.bin -1 /dev/stdout'),

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -100,16 +100,6 @@ config.substitutions.extend([
             %t.interpreter $in -1 /dev/stdout | diff - $out || (echo $in && exit 1)
         done
     ''')),
-    
-    ('%check-search-convert-test', one_line('''
-        for out in %test-dir-out/*.out.diff; do
-            in=%test-dir-in/`basename $out .out.diff`.in
-            %t.interpreter $in 3 /dev/stdout | diff - $out
-            %kore-convert $in -o %t.bin && %t.interpreter %t.bin 3 /dev/stdout | diff - $out
-            %t.interpreter $in 3 %t.bin --binary-output
-            %kore-convert %t.bin -o %t.kore && %kore-convert $out --to=text | diff - %t.kore
-        done
-    ''')),
 
     ('%run-binary-out', '%t.interpreter %test-input -1 %t.out.bin --binary-output'),
     ('%run-binary', '%convert-input && %t.interpreter %t.bin -1 /dev/stdout'),

--- a/test/search/search.kore
+++ b/test/search/search.kore
@@ -1,5 +1,6 @@
 // RUN: %search-interpreter
 // RUN: %check-dir-diff
+// RUN: %check-search-convert-test
 
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/robertorosmaninho/rv/tests/search.k)")]
 

--- a/test/search/search.kore
+++ b/test/search/search.kore
@@ -1,6 +1,13 @@
 // RUN: %search-interpreter
 // RUN: %check-dir-diff
-// RUN: %check-search-convert-test
+// RUN: %t.interpreter %test-dir-in/search.initial.in 3 /dev/stdout | diff - %test-dir-out/search.initial.out.diff
+// RUN: %kore-convert %test-dir-in/search.initial.in -o %t.bin && %t.interpreter %t.bin 3 /dev/stdout | diff - %test-dir-out/search.initial.out.diff
+// RUN: %t.interpreter %test-dir-in/search.initial.in 3 %t.bin --binary-output
+// RUN: %kore-convert %t.bin -o %t.kore && %kore-convert %test-dir-out/search.initial.out.diff --to=text | diff - %t.kore
+// RUN: %t.interpreter %test-dir-in/search.next1.in 3 /dev/stdout | diff - %test-dir-out/search.next1.out.diff
+// RUN: %kore-convert %test-dir-in/search.next1.in -o %t.bin && %t.interpreter %t.bin 3 /dev/stdout | diff - %test-dir-out/search.next1.out.diff
+// RUN: %t.interpreter %test-dir-in/search.next1.in 3 %t.bin --binary-output
+// RUN: %kore-convert %t.bin -o %t.kore && %kore-convert %test-dir-out/search.next1.out.diff --to=text | diff - %t.kore
 
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/robertorosmaninho/rv/tests/search.k)")]
 


### PR DESCRIPTION
Fixes #690 

This PR enables the interpreter created with search support to print the file using the KORE binary.