### PR TITLE
Run on ephemeral runner

### DIFF
--- a/.github/workflows/test-flake.yml
+++ b/.github/workflows/test-flake.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-20.04
+          - runner: [self-hosted, linux, normal-ephemeral]
             os: ubuntu-20.04
           - runner: macos-12
             os: macos-12


### PR DESCRIPTION
We have been seeing OOMs for the Nix tests running on public Ubuntu runners. This PR switches to the new RV ephemeral runners to avoid this.