### PR TITLE
Output processed KORE from `kprint`

### DIFF
--- a/include/kllvm/printer/printer.h
+++ b/include/kllvm/printer/printer.h
@@ -12,7 +12,8 @@ sptr<KOREPattern> addBrackets(sptr<KOREPattern>, PrettyPrintData const &);
 
 std::ostream &printKORE(
     std::ostream &os, std::string const &definitionPath,
-    std::string const &patternPath, bool hasColor, bool filterSubst);
+    std::string const &patternPath, bool hasColor, bool filterSubst,
+    bool pretty = true);
 
 } // namespace kllvm
 

--- a/lib/printer/printer.cpp
+++ b/lib/printer/printer.cpp
@@ -343,7 +343,8 @@ using namespace parser;
 
 std::ostream &printKORE(
     std::ostream &os, std::string const &definitionPath,
-    std::string const &patternPath, bool hasColor, bool filterSubst) {
+    std::string const &patternPath, bool hasColor, bool filterSubst,
+    bool pretty) {
   static std::map<std::string, PreprocessedPrintData> cache;
 
   auto const &def = getDefinition(definitionPath);
@@ -391,7 +392,11 @@ std::ostream &printKORE(
   }
 
   sptr<KOREPattern> withBrackets = addBrackets(filtered, data);
-  withBrackets->prettyPrint(os, data);
+  if (pretty) {
+    withBrackets->prettyPrint(os, data);
+  } else {
+    withBrackets->print(os);
+  }
   os << std::endl;
 
   return os;

--- a/test/unparse/exp/exp2kore.cfg.kore
+++ b/test/unparse/exp/exp2kore.cfg.kore
@@ -1,0 +1,2 @@
+// RUN: kprint %S %s true --kore | diff - %s.out
+Lbl'UndsPlusUndsUnds'TEST'Unds'Exp'Unds'Exp'Unds'Exp{}(Lbl'UndsPlusUndsUnds'TEST'Unds'Exp'Unds'Exp'Unds'Exp{}(inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("1")),Lbl'UndsPlusUndsUnds'TEST'Unds'Exp'Unds'Exp'Unds'Exp{}(inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("1")),inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("1")))),inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("1")))

--- a/test/unparse/exp/exp2kore.cfg.kore.out
+++ b/test/unparse/exp/exp2kore.cfg.kore.out
@@ -1,0 +1,1 @@
+Lbl'UndsPlusUndsUnds'TEST'Unds'Exp'Unds'Exp'Unds'Exp{}(Lbl'UndsPlusUndsUnds'TEST'Unds'Exp'Unds'Exp'Unds'Exp{}(\dv{SortInt{}}("1"),Lbl'LParUndsRParUnds'TEST'Unds'Exp'Unds'Exp{}(Lbl'UndsPlusUndsUnds'TEST'Unds'Exp'Unds'Exp'Unds'Exp{}(\dv{SortInt{}}("1"),\dv{SortInt{}}("1")))),\dv{SortInt{}}("1"))

--- a/tools/kprint/main.cpp
+++ b/tools/kprint/main.cpp
@@ -28,6 +28,11 @@ cl::opt<bool> FilterSubst(
     cl::Positional, cl::desc("[true|false]"), cl::init(true),
     cl::cat(KPrintCat));
 
+cl::opt<bool> PrintAsKore(
+    "kore",
+    cl::desc("Perform unparsing, but print KORE rather than surface syntax"),
+    cl::cat(KPrintCat));
+
 int main(int argc, char **argv) {
   cl::HideUnrelatedOptions({&KPrintCat});
   cl::ParseCommandLineOptions(argc, argv);
@@ -35,5 +40,6 @@ int main(int argc, char **argv) {
   bool has_color = ArgColor == "true" || (ArgColor == "auto" && isatty(1));
 
   printKORE(
-      std::cout, DefinitionFilename, PatternFilename, has_color, FilterSubst);
+      std::cout, DefinitionFilename, PatternFilename, has_color, FilterSubst,
+      !PrintAsKore);
 }


### PR DESCRIPTION
Fixes https://github.com/runtimeverification/llvm-backend/issues/693; this issue is a feature request to get access to the post-processed KORE that `kprint` currently uses to produce pretty surface syntax.