### PR TITLE
Infer shared library extension in `c` mode

### DIFF
--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -22,6 +22,11 @@ print(sysconfig.get_config_var('EXT_SUFFIX'))
 HERE
 }
 
+infer_library_name() {
+  base_name="$1"
+  echo "$base_name"
+}
+
 clangpp_args=("--std=c++17")
 while [[ $# -gt 0 ]]; do
   if $output; then
@@ -186,6 +191,8 @@ elif [[ "$main" =~ "python" ]]; then
     flags+=("-o" "${python_output_dir}/_kllvm${suffix}$(python_extension "${python_cmd}")")
   fi
 elif [ "$main" = "c" ]; then
+  output_file="$(infer_library_name "$output_file")"
+
   # Avoid jemalloc for similar reasons as Python; we don't know who is loading
   # this library so don't want to impose it.
   all_libraries=("${libraries[@]}" "-lgmp" "-lmpfr" "-lpthread" "-ldl" "-lffi")

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -24,7 +24,18 @@ HERE
 
 infer_library_name() {
   base_name="$1"
-  echo "$base_name"
+  
+  if [[ "$base_name" =~ "." ]]; then
+    echo "$base_name"
+  else
+    if [[ "$(uname)" == "Darwin" ]]; then
+      ext=".dylib"
+    else
+      ext=".so"
+    fi
+
+    echo "${base_name}${ext}"
+  fi
 }
 
 clangpp_args=("--std=c++17")
@@ -197,6 +208,7 @@ elif [ "$main" = "c" ]; then
   # this library so don't want to impose it.
   all_libraries=("${libraries[@]}" "-lgmp" "-lmpfr" "-lpthread" "-ldl" "-lffi")
   flags+=("-fPIC" "-shared" "$start_whole_archive" "$LIBDIR/libkllvmcruntime.a" "$end_whole_archive")
+  clangpp_args+=("-o" "${output_file}")
 else
   all_libraries=("${libraries[@]}" "-lgmp" "-lmpfr" "-lpthread" "-ldl" "-lffi" "-ljemalloc")
 fi


### PR DESCRIPTION
Currently, we require callers of `kompile` to know their platform's shared library extension (and invoke the K tools accordingly). It would be convenient to add the correct extension for them automatically when compiling in C mode.

The positive case of this change is not yet used by any code (https://github.com/runtimeverification/k/pull/3259 and related K as a library work will eventually integration test it), and I'm confident that the existing test suite will catch any inadvertent breakages caused by the PR.