### PR TITLE
Fix injections for interpreter input

### DIFF
--- a/bindings/c/include/kllvm-c/kllvm-c.h
+++ b/bindings/c/include/kllvm-c/kllvm-c.h
@@ -4,8 +4,10 @@
 #ifndef __cplusplus
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #else
 #include <cstddef>
+#include <cstdint>
 #endif
 
 #ifdef __cplusplus
@@ -50,7 +52,8 @@ kore_pattern_new_token_with_len(char const *, size_t, kore_sort const *);
 kore_pattern *kore_pattern_new_injection(
     kore_pattern const *, kore_sort const *, kore_sort const *);
 
-kore_pattern *kore_pattern_make_interpreter_input(kore_pattern const *);
+kore_pattern *
+kore_pattern_make_interpreter_input(kore_pattern const *, kore_sort const *);
 
 kore_pattern *kore_composite_pattern_new(char const *);
 kore_pattern *kore_composite_pattern_from_symbol(kore_symbol *);
@@ -74,6 +77,8 @@ void kore_simplify(
     kore_pattern const *pattern, kore_sort const *sort, char **, size_t *);
 
 void kore_simplify_binary(char *, size_t, kore_sort const *, char **, size_t *);
+
+block *take_steps(int64_t depth, block *term);
 
 /* KORESort */
 

--- a/bindings/c/lib.cpp
+++ b/bindings/c/lib.cpp
@@ -116,7 +116,8 @@ kore_pattern *kore_pattern_new_injection(
   return inj;
 }
 
-kore_pattern *kore_pattern_make_interpreter_input(kore_pattern const *pgm) {
+kore_pattern *kore_pattern_make_interpreter_input(
+    kore_pattern const *pgm, kore_sort const *sort) {
   auto config_sort = kore_composite_sort_new("SortKConfigVar");
   auto kitem_sort = kore_composite_sort_new("SortKItem");
 
@@ -125,7 +126,14 @@ kore_pattern *kore_pattern_make_interpreter_input(kore_pattern const *pgm) {
 
   auto map_item = kore_composite_pattern_new("Lbl'UndsPipe'-'-GT-Unds'");
   kore_composite_pattern_add_argument(map_item, key);
-  kore_composite_pattern_add_argument(map_item, pgm);
+
+  if (kore_sort_is_kitem(sort)) {
+    kore_composite_pattern_add_argument(map_item, pgm);
+  } else {
+    auto inj = kore_pattern_new_injection(pgm, sort, kitem_sort);
+    kore_composite_pattern_add_argument(map_item, inj);
+    kore_pattern_free(inj);
+  }
 
   auto map_unit = kore_composite_pattern_new("Lbl'Stop'Map");
 

--- a/test/c/Inputs/steps.c
+++ b/test/c/Inputs/steps.c
@@ -1,0 +1,80 @@
+#include <assert.h>
+#include <dlfcn.h>
+#include <kllvm-c/kllvm-c.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef void init_t(void);
+typedef kore_pattern *parse_t(char const *);
+typedef char *dump_t(kore_pattern const *);
+typedef char *block_dump_t(block *);
+typedef kore_sort *new_sort_t(char const *);
+typedef kore_pattern *make_input_t(kore_pattern const *, kore_sort const *);
+typedef block *construct_t(kore_pattern const *);
+typedef block *step_t(int64_t, block *);
+
+int main(int argc, char **argv) {
+  if (argc <= 1) {
+    return 1;
+  }
+
+  void *lib = dlopen(argv[1], RTLD_NOW);
+  if (!lib) {
+    return 2;
+  }
+
+  init_t *init = (init_t *)dlsym(lib, "kllvm_init");
+  parse_t *parse = (parse_t *)dlsym(lib, "kore_pattern_parse");
+  dump_t *dump = (dump_t *)dlsym(lib, "kore_pattern_dump");
+  block_dump_t *block_dump = (block_dump_t *)dlsym(lib, "kore_block_dump");
+  new_sort_t *new_sort = (new_sort_t *)dlsym(lib, "kore_composite_sort_new");
+  make_input_t *make_input
+      = (make_input_t *)dlsym(lib, "kore_pattern_make_interpreter_input");
+  construct_t *construct = (construct_t *)dlsym(lib, "kore_pattern_construct");
+  step_t *steps = (step_t *)dlsym(lib, "take_steps");
+
+  if (!init || !parse || !dump || !block_dump || !new_sort || !make_input
+      || !construct || !steps) {
+    return 3;
+  }
+
+  /*
+    module ARITHMETIC-SYNTAX
+      imports UNSIGNED-INT-SYNTAX
+
+      syntax Exp ::= Int
+                   | Exp "+" Exp [left, strict]
+    endmodule
+
+    module ARITHMETIC
+      imports ARITHMETIC-SYNTAX
+      imports DOMAINS
+
+      configuration
+        <k> $PGM:Exp </k>
+
+      rule A + B => A +Int B
+
+      syntax Bool ::= isKResult(Exp) [function, symbol]
+      rule isKResult(_::Int) => true
+      rule isKResult(_)      => false [owise]
+    endmodule
+  */
+
+  init();
+
+  kore_pattern *pat = parse(
+      "Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}("
+      "inj{SortInt{}, SortExp{}}(\\dv{SortInt{}}(\"75\")),inj{SortInt{}, "
+      "SortExp{}}(\\dv{SortInt{}}(\"12\")))");
+
+  kore_sort *sort_exp = new_sort("SortExp");
+  kore_pattern *input = make_input(pat, sort_exp);
+
+  block *term = construct(input);
+  block *after = steps(-1, term);
+
+  printf("%s", block_dump(after));
+}

--- a/test/c/test_steps.kore
+++ b/test/c/test_steps.kore
@@ -1,0 +1,6326 @@
+// RUN: mkdir -p %t.dir
+// RUN: %kompile %s c -o %t.dir/libtest.so
+// RUN: clang -I %include-path Inputs/steps.c -o %t
+// RUN: %t %t.dir/libtest.so | grep -q '\\dv{SortInt{}}("87")'
+
+[topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)")]
+
+module BASIC-K
+    sort SortK{} []
+    sort SortKItem{} []
+endmodule
+[]
+module KSEQ
+    import BASIC-K []
+    symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol dotk{}() : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol append{}(SortK{}, SortK{}) : SortK{} [function{}(), functional{}()]
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, dotk{}()),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                TAIL:SortK{},
+                \top{SortK{}}()
+            )
+        )
+    ) []
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, kseq{}(K:SortKItem{}, KS:SortK{})),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                kseq{}(K:SortKItem{}, append{}(KS:SortK{}, TAIL:SortK{})),
+                \top{SortK{}}()
+            )
+        )
+    ) []
+endmodule
+[]
+module INJ
+    symbol inj{From, To}(From) : To [sortInjection{}()]
+    axiom {S1, S2, S3, R} \equals{S3, R}(inj{S2, S3}(inj{S1, S2}(T:S1)), inj{S1, S3}(T:S1)) [simplification{}()]
+endmodule
+[]
+module K
+    import KSEQ []
+    import INJ []
+    alias weakExistsFinally{A}(A) : A where weakExistsFinally{A}(@X:A) := @X:A []
+    alias weakAlwaysFinally{A}(A) : A where weakAlwaysFinally{A}(@X:A) := @X:A []
+    alias allPathGlobally{A}(A) : A where allPathGlobally{A}(@X:A) := @X:A []
+endmodule
+[]
+
+module ARITHMETIC
+
+// imports
+  import K []
+
+// sorts
+  sort SortKCellOpt{} []
+  sort SortIOInt{} []
+  sort SortGeneratedTopCellFragment{} []
+  sort SortIOFile{} []
+  hooked-sort SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), element{}(LblListItem{}()), concat{}(Lbl'Unds'List'Unds'{}()), unit{}(Lbl'Stop'List{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(723,3,723,32)")]
+  sort SortKCell{} []
+  sort SortGeneratedTopCell{} []
+  sort SortGeneratedCounterCell{} []
+  hooked-sort SortFloat{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1291,3,1291,35)"), hook{}("FLOAT.Float"), hasDomainValues{}()]
+  hooked-sort SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), concat{}(Lbl'Unds'Map'Unds'{}()), unit{}(Lbl'Stop'Map{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(218,3,218,29)")]
+  hooked-sort SortString{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1504,3,1504,38)"), hook{}("STRING.String"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), hasDomainValues{}()]
+  sort SortIOString{} []
+  sort SortId{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2135,3,2135,20)"), token{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), hasDomainValues{}()]
+  sort SortGeneratedCounterCellOpt{} []
+  sort SortKConfigVar{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/kast.md)"), token{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(40,3,40,28)"), hasDomainValues{}()]
+  sort SortExp{} []
+  hooked-sort SortInt{} [hook{}("INT.Int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(999,3,999,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), hasDomainValues{}()]
+  sort SortIOError{} []
+  hooked-sort SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), element{}(LblSetItem{}()), concat{}(Lbl'Unds'Set'Unds'{}()), unit{}(Lbl'Stop'Set{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(510,3,510,29)")]
+  sort SortStream{} []
+  hooked-sort SortBool{} [hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(878,3,878,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), hasDomainValues{}()]
+
+// symbols
+  symbol Lbl'Hash'E2BIG{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#E2BIG"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2317,22,2317,55)"), left{}(), format{}("%c#E2BIG%r"), injective{}()]
+  symbol Lbl'Hash'EACCES{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EACCES"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2318,22,2318,57)"), left{}(), format{}("%c#EACCES%r"), injective{}()]
+  symbol Lbl'Hash'EADDRINUSE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EADDRINUSE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2367,22,2367,65)"), left{}(), format{}("%c#EADDRINUSE%r"), injective{}()]
+  symbol Lbl'Hash'EADDRNOTAVAIL{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EADDRNOTAVAIL"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2368,22,2368,71)"), left{}(), format{}("%c#EADDRNOTAVAIL%r"), injective{}()]
+  symbol Lbl'Hash'EAFNOSUPPORT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EAFNOSUPPORT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2366,22,2366,69)"), left{}(), format{}("%c#EAFNOSUPPORT%r"), injective{}()]
+  symbol Lbl'Hash'EAGAIN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EAGAIN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2319,22,2319,57)"), left{}(), format{}("%c#EAGAIN%r"), injective{}()]
+  symbol Lbl'Hash'EALREADY{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EALREADY"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2356,22,2356,61)"), left{}(), format{}("%c#EALREADY%r"), injective{}()]
+  symbol Lbl'Hash'EBADF{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EBADF"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2320,22,2320,55)"), left{}(), format{}("%c#EBADF%r"), injective{}()]
+  symbol Lbl'Hash'EBUSY{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EBUSY"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2321,22,2321,55)"), left{}(), format{}("%c#EBUSY%r"), injective{}()]
+  symbol Lbl'Hash'ECHILD{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ECHILD"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2322,22,2322,57)"), left{}(), format{}("%c#ECHILD%r"), injective{}()]
+  symbol Lbl'Hash'ECONNABORTED{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ECONNABORTED"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2372,22,2372,69)"), left{}(), format{}("%c#ECONNABORTED%r"), injective{}()]
+  symbol Lbl'Hash'ECONNREFUSED{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ECONNREFUSED"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2380,22,2380,69)"), left{}(), format{}("%c#ECONNREFUSED%r"), injective{}()]
+  symbol Lbl'Hash'ECONNRESET{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ECONNRESET"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2373,22,2373,65)"), left{}(), format{}("%c#ECONNRESET%r"), injective{}()]
+  symbol Lbl'Hash'EDEADLK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EDEADLK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2323,22,2323,59)"), left{}(), format{}("%c#EDEADLK%r"), injective{}()]
+  symbol Lbl'Hash'EDESTADDRREQ{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EDESTADDRREQ"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2358,22,2358,69)"), left{}(), format{}("%c#EDESTADDRREQ%r"), injective{}()]
+  symbol Lbl'Hash'EDOM{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EDOM"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2324,22,2324,53)"), left{}(), format{}("%c#EDOM%r"), injective{}()]
+  symbol Lbl'Hash'EEXIST{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EEXIST"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2325,22,2325,57)"), left{}(), format{}("%c#EEXIST%r"), injective{}()]
+  symbol Lbl'Hash'EFAULT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EFAULT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2326,22,2326,57)"), left{}(), format{}("%c#EFAULT%r"), injective{}()]
+  symbol Lbl'Hash'EFBIG{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EFBIG"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2327,22,2327,55)"), left{}(), format{}("%c#EFBIG%r"), injective{}()]
+  symbol Lbl'Hash'EHOSTDOWN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EHOSTDOWN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2381,22,2381,63)"), left{}(), format{}("%c#EHOSTDOWN%r"), injective{}()]
+  symbol Lbl'Hash'EHOSTUNREACH{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EHOSTUNREACH"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2382,22,2382,69)"), left{}(), format{}("%c#EHOSTUNREACH%r"), injective{}()]
+  symbol Lbl'Hash'EINPROGRESS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EINPROGRESS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2355,22,2355,67)"), left{}(), format{}("%c#EINPROGRESS%r"), injective{}()]
+  symbol Lbl'Hash'EINTR{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EINTR"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2328,22,2328,55)"), left{}(), format{}("%c#EINTR%r"), injective{}()]
+  symbol Lbl'Hash'EINVAL{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EINVAL"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2329,22,2329,57)"), left{}(), format{}("%c#EINVAL%r"), injective{}()]
+  symbol Lbl'Hash'EIO{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EIO"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2330,22,2330,51)"), left{}(), format{}("%c#EIO%r"), injective{}()]
+  symbol Lbl'Hash'EISCONN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EISCONN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2375,22,2375,59)"), left{}(), format{}("%c#EISCONN%r"), injective{}()]
+  symbol Lbl'Hash'EISDIR{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EISDIR"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2331,22,2331,57)"), left{}(), format{}("%c#EISDIR%r"), injective{}()]
+  symbol Lbl'Hash'ELOOP{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ELOOP"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2383,22,2383,55)"), left{}(), format{}("%c#ELOOP%r"), injective{}()]
+  symbol Lbl'Hash'EMFILE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EMFILE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2332,22,2332,57)"), left{}(), format{}("%c#EMFILE%r"), injective{}()]
+  symbol Lbl'Hash'EMLINK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EMLINK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2333,22,2333,57)"), left{}(), format{}("%c#EMLINK%r"), injective{}()]
+  symbol Lbl'Hash'EMSGSIZE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EMSGSIZE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2359,22,2359,61)"), left{}(), format{}("%c#EMSGSIZE%r"), injective{}()]
+  symbol Lbl'Hash'ENAMETOOLONG{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENAMETOOLONG"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2334,22,2334,69)"), left{}(), format{}("%c#ENAMETOOLONG%r"), injective{}()]
+  symbol Lbl'Hash'ENETDOWN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENETDOWN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2369,22,2369,61)"), left{}(), format{}("%c#ENETDOWN%r"), injective{}()]
+  symbol Lbl'Hash'ENETRESET{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENETRESET"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2371,22,2371,63)"), left{}(), format{}("%c#ENETRESET%r"), injective{}()]
+  symbol Lbl'Hash'ENETUNREACH{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENETUNREACH"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2370,22,2370,67)"), left{}(), format{}("%c#ENETUNREACH%r"), injective{}()]
+  symbol Lbl'Hash'ENFILE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENFILE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2335,22,2335,57)"), left{}(), format{}("%c#ENFILE%r"), injective{}()]
+  symbol Lbl'Hash'ENOBUFS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOBUFS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2374,22,2374,59)"), left{}(), format{}("%c#ENOBUFS%r"), injective{}()]
+  symbol Lbl'Hash'ENODEV{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENODEV"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2336,22,2336,57)"), left{}(), format{}("%c#ENODEV%r"), injective{}()]
+  symbol Lbl'Hash'ENOENT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOENT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2337,22,2337,57)"), left{}(), format{}("%c#ENOENT%r"), injective{}()]
+  symbol Lbl'Hash'ENOEXEC{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOEXEC"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2338,22,2338,59)"), left{}(), format{}("%c#ENOEXEC%r"), injective{}()]
+  symbol Lbl'Hash'ENOLCK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOLCK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2339,22,2339,57)"), left{}(), format{}("%c#ENOLCK%r"), injective{}()]
+  symbol Lbl'Hash'ENOMEM{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOMEM"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2340,22,2340,57)"), left{}(), format{}("%c#ENOMEM%r"), injective{}()]
+  symbol Lbl'Hash'ENOPROTOOPT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOPROTOOPT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2361,22,2361,67)"), left{}(), format{}("%c#ENOPROTOOPT%r"), injective{}()]
+  symbol Lbl'Hash'ENOSPC{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOSPC"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2341,22,2341,57)"), left{}(), format{}("%c#ENOSPC%r"), injective{}()]
+  symbol Lbl'Hash'ENOSYS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOSYS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2342,22,2342,57)"), left{}(), format{}("%c#ENOSYS%r"), injective{}()]
+  symbol Lbl'Hash'ENOTCONN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTCONN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2376,22,2376,61)"), left{}(), format{}("%c#ENOTCONN%r"), injective{}()]
+  symbol Lbl'Hash'ENOTDIR{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTDIR"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2343,22,2343,59)"), left{}(), format{}("%c#ENOTDIR%r"), injective{}()]
+  symbol Lbl'Hash'ENOTEMPTY{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTEMPTY"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2344,22,2344,63)"), left{}(), format{}("%c#ENOTEMPTY%r"), injective{}()]
+  symbol Lbl'Hash'ENOTSOCK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTSOCK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2357,22,2357,61)"), left{}(), format{}("%c#ENOTSOCK%r"), injective{}()]
+  symbol Lbl'Hash'ENOTTY{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTTY"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2345,22,2345,57)"), left{}(), format{}("%c#ENOTTY%r"), injective{}()]
+  symbol Lbl'Hash'ENXIO{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENXIO"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2346,22,2346,55)"), left{}(), format{}("%c#ENXIO%r"), injective{}()]
+  symbol Lbl'Hash'EOF{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EOF"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2316,22,2316,51)"), left{}(), format{}("%c#EOF%r"), injective{}()]
+  symbol Lbl'Hash'EOPNOTSUPP{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EOPNOTSUPP"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2364,22,2364,65)"), left{}(), format{}("%c#EOPNOTSUPP%r"), injective{}()]
+  symbol Lbl'Hash'EOVERFLOW{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EOVERFLOW"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2384,22,2384,63)"), left{}(), format{}("%c#EOVERFLOW%r"), injective{}()]
+  symbol Lbl'Hash'EPERM{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPERM"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2347,22,2347,55)"), left{}(), format{}("%c#EPERM%r"), injective{}()]
+  symbol Lbl'Hash'EPFNOSUPPORT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPFNOSUPPORT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2365,22,2365,69)"), left{}(), format{}("%c#EPFNOSUPPORT%r"), injective{}()]
+  symbol Lbl'Hash'EPIPE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPIPE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2348,22,2348,55)"), left{}(), format{}("%c#EPIPE%r"), injective{}()]
+  symbol Lbl'Hash'EPROTONOSUPPORT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPROTONOSUPPORT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2362,22,2362,75)"), left{}(), format{}("%c#EPROTONOSUPPORT%r"), injective{}()]
+  symbol Lbl'Hash'EPROTOTYPE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPROTOTYPE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2360,22,2360,65)"), left{}(), format{}("%c#EPROTOTYPE%r"), injective{}()]
+  symbol Lbl'Hash'ERANGE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ERANGE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2349,22,2349,57)"), left{}(), format{}("%c#ERANGE%r"), injective{}()]
+  symbol Lbl'Hash'EROFS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EROFS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2350,22,2350,55)"), left{}(), format{}("%c#EROFS%r"), injective{}()]
+  symbol Lbl'Hash'ESHUTDOWN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ESHUTDOWN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2377,22,2377,63)"), left{}(), format{}("%c#ESHUTDOWN%r"), injective{}()]
+  symbol Lbl'Hash'ESOCKTNOSUPPORT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ESOCKTNOSUPPORT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2363,22,2363,75)"), left{}(), format{}("%c#ESOCKTNOSUPPORT%r"), injective{}()]
+  symbol Lbl'Hash'ESPIPE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ESPIPE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2351,22,2351,57)"), left{}(), format{}("%c#ESPIPE%r"), injective{}()]
+  symbol Lbl'Hash'ESRCH{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ESRCH"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2352,22,2352,55)"), left{}(), format{}("%c#ESRCH%r"), injective{}()]
+  symbol Lbl'Hash'ETIMEDOUT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ETIMEDOUT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2379,22,2379,63)"), left{}(), format{}("%c#ETIMEDOUT%r"), injective{}()]
+  symbol Lbl'Hash'ETOOMANYREFS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ETOOMANYREFS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2378,22,2378,69)"), left{}(), format{}("%c#ETOOMANYREFS%r"), injective{}()]
+  symbol Lbl'Hash'EWOULDBLOCK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EWOULDBLOCK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2354,22,2354,67)"), left{}(), format{}("%c#EWOULDBLOCK%r"), injective{}()]
+  symbol Lbl'Hash'EXDEV{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EXDEV"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2353,22,2353,55)"), left{}(), format{}("%c#EXDEV%r"), injective{}()]
+  hooked-symbol Lbl'Hash'accept'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.accept"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2482,20,2482,81)"), left{}(), format{}("%c#accept%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(SortK{}) : SortStream{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("#buffer"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2586,21,2586,31)"), left{}(), format{}("%c#buffer%r %c(%r %1 %c)%r"), injective{}()]
+  hooked-symbol Lbl'Hash'close'LParUndsRParUnds'K-IO'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.close"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2456,16,2456,75)"), left{}(), format{}("%c#close%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(SortK{}) : SortKItem{} [functional{}(), constructor{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%c#freezer_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp0_%r %c(%r %1 %c)%r"), injective{}()]
+  symbol Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(SortK{}) : SortKItem{} [functional{}(), constructor{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%c#freezer_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp1_%r %c(%r %1 %c)%r"), injective{}()]
+  hooked-symbol Lbl'Hash'getc'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.getc"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2437,20,2437,89)"), left{}(), format{}("%c#getc%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(SortBool{}, SortSort, SortSort) : SortSort [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), smt-hook{}("ite"), right{}(), terminals{}("1010101"), hook{}("KEQUAL.ite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2186,26,2186,121)"), left{}(), format{}("%c#if%r %1 %c#then%r %2 %c#else%r %3 %c#fi%r"), function{}()]
+  symbol Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(SortInt{}) : SortStream{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("#istream"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2587,21,2587,34)"), left{}(), format{}("%c#istream%r %c(%r %1 %c)%r"), injective{}()]
+  hooked-symbol Lbl'Hash'lock'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.lock"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2468,16,2468,91)"), left{}(), format{}("%c#lock%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'log{}(SortString{}) : SortK{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), returnsUnit{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("#log"), hook{}("IO.logString"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2562,16,2562,102)"), left{}(), format{}("%c#log%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'logToFile{}(SortString{}, SortString{}) : SortK{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), returnsUnit{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("110101"), impure{}(), klabel{}("#logToFile"), hook{}("IO.log"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2553,16,2553,116)"), left{}(), format{}("%c#logToFile%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'mkstemp'LParUndsRParUnds'K-IO'Unds'IOFile'Unds'String{}(SortString{}) : SortIOFile{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("#mkstemp"), hook{}("IO.mkstemp"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2530,21,2530,84)"), left{}(), format{}("%c#mkstemp%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'Hash'open'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'String{}(SortString{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2407,20,2407,59)"), left{}(), format{}("%c#open%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'Unds'IOInt'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.open"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2408,18,2408,97)"), left{}(), format{}("%c#open%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  symbol Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(SortInt{}) : SortStream{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("#ostream"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2589,21,2589,34)"), left{}(), format{}("%c#ostream%r %c(%r %1 %c)%r"), injective{}()]
+  symbol Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortStream{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("#parseInput"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2588,21,2588,48)"), left{}(), format{}("%c#parseInput%r %c(%r %1 %c,%r %2 %c)%r"), injective{}()]
+  hooked-symbol Lbl'Hash'putc'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.putc"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2447,16,2447,93)"), left{}(), format{}("%c#putc%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'read'LParUndsCommUndsRParUnds'K-IO'Unds'IOString'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortIOString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.read"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2438,23,2438,99)"), left{}(), format{}("%c#read%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'remove'LParUndsRParUnds'K-IO'Unds'K'Unds'String{}(SortString{}) : SortK{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("#remove"), hook{}("IO.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2541,16,2541,80)"), left{}(), format{}("%c#remove%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'seek'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.seek"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2423,16,2423,88)"), left{}(), format{}("%c#seek%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'seekEnd'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.seekEnd"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2424,16,2424,96)"), left{}(), format{}("%c#seekEnd%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'shutdownWrite'LParUndsRParUnds'K-IO'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.shutdownWrite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2483,16,2483,91)"), left{}(), format{}("%c#shutdownWrite%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}() : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2503,19,2503,46)"), left{}(), format{}("%c#stderr%r"), function{}()]
+  symbol Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}() : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2501,18,2501,46)"), left{}(), format{}("%c#stdin%r"), function{}()]
+  symbol Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}() : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2502,19,2502,46)"), left{}(), format{}("%c#stdout%r"), function{}()]
+  hooked-symbol Lbl'Hash'system'LParUndsRParUnds'K-IO'Unds'KItem'Unds'String{}(SortString{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("#system"), hook{}("IO.system"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2519,20,2519,74)"), left{}(), format{}("%c#system%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'Hash'systemResult{}(SortInt{}, SortString{}, SortString{}) : SortKItem{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("#systemResult"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2520,20,2520,143)"), left{}(), format{}("%c#systemResult%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), injective{}()]
+  hooked-symbol Lbl'Hash'tell'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.tell"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2422,20,2422,77)"), left{}(), format{}("%c#tell%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'Hash'tempFile{}(SortString{}, SortInt{}) : SortIOFile{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("110101"), klabel{}("#tempFile"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2532,21,2532,93)"), left{}(), format{}("%c#tempFile%r %c(%r %1 %c,%r %2 %c)%r"), injective{}()]
+  hooked-symbol Lbl'Hash'time'LParRParUnds'K-IO'Unds'Int{}() : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("111"), impure{}(), hook{}("IO.time"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2492,18,2492,67)"), left{}(), format{}("%c#time%r %c(%r %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'trace{}(SortKItem{}) : SortK{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), returnsUnit{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("#trace"), hook{}("IO.traceTerm"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2573,16,2573,103)"), left{}(), format{}("%c#trace%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'traceK{}(SortK{}) : SortK{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), returnsUnit{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("#traceK"), hook{}("IO.traceTerm"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2574,16,2574,103)"), left{}(), format{}("%c#traceK%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'Hash'unknownIOError{}(SortInt{}) : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("#unknownIOError"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2316,54,2316,90)"), left{}(), format{}("%c#unknownIOError%r %c(%r %1 %c)%r"), injective{}()]
+  hooked-symbol Lbl'Hash'unlock'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.unlock"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2469,16,2469,95)"), left{}(), format{}("%c#unlock%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'write'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'String{}(SortInt{}, SortString{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.write"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2448,16,2448,93)"), left{}(), format{}("%c#write%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [latex{}("\\dotCt{List}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), smtlib{}("smt_seq_nil"), terminals{}("1"), klabel{}(".List"), hook{}("LIST.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(747,19,747,142)"), left{}(), format{}("%c.List%r"), function{}()]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [latex{}("\\dotCt{Map}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}(".Map"), hook{}("MAP.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(248,18,248,124)"), left{}(), format{}("%c.Map%r"), function{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [latex{}("\\dotCt{Set}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}(".Set"), hook{}("SET.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(539,18,539,118)"), left{}(), format{}("%c.Set%r"), function{}()]
+  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [functional{}(), constructor{}(), cellName{}("generatedCounter"), priorities{}(), right{}(), terminals{}("101"), left{}(), format{}("%c<generatedCounter>%r%i%n%1%d%n%c</generatedCounter>%r"), injective{}(), cell{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortKCell{}, SortGeneratedCounterCell{}) : SortGeneratedTopCell{} [functional{}(), constructor{}(), cellName{}("generatedTop"), priorities{}(), right{}(), terminals{}("1001"), left{}(), format{}("%1"), injective{}(), cell{}(), topcell{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortKCellOpt{}, SortGeneratedCounterCellOpt{}) : SortGeneratedTopCellFragment{} [functional{}(), constructor{}(), cellFragment{}("GeneratedTopCell"), priorities{}(), right{}(), terminals{}("1001"), left{}(), format{}("%c<generatedTop>-fragment%r %1 %2 %c</generatedTop>-fragment%r"), injective{}()]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)"), cellName{}("k"), maincell{}(), priorities{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), right{}(), terminals{}("101"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(13,5,13,22)"), left{}(), format{}("%c<k>%r%i%n%1%d%n%c</k>%r"), injective{}(), cell{}(), topcell{}()]
+  hooked-symbol LblBase2String'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("Base2String"), hook{}("STRING.base2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1633,21,1633,99)"), left{}(), format{}("%cBase2String%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  symbol LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(SortBool{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Bool2String"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1583,21,1583,56)"), left{}(), format{}("%cBool2String%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblFloat2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float{}(SortFloat{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Float2String"), hook{}("STRING.float2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1610,21,1610,101)"), left{}(), format{}("%cFloat2String%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblFloat2String'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float'Unds'String{}(SortFloat{}, SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("FloatFormat"), hook{}("STRING.floatFormat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1611,21,1611,122)"), left{}(), format{}("%cFloat2String%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol LblId2String'LParUndsRParUnds'ID-COMMON'Unds'String'Unds'Id{}(SortId{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Id2String"), hook{}("STRING.token2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2142,21,2142,85)"), left{}(), format{}("%cId2String%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(SortInt{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Int2String"), hook{}("STRING.int2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1632,21,1632,99)"), left{}(), format{}("%cInt2String%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("0101"), klabel{}("List:get"), hook{}("LIST.get"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(766,20,766,99)"), left{}(), format{}("%1 %c[%r %2 %c]%r"), function{}()]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("List:range"), hook{}("LIST.range"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(813,19,813,120)"), left{}(), format{}("%crange%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), smtlib{}("smt_seq_elem"), terminals{}("1101"), klabel{}("ListItem"), hook{}("LIST.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(755,19,755,132)"), left{}(), format{}("%cListItem%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("0101"), klabel{}("Map:lookup"), hook{}("MAP.lookup"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(271,20,271,113)"), left{}(), format{}("%1 %c[%r %2 %c]%r"), function{}()]
+  hooked-symbol LblMap'Coln'update{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), prefer{}(), right{}(), terminals{}("010101"), klabel{}("Map:update"), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,18,290,140)"), left{}(), format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}()]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [latex{}("{#1}-_{\\it Set}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("010"), klabel{}("Set:difference"), hook{}("SET.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(579,18,579,142)"), left{}(), format{}("%1 %c-Set%r %2"), function{}()]
+  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("010"), klabel{}("Set:in"), hook{}("SET.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(587,19,587,102)"), left{}(), format{}("%1 %cin%r %2"), function{}()]
+  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("SetItem"), hook{}("SET.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(547,18,547,119)"), left{}(), format{}("%cSetItem%r %c(%r %1 %c)%r"), injective{}(), function{}()]
+  hooked-symbol LblString2Base'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'Int{}(SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("String2Base"), hook{}("STRING.string2base"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1634,21,1634,99)"), left{}(), format{}("%cString2Base%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  symbol LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(SortString{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("String2Bool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1589,19,1589,49)"), left{}(), format{}("%cString2Bool%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblString2Float'LParUndsRParUnds'STRING-COMMON'Unds'Float'Unds'String{}(SortString{}) : SortFloat{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("String2Float"), hook{}("STRING.string2float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1612,21,1612,94)"), left{}(), format{}("%cString2Float%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(SortString{}) : SortId{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("String2Id"), hook{}("STRING.string2token"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2143,17,2143,80)"), left{}(), format{}("%cString2Id%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblString2Int'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("String2Int"), hook{}("STRING.string2int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1631,21,1631,92)"), left{}(), format{}("%cString2Int%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbl'UndsPerc'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("mod"), right{}(), terminals{}("010"), klabel{}("_%Int_"), hook{}("INT.tmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1047,18,1047,171)"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), format{}("%1 %c%%Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsAnd-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), comm{}(), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("andInt"), terminals{}("010"), klabel{}("_&Int_"), hook{}("INT.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1058,18,1058,184)"), left{}(Lbl'UndsAnd-'Int'Unds'{}()), format{}("%1 %c&Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsStar'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), comm{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("*"), right{}(), terminals{}("010"), klabel{}("_*Int_"), hook{}("INT.mul"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1043,18,1043,183)"), left{}(Lbl'Unds'modInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), format{}("%1 %c*Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), comm{}(), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), smt-hook{}("+"), right{}(), terminals{}("010"), klabel{}("_+Int_"), hook{}("INT.add"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1052,18,1052,180)"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), format{}("%1 %c+Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortString{} [latex{}("{#1}+_{\\scriptstyle\\it String}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1522,21,1522,135)"), left{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}()), format{}("%1 %c+String%r %2"), function{}()]
+  symbol Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(SortExp{}, SortExp{}) : SortExp{} [functional{}(), constructor{}(), strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)"), priorities{}(), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,18,5,44)"), left{}(Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}()), format{}("%1 %c+%r %2"), injective{}()]
+  hooked-symbol Lbl'Unds'-Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), smt-hook{}("-"), right{}(), terminals{}("010"), klabel{}("_-Int_"), hook{}("INT.sub"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1053,18,1053,174)"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), format{}("%1 %c-Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [latex{}("{#1}-_{\\it Map}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,18,311,116)"), left{}(), format{}("%1 %c-Map%r %2"), function{}()]
+  hooked-symbol Lbl'UndsSlsh'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("div"), right{}(), terminals{}("010"), klabel{}("_/Int_"), hook{}("INT.tdiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1046,18,1046,173)"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), format{}("%1 %c/Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shlInt"), terminals{}("010"), klabel{}("_<<Int_"), hook{}("INT.shl"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1056,18,1056,173)"), left{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}()), format{}("%1 %c<<Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}("<="), right{}(), terminals{}("010"), klabel{}("_<=Int_"), hook{}("INT.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1114,19,1114,172)"), left{}(Lbl'Unds-LT-Eqls'Int'Unds'{}()), format{}("%1 %c<=Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,19,383,87)"), left{}(), format{}("%1 %c<=Map%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(596,19,596,81)"), left{}(), format{}("%1 %c<=Set%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1667,19,1667,78)"), left{}(), format{}("%1 %c<=String%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}("<"), right{}(), terminals{}("010"), klabel{}("_<Int_"), hook{}("INT.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1115,19,1115,167)"), left{}(Lbl'Unds-LT-'Int'Unds'{}()), format{}("%1 %c<Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1666,19,1666,78)"), left{}(), format{}("%1 %c<String%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}("distinct"), right{}(), terminals{}("010"), klabel{}("_=/=Bool_"), hook{}("BOOL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(919,19,919,128)"), left{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}()), format{}("%1 %c=/=Bool%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}("distinct"), right{}(), terminals{}("010"), klabel{}("_=/=Int_"), hook{}("INT.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1119,19,1119,184)"), left{}(Lbl'UndsEqlsSlshEqls'Int'Unds'{}()), format{}("%1 %c=/=Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [latex{}("{#1}\\mathrel{\\neq_K}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), notEqualEqualK{}(), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), smt-hook{}("distinct"), right{}(), terminals{}("010"), klabel{}("_=/=K_"), hook{}("KEQUAL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2182,19,2182,166)"), left{}(Lbl'UndsEqlsEqls'K'Unds'{}(),Lbl'UndsEqlsSlshEqls'K'Unds'{}()), format{}("%1 %c=/=K%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1663,19,1663,90)"), left{}(Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}()), format{}("%1 %c=/=String%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}("="), right{}(), terminals{}("010"), klabel{}("_==Bool_"), hook{}("BOOL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(918,19,918,120)"), left{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), format{}("%1 %c==Bool%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}("="), right{}(), terminals{}("010"), klabel{}("_==Int_"), hook{}("INT.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1118,19,1118,173)"), left{}(Lbl'UndsEqlsEqls'Int'Unds'{}()), format{}("%1 %c==Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [latex{}("{#1}\\mathrel{=_K}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), smt-hook{}("="), right{}(), terminals{}("010"), equalEqualK{}(), klabel{}("_==K_"), hook{}("KEQUAL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2181,19,2181,152)"), left{}(Lbl'UndsEqlsSlshEqls'K'Unds'{}(),Lbl'UndsEqlsEqls'K'Unds'{}()), format{}("%1 %c==K%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1662,19,1662,84)"), left{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}()), format{}("%1 %c==String%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}(">="), right{}(), terminals{}("010"), klabel{}("_>=Int_"), hook{}("INT.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1116,19,1116,172)"), left{}(Lbl'Unds-GT-Eqls'Int'Unds'{}()), format{}("%1 %c>=Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1669,19,1669,78)"), left{}(), format{}("%1 %c>=String%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shrInt"), terminals{}("010"), klabel{}("_>>Int_"), hook{}("INT.shr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1055,18,1055,173)"), left{}(Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}()), format{}("%1 %c>>Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}(">"), right{}(), terminals{}("010"), klabel{}("_>Int_"), hook{}("INT.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1117,19,1117,167)"), left{}(Lbl'Unds-GT-'Int'Unds'{}()), format{}("%1 %c>Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1668,19,1668,78)"), left{}(), format{}("%1 %c>String%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [unit{}(Lbl'Stop'List{}()), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), element{}(LblListItem{}()), symbol'Kywd'{}(), priorities{}(), right{}(), assoc{}(), smtlib{}("smt_seq_concat"), terminals{}("00"), klabel{}("_List_"), hook{}("LIST.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(739,19,739,188)"), left{}(Lbl'Unds'List'Unds'{}()), format{}("%1%n%2"), function{}()]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [unit{}(Lbl'Stop'Map{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), symbol'Kywd'{}(), comm{}(), priorities{}(), right{}(), assoc{}(), terminals{}("00"), index{}("0"), klabel{}("_Map_"), hook{}("MAP.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,18,240,173)"), left{}(Lbl'Unds'Map'Unds'{}()), format{}("%1%n%2"), function{}()]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [unit{}(Lbl'Stop'Set{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), element{}(LblSetItem{}()), symbol'Kywd'{}(), idem{}(), comm{}(), priorities{}(), right{}(), assoc{}(), terminals{}("00"), klabel{}("_Set_"), hook{}("SET.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(531,18,531,165)"), left{}(Lbl'Unds'Set'Unds'{}()), format{}("%1%n%2"), function{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010101"), klabel{}("List:set"), hook{}("LIST.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(775,19,775,108)"), left{}(), format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("010111"), klabel{}("_[_<-undef]"), hook{}("MAP.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(299,18,299,117)"), left{}(), format{}("%1 %c[%r %2 %c<-%r %cundef%r %c]%r"), function{}()]
+  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'Unds'KItem'Unds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010110"), klabel{}("Map:lookupOrDefault"), hook{}("MAP.lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(281,20,281,134)"), left{}(), format{}("%1 %c[%r %2 %c]%r %corDefault%r %3"), function{}()]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUnds'{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("(mod (^ #1 #2) #3)"), right{}(), terminals{}("0100"), klabel{}("_^%Int__"), hook{}("INT.powmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1041,18,1041,139)"), left{}(Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'UndsXor-'Int'Unds'{}()), format{}("%1 %c^%%Int%r %2 %3"), function{}()]
+  hooked-symbol Lbl'UndsXor-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("^"), right{}(), terminals{}("010"), klabel{}("_^Int_"), hook{}("INT.pow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1040,18,1040,178)"), left{}(Lbl'UndsXor-'Int'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}()), format{}("%1 %c^Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("and"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_andBool_"), hook{}("BOOL.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(911,19,911,185)"), left{}(Lbl'Unds'andBool'Unds'{}()), format{}("%1 %candBool%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'andThenBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("and"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_andThenBool_"), hook{}("BOOL.andThen"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(912,19,912,147)"), left{}(Lbl'Unds'andThenBool'Unds'{}()), format{}("%1 %candThenBool%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'divInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("div"), right{}(), terminals{}("010"), klabel{}("_divInt_"), hook{}("INT.ediv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1049,18,1049,122)"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}()), format{}("%1 %cdivInt%r %2"), function{}()]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1128,19,1128,53)"), left{}(), format{}("%1 %cdividesInt%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'impliesBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("=>"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_impliesBool_"), hook{}("BOOL.implies"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(916,19,916,146)"), left{}(Lbl'Unds'impliesBool'Unds'{}()), format{}("%1 %cimpliesBool%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(SortKItem{}, SortList{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), klabel{}("_inList_"), hook{}("LIST.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(822,19,822,97)"), left{}(), format{}("%1 %cin%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("01101"), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(357,19,357,89)"), left{}(), format{}("%1 %cin_keys%r %c(%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Unds'modInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("mod"), right{}(), terminals{}("010"), klabel{}("_modInt_"), hook{}("INT.emod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1050,18,1050,122)"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), format{}("%1 %cmodInt%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'orBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("or"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_orBool_"), hook{}("BOOL.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(914,19,914,180)"), left{}(Lbl'Unds'orBool'Unds'{}()), format{}("%1 %corBool%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'orElseBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("or"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_orElseBool_"), hook{}("BOOL.orElse"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(915,19,915,144)"), left{}(Lbl'Unds'orElseBool'Unds'{}()), format{}("%1 %corElseBool%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'xorBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("xor"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_xorBool_"), hook{}("BOOL.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(913,19,913,139)"), left{}(Lbl'Unds'xorBool'Unds'{}()), format{}("%1 %cxorBool%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'xorInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), comm{}(), priorities{}(Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("xorInt"), terminals{}("010"), klabel{}("_xorInt_"), hook{}("INT.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1060,18,1060,190)"), left{}(Lbl'Unds'xorInt'Unds'{}()), format{}("%1 %cxorInt%r %2"), function{}()]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [latex{}("{#1}\\mapsto{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'Stop'Map{}(),Lbl'Unds'Map'Unds'{}()), right{}(Lbl'UndsPipe'-'-GT-Unds'{}()), terminals{}("010"), klabel{}("_|->_"), hook{}("MAP.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(257,18,257,151)"), left{}(Lbl'UndsPipe'-'-GT-Unds'{}()), format{}("%1 %c|->%r %2"), injective{}(), function{}()]
+  hooked-symbol Lbl'UndsPipe'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), comm{}(), priorities{}(), right{}(), smtlib{}("orInt"), terminals{}("010"), klabel{}("_|Int_"), hook{}("INT.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1062,18,1062,181)"), left{}(Lbl'UndsPipe'Int'Unds'{}()), format{}("%1 %c|Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), comm{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("SET.union"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(558,18,558,92)"), left{}(Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}()), format{}("%1 %c|Set%r %2"), function{}()]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), smt-hook{}("(ite (< #1 0) (- 0 #1) #1)"), right{}(), terminals{}("1101"), klabel{}("absInt"), hook{}("INT.abs"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1079,18,1079,119)"), left{}(), format{}("%cabsInt%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("bitRangeInt"), hook{}("INT.bitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1104,18,1104,103)"), left{}(), format{}("%cbitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblcategoryChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'String{}(SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("categoryChar"), hook{}("STRING.category"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1679,21,1679,81)"), left{}(), format{}("%ccategoryChar%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'Unds'KItem'Unds'Map{}(SortMap{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Map:choice"), hook{}("MAP.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,20,393,101)"), left{}(), format{}("%cchoice%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lblchoice'LParUndsRParUnds'SET'Unds'KItem'Unds'Set{}(SortSet{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Set:choice"), hook{}("SET.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(614,20,614,95)"), left{}(), format{}("%cchoice%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblchrChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("chrChar"), hook{}("STRING.chr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1539,21,1539,70)"), left{}(), format{}("%cchrChar%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("110101"), hook{}("STRING.countAllOccurrences"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1652,18,1652,146)"), left{}(), format{}("%ccountAllOccurrences%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol LbldirectionalityChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'String{}(SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("directionalityChar"), hook{}("STRING.directionality"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1680,21,1680,87)"), left{}(), format{}("%cdirectionalityChar%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101010101"), klabel{}("fillList"), hook{}("LIST.fill"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(803,19,803,100)"), left{}(), format{}("%cfillList%r %c(%r %1 %c,%r %2 %c,%r %3 %c,%r %4 %c)%r"), function{}()]
+  hooked-symbol LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("findChar"), hook{}("STRING.findChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1576,18,1576,116)"), left{}(), format{}("%cfindChar%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("findString"), hook{}("STRING.find"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1565,18,1565,111)"), left{}(), format{}("%cfindString%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  symbol LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(SortInt{}) : SortId{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), freshGenerator{}(), klabel{}("freshId"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2144,17,2144,75)"), left{}(), format{}("%cfreshId%r %c(%r %1 %c)%r"), private{}(), function{}()]
+  symbol LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), freshGenerator{}(), klabel{}("freshInt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1253,18,1253,77)"), left{}(), format{}("%cfreshInt%r %c(%r %1 %c)%r"), private{}(), function{}()]
+  symbol LblgetGeneratedCounterCell{}(SortGeneratedTopCell{}) : SortGeneratedCounterCell{} [priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cgetGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [noThread{}(), priorities{}(), right{}(), terminals{}("1"), left{}(), initializer{}(), format{}("%cinitGeneratedCounterCell%r"), function{}()]
+  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [noThread{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), initializer{}(), format{}("%cinitGeneratedTopCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [noThread{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), initializer{}(), format{}("%cinitKCell%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), comm{}(), priorities{}(), right{}(), terminals{}("110101"), klabel{}("intersectSet"), hook{}("SET.intersection"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(569,18,569,90)"), left{}(), format{}("%cintersectSet%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  symbol LblisBool{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Bool"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisBool%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisExp{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Exp"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisExp%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisFloat{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Float"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisFloat%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("GeneratedCounterCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("GeneratedCounterCellOpt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("GeneratedTopCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedTopCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("GeneratedTopCellFragment"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisIOError{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("IOError"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIOError%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisIOFile{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("IOFile"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIOFile%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisIOInt{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("IOInt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIOInt%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisIOString{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("IOString"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIOString%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisId{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Id"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisId%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisInt{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Int"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisInt%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisK{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("K"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisK%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("KCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("KCellOpt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKCellOpt%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("KConfigVar"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKConfigVar%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("KItem"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKItem%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisKResult{}(SortExp{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("isKResult"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(17,19,17,52)"), left{}(), format{}("%cisKResult%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisList{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("List"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisList%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisMap{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Map"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisMap%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Set"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisSet%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisStream{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Stream"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisStream%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisString{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("String"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisString%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(SortMap{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("keys"), hook{}("MAP.keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,18,341,82)"), left{}(), format{}("%ckeys%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,19,349,80)"), left{}(), format{}("%ckeys_list%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("lengthString"), hook{}("STRING.length"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1530,18,1530,80)"), left{}(), format{}("%clengthString%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("log2Int"), hook{}("INT.log2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1090,18,1090,75)"), left{}(), format{}("%clog2Int%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'Unds'List'Unds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("makeList"), hook{}("LIST.make"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(784,19,784,82)"), left{}(), format{}("%cmakeList%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), smt-hook{}("(ite (< #1 #2) #2 #1)"), right{}(), terminals{}("110101"), hook{}("INT.max"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1071,18,1071,114)"), left{}(), format{}("%cmaxInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), smt-hook{}("(ite (< #1 #2) #1 #2)"), right{}(), terminals{}("110101"), hook{}("INT.min"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1070,18,1070,114)"), left{}(), format{}("%cminInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol LblnewUUID'Unds'STRING-COMMON'Unds'String{}() : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1"), impure{}(), hook{}("STRING.uuid"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1682,21,1682,68)"), left{}(), format{}("%cnewUUID%r"), function{}()]
+  symbol LblnoGeneratedCounterCell{}() : SortGeneratedCounterCellOpt{} [functional{}(), constructor{}(), cellOptAbsent{}("GeneratedCounterCell"), priorities{}(), right{}(), terminals{}("1"), left{}(), format{}("%cnoGeneratedCounterCell%r"), injective{}()]
+  symbol LblnoKCell{}() : SortKCellOpt{} [functional{}(), constructor{}(), cellOptAbsent{}("KCell"), priorities{}(), right{}(), terminals{}("1"), left{}(), format{}("%cnoKCell%r"), injective{}()]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), smt-hook{}("not"), boolOperation{}(), right{}(), terminals{}("10"), klabel{}("notBool_"), hook{}("BOOL.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(910,19,910,172)"), left{}(), format{}("%cnotBool%r %1"), function{}()]
+  hooked-symbol LblordChar'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("ordChar"), hook{}("STRING.ord"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1540,18,1540,70)"), left{}(), format{}("%cordChar%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'ColnHash'tempFile'Coln'fd{}(SortIOFile{}) : SortInt{} [priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cfd%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'ColnHash'tempFile'Coln'path{}(SortIOFile{}) : SortString{} [priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cpath%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'ColnHash'unknownIOError'Coln'errno{}(SortIOError{}) : SortInt{} [priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cerrno%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'Bool{}(SortK{}) : SortBool{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Bool%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'Exp{}(SortK{}) : SortExp{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Exp%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'Float{}(SortK{}) : SortFloat{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Float%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'GeneratedCounterCell{}(SortK{}) : SortGeneratedCounterCell{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:GeneratedCounterCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'GeneratedCounterCellOpt{}(SortK{}) : SortGeneratedCounterCellOpt{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:GeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'GeneratedTopCell{}(SortK{}) : SortGeneratedTopCell{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:GeneratedTopCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'GeneratedTopCellFragment{}(SortK{}) : SortGeneratedTopCellFragment{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:GeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'IOError{}(SortK{}) : SortIOError{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:IOError%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'IOFile{}(SortK{}) : SortIOFile{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:IOFile%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'IOInt{}(SortK{}) : SortIOInt{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:IOInt%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'IOString{}(SortK{}) : SortIOString{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:IOString%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'Id{}(SortK{}) : SortId{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Id%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'Int{}(SortK{}) : SortInt{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Int%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'K{}(SortK{}) : SortK{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:K%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'KCell{}(SortK{}) : SortKCell{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:KCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'KCellOpt{}(SortK{}) : SortKCellOpt{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:KCellOpt%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'KItem{}(SortK{}) : SortKItem{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:KItem%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'List{}(SortK{}) : SortList{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:List%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'Map{}(SortK{}) : SortMap{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Map%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'Set{}(SortK{}) : SortSet{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Set%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'Stream{}(SortK{}) : SortStream{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Stream%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblproject'Coln'String{}(SortK{}) : SortString{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:String%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("randInt"), hook{}("INT.rand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1138,18,1138,65)"), left{}(), format{}("%crandInt%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("110101"), klabel{}("removeAll"), hook{}("MAP.removeAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,18,333,87)"), left{}(), format{}("%cremoveAll%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortString{}, SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101010101"), hook{}("STRING.replace"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1650,21,1650,146)"), left{}(), format{}("%creplace%r %c(%r %1 %c,%r %2 %c,%r %3 %c,%r %4 %c)%r"), function{}()]
+  hooked-symbol LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("11010101"), hook{}("STRING.replaceAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1649,21,1649,149)"), left{}(), format{}("%creplaceAll%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("11010101"), hook{}("STRING.replaceFirst"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1651,21,1651,151)"), left{}(), format{}("%creplaceFirst%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("rfindChar"), hook{}("STRING.rfindChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1577,18,1577,117)"), left{}(), format{}("%crfindChar%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("rfindString"), hook{}("STRING.rfind"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1566,18,1566,112)"), left{}(), format{}("%crfindString%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("signExtendBitRangeInt"), hook{}("INT.signExtendBitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1105,18,1105,113)"), left{}(), format{}("%csignExtendBitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'LIST'Unds'Int'Unds'List{}(SortList{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), smtlib{}("smt_seq_len"), terminals{}("1101"), klabel{}("sizeList"), hook{}("LIST.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(830,18,830,117)"), left{}(), format{}("%csize%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'MAP'Unds'Int'Unds'Map{}(SortMap{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("sizeMap"), hook{}("MAP.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(373,18,373,99)"), left{}(), format{}("%csize%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(SortSet{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("size"), hook{}("SET.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(604,18,604,76)"), left{}(), format{}("%csize%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT-COMMON'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("srandInt"), hook{}("INT.srand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1139,16,1139,65)"), left{}(), format{}("%csrandInt%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(SortString{}, SortInt{}, SortInt{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("substrString"), hook{}("STRING.substr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1555,21,1555,117)"), left{}(), format{}("%csubstrString%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("updateList"), hook{}("LIST.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(794,19,794,97)"), left{}(), format{}("%cupdateList%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("110101"), klabel{}("updateMap"), hook{}("MAP.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(324,18,324,87)"), left{}(), format{}("%cupdateMap%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("values"), hook{}("MAP.values"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(365,19,365,77)"), left{}(), format{}("%cvalues%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbl'Tild'Int'Unds'{}(SortInt{}) : SortInt{} [latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsXor-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smtlib{}("notInt"), terminals{}("10"), klabel{}("~Int_"), hook{}("INT.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1038,18,1038,168)"), left{}(), format{}("%c~Int%r %1"), function{}()]
+
+// generated axioms
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOString{}, SortKItem{}} (From:SortIOString{}))) [subsort{SortIOString{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortString{}, SortKItem{}} (From:SortString{}))) [subsort{SortString{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCellOpt{}, SortKItem{}} (From:SortKCellOpt{}))) [subsort{SortKCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (From:SortGeneratedCounterCellOpt{}))) [subsort{SortGeneratedCounterCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCell{}, SortKItem{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOInt{}, \equals{SortIOInt{}, R} (Val:SortIOInt{}, inj{SortIOError{}, SortIOInt{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOInt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, inj{SortKCell{}, SortKCellOpt{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSet{}, SortKItem{}} (From:SortSet{}))) [subsort{SortSet{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOError{}, SortKItem{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOInt{}, \equals{SortIOInt{}, R} (Val:SortIOInt{}, inj{SortInt{}, SortIOInt{}} (From:SortInt{}))) [subsort{SortInt{}, SortIOInt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStream{}, SortKItem{}} (From:SortStream{}))) [subsort{SortStream{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOFile{}, SortKItem{}} (From:SortIOFile{}))) [subsort{SortIOFile{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCell{}, SortKItem{}} (From:SortGeneratedTopCell{}))) [subsort{SortGeneratedTopCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOInt{}, SortKItem{}} (From:SortIOInt{}))) [subsort{SortIOInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortList{}, SortKItem{}} (From:SortList{}))) [subsort{SortList{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKConfigVar{}, SortKItem{}} (From:SortKConfigVar{}))) [subsort{SortKConfigVar{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOString{}, \equals{SortIOString{}, R} (Val:SortIOString{}, inj{SortString{}, SortIOString{}} (From:SortString{}))) [subsort{SortString{}, SortIOString{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortId{}, SortKItem{}} (From:SortId{}))) [subsort{SortId{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortFloat{}, SortKItem{}} (From:SortFloat{}))) [subsort{SortFloat{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBool{}, SortKItem{}} (From:SortBool{}))) [subsort{SortBool{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (From:SortGeneratedTopCellFragment{}))) [subsort{SortGeneratedTopCellFragment{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortExp{}, SortKItem{}} (From:SortExp{}))) [subsort{SortExp{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMap{}, SortKItem{}} (From:SortMap{}))) [subsort{SortMap{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortInt{}, SortExp{}} (From:SortInt{}))) [subsort{SortInt{}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOString{}, \equals{SortIOString{}, R} (Val:SortIOString{}, inj{SortIOError{}, SortIOString{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOString{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOFile{}, \equals{SortIOFile{}, R} (Val:SortIOFile{}, inj{SortIOError{}, SortIOFile{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOFile{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'E2BIG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EACCES{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EADDRINUSE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EADDRNOTAVAIL{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EAFNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EAGAIN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EALREADY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EBADF{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EBUSY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECHILD{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNABORTED{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNREFUSED{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNRESET{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDEADLK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDESTADDRREQ{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDOM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EEXIST{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EFAULT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EFBIG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EHOSTDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EHOSTUNREACH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINPROGRESS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINTR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINVAL{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EIO{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EISCONN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EISDIR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ELOOP{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMFILE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMLINK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMSGSIZE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENAMETOOLONG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETRESET{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETUNREACH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENFILE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOBUFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENODEV{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOENT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOEXEC{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOLCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOMEM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOPROTOOPT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOSPC{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOSYS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTCONN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTDIR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTEMPTY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTSOCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTTY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENXIO{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOF{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOPNOTSUPP{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOVERFLOW{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPERM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPFNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPIPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPROTONOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPROTOTYPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ERANGE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EROFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESHUTDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESOCKTNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESPIPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESRCH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ETIMEDOUT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ETOOMANYREFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EWOULDBLOCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EXDEV{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(Y0:SortK{})), Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(X0:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(X0:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R, SortSort} \exists{R} (Val:SortSort, \equals{SortSort, R} (Val:SortSort, Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(K0:SortBool{}, K1:SortSort, K2:SortSort))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{})), Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'log{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'logToFile{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{})), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(X0:SortString{}, X1:SortString{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{})), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(\and{SortString{}} (X0:SortString{}, Y0:SortString{}), \and{SortString{}} (X1:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'remove'LParUndsRParUnds'K-IO'Unds'K'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'systemResult{}(K0:SortInt{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'systemResult{}(X0:SortInt{}, X1:SortString{}, X2:SortString{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{})), Lbl'Hash'systemResult{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}), \and{SortString{}} (X1:SortString{}, Y1:SortString{}), \and{SortString{}} (X2:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortIOFile{}, \equals{SortIOFile{}, R} (Val:SortIOFile{}, Lbl'Hash'tempFile{}(K0:SortString{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortIOFile{}} (\and{SortIOFile{}} (Lbl'Hash'tempFile{}(X0:SortString{}, X1:SortInt{}), Lbl'Hash'tempFile{}(Y0:SortString{}, Y1:SortInt{})), Lbl'Hash'tempFile{}(\and{SortString{}} (X0:SortString{}, Y0:SortString{}), \and{SortInt{}} (X1:SortInt{}, Y1:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'trace{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'traceK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'unknownIOError{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'unknownIOError{}(Y0:SortInt{})), Lbl'Hash'unknownIOError{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Stop'Set{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, Lbl'-LT-'generatedCounter'-GT-'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedCounterCell{}} (\and{SortGeneratedCounterCell{}} (Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{}), Lbl'-LT-'generatedCounter'-GT-'{}(Y0:SortInt{})), Lbl'-LT-'generatedCounter'-GT-'{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCell{}, \equals{SortGeneratedTopCell{}, R} (Val:SortGeneratedTopCell{}, Lbl'-LT-'generatedTop'-GT-'{}(K0:SortKCell{}, K1:SortGeneratedCounterCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCell{}} (\and{SortGeneratedTopCell{}} (Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}), Lbl'-LT-'generatedTop'-GT-'{}(Y0:SortKCell{}, Y1:SortGeneratedCounterCell{})), Lbl'-LT-'generatedTop'-GT-'{}(\and{SortKCell{}} (X0:SortKCell{}, Y0:SortKCell{}), \and{SortGeneratedCounterCell{}} (X1:SortGeneratedCounterCell{}, Y1:SortGeneratedCounterCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCellFragment{}, \equals{SortGeneratedTopCellFragment{}, R} (Val:SortGeneratedTopCellFragment{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(K0:SortKCellOpt{}, K1:SortGeneratedCounterCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCellFragment{}} (\and{SortGeneratedTopCellFragment{}} (Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}), Lbl'-LT-'generatedTop'-GT-'-fragment{}(Y0:SortKCellOpt{}, Y1:SortGeneratedCounterCellOpt{})), Lbl'-LT-'generatedTop'-GT-'-fragment{}(\and{SortKCellOpt{}} (X0:SortKCellOpt{}, Y0:SortKCellOpt{}), \and{SortGeneratedCounterCellOpt{}} (X1:SortGeneratedCounterCellOpt{}, Y1:SortGeneratedCounterCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, Lbl'-LT-'k'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblFloat2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float{}(K0:SortFloat{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblId2String'LParUndsRParUnds'ID-COMMON'Unds'String'Unds'Id{}(K0:SortId{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblMap'Coln'update{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortKItem{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \equals{SortInt{}, R} (Lbl'UndsAnd-'Int'Unds'{}(K1:SortInt{},K2:SortInt{}),Lbl'UndsAnd-'Int'Unds'{}(K2:SortInt{},K1:SortInt{})) [comm{}()] // commutativity
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \equals{SortInt{}, R} (Lbl'UndsStar'Int'Unds'{}(K1:SortInt{},K2:SortInt{}),Lbl'UndsStar'Int'Unds'{}(K2:SortInt{},K1:SortInt{})) [comm{}()] // commutativity
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \equals{SortInt{}, R} (Lbl'UndsPlus'Int'Unds'{}(K1:SortInt{},K2:SortInt{}),Lbl'UndsPlus'Int'Unds'{}(K2:SortInt{},K1:SortInt{})) [comm{}()] // commutativity
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(K0:SortExp{}, K1:SortExp{}))) [functional{}()] // functional
+  axiom{}\implies{SortExp{}} (\and{SortExp{}} (Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(X0:SortExp{}, X1:SortExp{}), Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(Y0:SortExp{}, Y1:SortExp{})), Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(\and{SortExp{}} (X0:SortExp{}, Y0:SortExp{}), \and{SortExp{}} (X1:SortExp{}, Y1:SortExp{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:SortList{},K2:SortList{}),K3:SortList{}),Lbl'Unds'List'Unds'{}(K1:SortList{},Lbl'Unds'List'Unds'{}(K2:SortList{},K3:SortList{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(K:SortList{},Lbl'Stop'List{}()),K:SortList{}) [unit{}()] // right unit
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Stop'List{}(),K:SortList{}),K:SortList{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),Lbl'Unds'Map'Unds'{}(K2:SortMap{},K1:SortMap{})) [comm{}()] // commutativity
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K:SortMap{},Lbl'Stop'Map{}()),K:SortMap{}) [unit{}()] // right unit
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),K:SortMap{}),K:SortMap{}) [unit{}()] // left unit
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),Lbl'Unds'Set'Unds'{}(K2:SortSet{},K1:SortSet{})) [comm{}()] // commutativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},Lbl'Stop'Set{}()),K:SortSet{}) [unit{}()] // right unit
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Stop'Set{}(),K:SortSet{}),K:SortSet{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'Unds'KItem'Unds'Map'Unds'KItem'Unds'KItem{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(K0:SortKItem{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \equals{SortInt{}, R} (Lbl'Unds'xorInt'Unds'{}(K1:SortInt{},K2:SortInt{}),Lbl'Unds'xorInt'Unds'{}(K2:SortInt{},K1:SortInt{})) [comm{}()] // commutativity
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortKItem{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \equals{SortInt{}, R} (Lbl'UndsPipe'Int'Unds'{}(K1:SortInt{},K2:SortInt{}),Lbl'UndsPipe'Int'Unds'{}(K2:SortInt{},K1:SortInt{})) [comm{}()] // commutativity
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \equals{SortSet{}, R} (Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K1:SortSet{},K2:SortSet{}),Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K2:SortSet{},K1:SortSet{})) [comm{}()] // commutativity
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \equals{SortSet{}, R} (LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K1:SortSet{},K2:SortSet{}),LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K2:SortSet{},K1:SortSet{})) [comm{}()] // commutativity
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBool{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisExp{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisFloat{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCellFragment{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOError{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOFile{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOString{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisId{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKConfigVar{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisList{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMap{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisSet{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisStream{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisString{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, LblnoGeneratedCounterCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, LblnoKCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'LIST'Unds'Int'Unds'List{}(K0:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'MAP'Unds'Int'Unds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(K0:SortString{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'Unds'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortInt{}, \exists{SortKItem{}} (X1:SortString{}, \exists{SortKItem{}} (X2:SortString{}, Lbl'Hash'systemResult{}(X0:SortInt{}, X1:SortString{}, X2:SortString{})))), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortString{}, inj{SortString{}, SortKItem{}} (Val:SortString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKConfigVar{}, inj{SortKConfigVar{}, SortKItem{}} (Val:SortKConfigVar{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOInt{}, inj{SortIOInt{}, SortKItem{}} (Val:SortIOInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortExp{}, inj{SortExp{}, SortKItem{}} (Val:SortExp{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (Val:SortGeneratedCounterCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (Val:SortGeneratedCounterCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortId{}, inj{SortId{}, SortKItem{}} (Val:SortId{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStream{}, inj{SortStream{}, SortKItem{}} (Val:SortStream{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOFile{}, inj{SortIOFile{}, SortKItem{}} (Val:SortIOFile{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortFloat{}, inj{SortFloat{}, SortKItem{}} (Val:SortFloat{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOString{}, inj{SortIOString{}, SortKItem{}} (Val:SortIOString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOError{}, inj{SortIOError{}, SortKItem{}} (Val:SortIOError{})), \bottom{SortKItem{}}())))))))))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \bottom{SortList{}}() [constructor{}()] // no junk
+  axiom{} \or{SortString{}} (\top{SortString{}}(), \bottom{SortString{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortIOInt{}} (\exists{SortIOInt{}} (Val:SortInt{}, inj{SortInt{}, SortIOInt{}} (Val:SortInt{})), \or{SortIOInt{}} (\exists{SortIOInt{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOInt{}} (Val:SortIOError{})), \bottom{SortIOInt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortExp{}} (\exists{SortExp{}} (X0:SortExp{}, \exists{SortExp{}} (X1:SortExp{}, Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(X0:SortExp{}, X1:SortExp{}))), \or{SortExp{}} (\exists{SortExp{}} (Val:SortInt{}, inj{SortInt{}, SortExp{}} (Val:SortInt{})), \bottom{SortExp{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCellOpt{}} (LblnoGeneratedCounterCell{}(), \or{SortGeneratedCounterCellOpt{}} (\exists{SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{})), \bottom{SortGeneratedCounterCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortId{}} (\top{SortId{}}(), \bottom{SortId{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortStream{}} (\exists{SortStream{}} (X0:SortK{}, Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{})), \or{SortStream{}} (\exists{SortStream{}} (X0:SortInt{}, Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{})), \or{SortStream{}} (\exists{SortStream{}} (X0:SortInt{}, Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{})), \or{SortStream{}} (\exists{SortStream{}} (X0:SortString{}, \exists{SortStream{}} (X1:SortString{}, Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(X0:SortString{}, X1:SortString{}))), \bottom{SortStream{}}())))) [constructor{}()] // no junk
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
+  axiom{} \bottom{SortK{}}() [constructor{}()] // no junk
+  axiom{} \or{SortIOFile{}} (\exists{SortIOFile{}} (X0:SortString{}, \exists{SortIOFile{}} (X1:SortInt{}, Lbl'Hash'tempFile{}(X0:SortString{}, X1:SortInt{}))), \or{SortIOFile{}} (\exists{SortIOFile{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOFile{}} (Val:SortIOError{})), \bottom{SortIOFile{}}())) [constructor{}()] // no junk
+  axiom{} \bottom{SortMap{}}() [constructor{}()] // no junk
+  axiom{} \or{SortKCellOpt{}} (LblnoKCell{}(), \or{SortKCellOpt{}} (\exists{SortKCellOpt{}} (Val:SortKCell{}, inj{SortKCell{}, SortKCellOpt{}} (Val:SortKCell{})), \bottom{SortKCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortFloat{}} (\top{SortFloat{}}(), \bottom{SortFloat{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortGeneratedTopCell{}} (\exists{SortGeneratedTopCell{}} (X0:SortKCell{}, \exists{SortGeneratedTopCell{}} (X1:SortGeneratedCounterCell{}, Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}))), \bottom{SortGeneratedTopCell{}}()) [constructor{}()] // no junk
+  axiom{} \bottom{SortSet{}}() [constructor{}()] // no junk
+  axiom{} \or{SortIOString{}} (\exists{SortIOString{}} (Val:SortString{}, inj{SortString{}, SortIOString{}} (Val:SortString{})), \or{SortIOString{}} (\exists{SortIOString{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOString{}} (Val:SortIOError{})), \bottom{SortIOString{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCellFragment{}} (\exists{SortGeneratedTopCellFragment{}} (X0:SortKCellOpt{}, \exists{SortGeneratedTopCellFragment{}} (X1:SortGeneratedCounterCellOpt{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}))), \bottom{SortGeneratedTopCellFragment{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOError{}} (Lbl'Hash'E2BIG{}(), \or{SortIOError{}} (Lbl'Hash'EACCES{}(), \or{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), \or{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), \or{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), \or{SortIOError{}} (Lbl'Hash'EAGAIN{}(), \or{SortIOError{}} (Lbl'Hash'EALREADY{}(), \or{SortIOError{}} (Lbl'Hash'EBADF{}(), \or{SortIOError{}} (Lbl'Hash'EBUSY{}(), \or{SortIOError{}} (Lbl'Hash'ECHILD{}(), \or{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), \or{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), \or{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), \or{SortIOError{}} (Lbl'Hash'EDEADLK{}(), \or{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), \or{SortIOError{}} (Lbl'Hash'EDOM{}(), \or{SortIOError{}} (Lbl'Hash'EEXIST{}(), \or{SortIOError{}} (Lbl'Hash'EFAULT{}(), \or{SortIOError{}} (Lbl'Hash'EFBIG{}(), \or{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), \or{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), \or{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), \or{SortIOError{}} (Lbl'Hash'EINTR{}(), \or{SortIOError{}} (Lbl'Hash'EINVAL{}(), \or{SortIOError{}} (Lbl'Hash'EIO{}(), \or{SortIOError{}} (Lbl'Hash'EISCONN{}(), \or{SortIOError{}} (Lbl'Hash'EISDIR{}(), \or{SortIOError{}} (Lbl'Hash'ELOOP{}(), \or{SortIOError{}} (Lbl'Hash'EMFILE{}(), \or{SortIOError{}} (Lbl'Hash'EMLINK{}(), \or{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), \or{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), \or{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), \or{SortIOError{}} (Lbl'Hash'ENETRESET{}(), \or{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), \or{SortIOError{}} (Lbl'Hash'ENFILE{}(), \or{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), \or{SortIOError{}} (Lbl'Hash'ENODEV{}(), \or{SortIOError{}} (Lbl'Hash'ENOENT{}(), \or{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), \or{SortIOError{}} (Lbl'Hash'ENOLCK{}(), \or{SortIOError{}} (Lbl'Hash'ENOMEM{}(), \or{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), \or{SortIOError{}} (Lbl'Hash'ENOSPC{}(), \or{SortIOError{}} (Lbl'Hash'ENOSYS{}(), \or{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), \or{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), \or{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), \or{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), \or{SortIOError{}} (Lbl'Hash'ENOTTY{}(), \or{SortIOError{}} (Lbl'Hash'ENXIO{}(), \or{SortIOError{}} (Lbl'Hash'EOF{}(), \or{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), \or{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), \or{SortIOError{}} (Lbl'Hash'EPERM{}(), \or{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), \or{SortIOError{}} (Lbl'Hash'EPIPE{}(), \or{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), \or{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), \or{SortIOError{}} (Lbl'Hash'ERANGE{}(), \or{SortIOError{}} (Lbl'Hash'EROFS{}(), \or{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), \or{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), \or{SortIOError{}} (Lbl'Hash'ESPIPE{}(), \or{SortIOError{}} (Lbl'Hash'ESRCH{}(), \or{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), \or{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), \or{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), \or{SortIOError{}} (Lbl'Hash'EXDEV{}(), \or{SortIOError{}} (\exists{SortIOError{}} (X0:SortInt{}, Lbl'Hash'unknownIOError{}(X0:SortInt{})), \bottom{SortIOError{}}())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) [constructor{}()] // no junk
+
+// rules
+// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,B1,_Gen0)=>B1 requires C ensures #token("true","Bool") [UNIQUE_ID(2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2), org.kframework.attributes.Location(Location(2222,8,2222,59)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        VarC:SortBool{},
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarB1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB1:SortK{},
+        \top{SortK{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2222,8,2222,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2")]
+
+// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,_Gen0,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [UNIQUE_ID(651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa), org.kframework.attributes.Location(Location(2223,8,2223,67)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        LblnotBool'Unds'{}(VarC:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            VarB2:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB2:SortK{},
+        \top{SortK{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2223,8,2223,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa")]
+
+// rule `#open(_)_K-IO_IOInt_String`(S)=>`#open(_,_)_K-IO_IOInt_String_String`(S,#token("\"r+\"","String")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7ad2779cd54b9009119458217cae5138026cc4ff244e54c28e64db21100f63d9), org.kframework.attributes.Location(Location(2410,8,2410,48)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS:SortString{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOInt{},R} (
+      Lbl'Hash'open'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'String{}(X0:SortString{}),
+     \and{SortIOInt{}} (
+       Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'Unds'IOInt'Unds'String'Unds'String{}(VarS:SortString{},\dv{SortString{}}("r+")),
+        \top{SortIOInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2410,8,2410,48)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("7ad2779cd54b9009119458217cae5138026cc4ff244e54c28e64db21100f63d9")]
+
+// rule `#stderr_K-IO_Int`(.KList)=>#token("2","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(75e0a8082acda4cf1e29caa6aaafb7f9a421e16421a41f2006943d6fab17a162), org.kframework.attributes.Location(Location(2507,8,2507,20)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortInt{},R} (
+      Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}(),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("2"),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2507,8,2507,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("75e0a8082acda4cf1e29caa6aaafb7f9a421e16421a41f2006943d6fab17a162")]
+
+// rule `#stdin_K-IO_Int`(.KList)=>#token("0","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c7ffdc9908c28a954521816d680f4e5ec44a679c7231a8dd09d4700f50b6d8c3), org.kframework.attributes.Location(Location(2505,8,2505,19)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortInt{},R} (
+      Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}(),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("0"),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2505,8,2505,19)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("c7ffdc9908c28a954521816d680f4e5ec44a679c7231a8dd09d4700f50b6d8c3")]
+
+// rule `#stdout_K-IO_Int`(.KList)=>#token("1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4ad4f379ff9db687ff9dfd1b15052edbcd3342a2ed262ecdd38c769e177a592c), org.kframework.attributes.Location(Location(2506,8,2506,20)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortInt{},R} (
+      Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}(),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("1"),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2506,8,2506,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("4ad4f379ff9db687ff9dfd1b15052edbcd3342a2ed262ecdd38c769e177a592c")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp0_`(inj{Exp,KItem}(K1))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp`(HOLE,K1))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(HOLE)) ensures #token("true","Bool") [UNIQUE_ID(2e9a018f211f6dae4efd71c7d497612c1854e3b4e716a3b64c42742396bb68f2), cool, cool-like, left, org.kframework.attributes.Location(Location(5,18,5,44)), org.kframework.attributes.Source(Source(/home/bruce/code/scratch/arithmetic.k)), strict]
+  alias rule6LHS{}(SortExp{},SortExp{},SortGeneratedCounterCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule6LHS{}(VarHOLE:SortExp{},VarK1:SortExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortK{}) :=
+    \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(VarHOLE:SortExp{})),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK1:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
+
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+    rule6LHS{}(VarHOLE:SortExp{},VarK1:SortExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortK{}),
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(VarHOLE:SortExp{},VarK1:SortExp{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [cool{}(), strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)"), left{}(), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,18,5,44)"), UNIQUE'Unds'ID{}("2e9a018f211f6dae4efd71c7d497612c1854e3b4e716a3b64c42742396bb68f2")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp1_`(inj{Exp,KItem}(K0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp`(K0,HOLE))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(HOLE)) ensures #token("true","Bool") [UNIQUE_ID(75cae68863d7594ffd59a6b351cc294e0c0d27ecd155cd8fdb143ec822ffa373), cool, cool-like, left, org.kframework.attributes.Location(Location(5,18,5,44)), org.kframework.attributes.Source(Source(/home/bruce/code/scratch/arithmetic.k)), strict]
+  alias rule7LHS{}(SortExp{},SortExp{},SortGeneratedCounterCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule7LHS{}(VarHOLE:SortExp{},VarK0:SortExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortK{}) :=
+    \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(VarHOLE:SortExp{})),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
+
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+    rule7LHS{}(VarHOLE:SortExp{},VarK0:SortExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortK{}),
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(VarK0:SortExp{},VarHOLE:SortExp{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [cool{}(), strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)"), left{}(), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,18,5,44)"), UNIQUE'Unds'ID{}("75cae68863d7594ffd59a6b351cc294e0c0d27ecd155cd8fdb143ec822ffa373")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp`(HOLE,K1))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp0_`(inj{Exp,KItem}(K1))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(256b43ee5c1a63b36aeb7bc842c5115fd3ce501bdd7df89f992079de96ed0ebe), heat, left, org.kframework.attributes.Location(Location(5,18,5,44)), org.kframework.attributes.Source(Source(/home/bruce/code/scratch/arithmetic.k)), strict]
+  alias rule8LHS{}(SortExp{},SortExp{},SortGeneratedCounterCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule8LHS{}(VarHOLE:SortExp{},VarK1:SortExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortK{}) :=
+    \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(VarHOLE:SortExp{}))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(VarHOLE:SortExp{},VarK1:SortExp{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
+
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+    rule8LHS{}(VarHOLE:SortExp{},VarK1:SortExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortK{}),
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK1:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)"), left{}(), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,18,5,44)"), UNIQUE'Unds'ID{}("256b43ee5c1a63b36aeb7bc842c5115fd3ce501bdd7df89f992079de96ed0ebe")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp`(K0,HOLE))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp1_`(inj{Exp,KItem}(K0))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(10f0aa53782d755b1057e9704033267f95c078122801f72f89a34a5687af749b), heat, left, org.kframework.attributes.Location(Location(5,18,5,44)), org.kframework.attributes.Source(Source(/home/bruce/code/scratch/arithmetic.k)), strict]
+  alias rule9LHS{}(SortExp{},SortExp{},SortGeneratedCounterCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule9LHS{}(VarHOLE:SortExp{},VarK0:SortExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortK{}) :=
+    \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(VarHOLE:SortExp{}))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(VarK0:SortExp{},VarHOLE:SortExp{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
+
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+    rule9LHS{}(VarHOLE:SortExp{},VarK0:SortExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortK{}),
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)"), left{}(), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,18,5,44)"), UNIQUE'Unds'ID{}("10f0aa53782d755b1057e9704033267f95c078122801f72f89a34a5687af749b")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp`(inj{Int,Exp}(A),inj{Int,Exp}(B)))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Int,KItem}(`_+Int_`(A,B))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(97f36d703686de5cd6bd8dd08a2f05cb258966bec3f144f0018ac28c1f5ab617), org.kframework.attributes.Location(Location(15,8,15,25)), org.kframework.attributes.Source(Source(/home/bruce/code/scratch/arithmetic.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  alias rule10LHS{}(SortInt{},SortInt{},SortGeneratedCounterCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule10LHS{}(VarA:SortInt{},VarB:SortInt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortK{}) :=
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(inj{SortInt{}, SortExp{}}(VarA:SortInt{}),inj{SortInt{}, SortExp{}}(VarB:SortInt{}))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
+
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+    rule10LHS{}(VarA:SortInt{},VarB:SortInt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortK{}),
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'UndsPlus'Int'Unds'{}(VarA:SortInt{},VarB:SortInt{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(15,8,15,25)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("97f36d703686de5cd6bd8dd08a2f05cb258966bec3f144f0018ac28c1f5ab617")]
+
+// rule `Bool2String(_)_STRING-COMMON_String_Bool`(#token("false","Bool"))=>#token("\"false\"","String") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cca4780e4e7660055f781b9643f3125234a0f4f08ba76cacf8e5a18fe7fc999f), org.kframework.attributes.Location(Location(1585,8,1585,37)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(X0:SortBool{}),
+     \and{SortString{}} (
+       \dv{SortString{}}("false"),
+        \top{SortString{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1585,8,1585,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("cca4780e4e7660055f781b9643f3125234a0f4f08ba76cacf8e5a18fe7fc999f")]
+
+// rule `Bool2String(_)_STRING-COMMON_String_Bool`(#token("true","Bool"))=>#token("\"true\"","String") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(365df37345a5a44ac061f8741369c7bd74a49f0f6e7b716be0374806dd1add3d), org.kframework.attributes.Location(Location(1584,8,1584,36)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(X0:SortBool{}),
+     \and{SortString{}} (
+       \dv{SortString{}}("true"),
+        \top{SortString{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1584,8,1584,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("365df37345a5a44ac061f8741369c7bd74a49f0f6e7b716be0374806dd1add3d")]
+
+// rule `String2Bool(_)_STRING-COMMON_Bool_String`(#token("\"false\"","String"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b73b5c8e0ae45020f2b9b8170d366691fee01a63763b79653a2075703ec4e835), org.kframework.attributes.Location(Location(1591,8,1591,37)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            \dv{SortString{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(X0:SortString{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1591,8,1591,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("b73b5c8e0ae45020f2b9b8170d366691fee01a63763b79653a2075703ec4e835")]
+
+// rule `String2Bool(_)_STRING-COMMON_Bool_String`(#token("\"true\"","String"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(27a5d1d7872d61f82556a4e44bda13846dde7dc2d9c54304d7858de9a8b9d6b8), org.kframework.attributes.Location(Location(1590,8,1590,36)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            \dv{SortString{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(X0:SortString{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1590,8,1590,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("27a5d1d7872d61f82556a4e44bda13846dde7dc2d9c54304d7858de9a8b9d6b8")]
+
+// rule `_<=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_<String__STRING-COMMON_Bool_String_String`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9e50fb4dcba1212ee863c170298cb8b555f39fb3b4bcb649f3d1d8e321accc80), org.kframework.attributes.Location(Location(1684,8,1684,63)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{})),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1684,8,1684,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("9e50fb4dcba1212ee863c170298cb8b555f39fb3b4bcb649f3d1d8e321accc80")]
+
+// rule `_=/=Bool_`(B1,B2)=>`notBool_`(`_==Bool_`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f), org.kframework.attributes.Location(Location(960,8,960,57)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB1:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB2:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(VarB1:SortBool{},VarB2:SortBool{})),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(960,8,960,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f")]
+
+// rule `_=/=Int_`(I1,I2)=>`notBool_`(`_==Int_`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3), org.kframework.attributes.Location(Location(1250,8,1250,53)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Int'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1250,8,1250,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3")]
+
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c), org.kframework.attributes.Location(Location(2220,8,2220,45)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarK2:SortK{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2220,8,2220,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c")]
+
+// rule `_=/=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_==String__STRING-COMMON_Bool_String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f390a9b650f3de0e3a93773a46e65aae3decdeb2a10906058f204f031681c9b7), org.kframework.attributes.Location(Location(1664,8,1664,65)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{})),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1664,8,1664,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("f390a9b650f3de0e3a93773a46e65aae3decdeb2a10906058f204f031681c9b7")]
+
+// rule `_>=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_<String__STRING-COMMON_Bool_String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b376ffb0925555ed27696d73fc8fe43306e2005e4cf6ad819e860958992f9f17), org.kframework.attributes.Location(Location(1686,8,1686,63)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{})),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1686,8,1686,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("b376ffb0925555ed27696d73fc8fe43306e2005e4cf6ad819e860958992f9f17")]
+
+// rule `_>String__STRING-COMMON_Bool_String_String`(S1,S2)=>`_<String__STRING-COMMON_Bool_String_String`(S2,S1) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8e5353c0a58491f8613ad7a35d0833206c342df0c91773e42485e52f4dad0cd0), org.kframework.attributes.Location(Location(1685,8,1685,52)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{}),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1685,8,1685,52)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("8e5353c0a58491f8613ad7a35d0833206c342df0c91773e42485e52f4dad0cd0")]
+
+// rule `_andBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497), org.kframework.attributes.Location(Location(933,8,933,37)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(933,8,933,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497")]
+
+// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98), org.kframework.attributes.Location(Location(932,8,932,37)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(932,8,932,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98")]
+
+// rule `_andBool_`(_Gen0,#token("false","Bool") #as _Gen1)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca), org.kframework.attributes.Location(Location(934,8,934,37)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(934,8,934,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca")]
+
+// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f), org.kframework.attributes.Location(Location(931,8,931,37)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(931,8,931,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f")]
+
+// rule `_andThenBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d), org.kframework.attributes.Location(Location(938,8,938,36)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(938,8,938,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d")]
+
+// rule `_andThenBool_`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c), org.kframework.attributes.Location(Location(937,8,937,37)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarK:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(937,8,937,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c")]
+
+// rule `_andThenBool_`(_Gen0,#token("false","Bool") #as _Gen1)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2), org.kframework.attributes.Location(Location(939,8,939,36)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(939,8,939,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2")]
+
+// rule `_andThenBool_`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689), org.kframework.attributes.Location(Location(936,8,936,37)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(936,8,936,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689")]
+
+// rule `_divInt_`(I1,I2)=>`_/Int_`(`_-Int_`(I1,`_modInt_`(I1,I2)),I2) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4), org.kframework.attributes.Location(Location(1239,8,1240,23)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      Lbl'Unds'divInt'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsSlsh'Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{}),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1239,8,1240,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4")]
+
+// rule `_dividesInt__INT-COMMON_Bool_Int_Int`(I1,I2)=>`_==Int_`(`_%Int_`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5), org.kframework.attributes.Location(Location(1251,8,1251,58)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       Lbl'UndsEqlsEqls'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0")),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1251,8,1251,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5")]
+
+// rule `_impliesBool_`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96), org.kframework.attributes.Location(Location(958,8,958,45)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(VarB:SortBool{}),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(958,8,958,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96")]
+
+// rule `_impliesBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712), org.kframework.attributes.Location(Location(957,8,957,39)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(957,8,957,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712")]
+
+// rule `_impliesBool_`(#token("false","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e), org.kframework.attributes.Location(Location(956,8,956,40)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(956,8,956,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e")]
+
+// rule `_impliesBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d), org.kframework.attributes.Location(Location(955,8,955,36)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(955,8,955,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d")]
+
+// rule `_modInt_`(I1,I2)=>`_%Int_`(`_+Int_`(`_%Int_`(I1,`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6), concrete, org.kframework.attributes.Location(Location(1242,5,1245,23)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \equals{SortInt{},R} (
+      Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsPerc'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1242,5,1245,23)"), simplification{}(), UNIQUE'Unds'ID{}("adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6")]
+
+// rule `_orBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26), org.kframework.attributes.Location(Location(948,8,948,32)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(948,8,948,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26")]
+
+// rule `_orBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3), org.kframework.attributes.Location(Location(946,8,946,34)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(946,8,946,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3")]
+
+// rule `_orBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b), org.kframework.attributes.Location(Location(947,8,947,32)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(947,8,947,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b")]
+
+// rule `_orBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2), org.kframework.attributes.Location(Location(945,8,945,34)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(945,8,945,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2")]
+
+// rule `_orElseBool_`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480), org.kframework.attributes.Location(Location(953,8,953,37)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarK:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(953,8,953,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480")]
+
+// rule `_orElseBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14), org.kframework.attributes.Location(Location(951,8,951,33)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(951,8,951,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14")]
+
+// rule `_orElseBool_`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf), org.kframework.attributes.Location(Location(952,8,952,37)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(952,8,952,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf")]
+
+// rule `_orElseBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6), org.kframework.attributes.Location(Location(950,8,950,33)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(950,8,950,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6")]
+
+// rule `_xorBool_`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f), org.kframework.attributes.Location(Location(943,8,943,38)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(943,8,943,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f")]
+
+// rule `_xorBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75), org.kframework.attributes.Location(Location(942,8,942,38)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(942,8,942,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75")]
+
+// rule `_xorBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf), org.kframework.attributes.Location(Location(941,8,941,38)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(941,8,941,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf")]
+
+// rule `_|Set__SET_Set_Set_Set`(S1,S2)=>`_Set_`(S1,`Set:difference`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62), concrete, org.kframework.attributes.Location(Location(559,8,559,45)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortSet{}, R} (
+            X0:SortSet{},
+            VarS1:SortSet{}
+          ),\and{R} (
+          \in{SortSet{}, R} (
+            X1:SortSet{},
+            VarS2:SortSet{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortSet{},R} (
+      Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(X0:SortSet{},X1:SortSet{}),
+     \and{SortSet{}} (
+       Lbl'Unds'Set'Unds'{}(VarS1:SortSet{},LblSet'Coln'difference{}(VarS2:SortSet{},VarS1:SortSet{})),
+        \top{SortSet{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(559,8,559,45)"), UNIQUE'Unds'ID{}("e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62")]
+
+// rule `bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_modInt_`(`_>>Int_`(I,IDX),`_<<Int_`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119), org.kframework.attributes.Location(Location(1235,8,1235,85)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'modInt'Unds'{}(Lbl'Unds-GT--GT-'Int'Unds'{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1235,8,1235,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119")]
+
+// rule `countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToCount)=>`_+Int_`(#token("1","Int"),`countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToCount)),`lengthString(_)_STRING-COMMON_Int_String`(Source)),ToCount)) requires `_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(628cff029a6d79e4c99999c0309f91ab8cb12f0ba549bb3faa850f96304c970e), org.kframework.attributes.Location(Location(1695,8,1696,60)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToCount:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortInt{}} (
+       Lbl'UndsPlus'Int'Unds'{}(\dv{SortInt{}}("1"),LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToCount:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})),VarToCount:SortString{})),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1695,8,1696,60)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("628cff029a6d79e4c99999c0309f91ab8cb12f0ba549bb3faa850f96304c970e")]
+
+// rule `countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToCount)=>#token("0","Int") requires `_<Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(1c726cd81629c2e5f411539a7f9b4d297e8600e5d71a5d235d287e3001f3ec84), org.kframework.attributes.Location(Location(1693,8,1694,59)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToCount:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("0"),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1693,8,1694,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("1c726cd81629c2e5f411539a7f9b4d297e8600e5d71a5d235d287e3001f3ec84")]
+
+// rule `findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,S2,I)=>`#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{Int}(`_==Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),#token("-1","Int")),`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I),`#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{Int}(`_==Int_`(`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I),#token("-1","Int")),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`minInt(_,_)_INT-COMMON_Int_Int_Int`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I)))) requires `_=/=String__STRING-COMMON_Bool_String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [UNIQUE_ID(9a3b7d1924363894c859ceb6bcec34fb944f01a5e0c90679d41b8430990b7295), org.kframework.attributes.Location(Location(1688,8,1688,431)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortInt{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}),Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortInt{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{})))),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1688,8,1688,431)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("9a3b7d1924363894c859ceb6bcec34fb944f01a5e0c90679d41b8430990b7295")]
+
+// rule `findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(_Gen0,#token("\"\"","String"),_Gen1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5a6cf981f0ec2494854cd3e517b0cf645a1c9762c92a14849adfca9a6a553117), org.kframework.attributes.Location(Location(1689,8,1689,32)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            \dv{SortString{}}("")
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            Var'Unds'Gen1:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("-1"),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1689,8,1689,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("5a6cf981f0ec2494854cd3e517b0cf645a1c9762c92a14849adfca9a6a553117")]
+
+// rule `freshId(_)_ID-COMMON_Id_Int`(I)=>`String2Id(_)_ID-COMMON_Id_String`(`_+String__STRING-COMMON_String_String_String`(#token("\"_\"","String"),`Int2String(_)_STRING-COMMON_String_Int`(I))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3965c8e65257ebae926d601fa8ac672d34e4c211d73ba594c571c6bc5960f3de), org.kframework.attributes.Location(Location(2146,8,2146,62)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortId{},R} (
+      LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(X0:SortInt{}),
+     \and{SortId{}} (
+       LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(\dv{SortString{}}("_"),LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(VarI:SortInt{}))),
+        \top{SortId{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2146,8,2146,62)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("3965c8e65257ebae926d601fa8ac672d34e4c211d73ba594c571c6bc5960f3de")]
+
+// rule `freshInt(_)_INT_Int_Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b), org.kframework.attributes.Location(Location(1254,8,1254,28)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       VarI:SortInt{},
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1254,8,1254,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b")]
+
+// rule getGeneratedCounterCell(`<generatedTop>`(_DotVar0,Cell))=>Cell requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortGeneratedTopCell{}, R} (
+            X0:SortGeneratedTopCell{},
+            Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'DotVar0:SortKCell{},VarCell:SortGeneratedCounterCell{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblgetGeneratedCounterCell{}(X0:SortGeneratedTopCell{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarCell:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  []
+
+// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblinitGeneratedCounterCell{}(),
+     \and{SortGeneratedCounterCell{}} (
+       Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")),
+        \top{SortGeneratedCounterCell{}}())))
+  [initializer{}()]
+
+// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initKCell(Init),initGeneratedCounterCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      LblinitGeneratedTopCell{}(X0:SortMap{}),
+     \and{SortGeneratedTopCell{}} (
+       Lbl'-LT-'generatedTop'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}()),
+        \top{SortGeneratedTopCell{}}())))
+  [initializer{}()]
+
+// rule initKCell(Init)=>`<k>`(inj{Exp,KItem}(`project:Exp`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar")))))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0708978885290eac9fd6647e7f8578594241e8c0c6ee97e8d8735f9732f4ab5c), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCell{},R} (
+      LblinitKCell{}(X0:SortMap{}),
+     \and{SortKCell{}} (
+       Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lblproject'Coln'Exp{}(kseq{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))),dotk{}()))),dotk{}())),
+        \top{SortKCell{}}())))
+  [initializer{}(), UNIQUE'Unds'ID{}("0708978885290eac9fd6647e7f8578594241e8c0c6ee97e8d8735f9732f4ab5c")]
+
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortBool{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'Gen0:SortBool{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarBool:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isExp(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortExp{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisExp{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isExp(inj{Exp,KItem}(Exp))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp{}, SortKItem{}}(VarExp:SortExp{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisExp{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isFloat(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortFloat{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortFloat{}, SortKItem{}}(Var'Unds'Gen1:SortFloat{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisFloat{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isFloat(inj{Float,KItem}(Float))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortFloat{}, SortKItem{}}(VarFloat:SortFloat{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisFloat{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedCounterCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedCounterCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarGeneratedCounterCell:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isGeneratedCounterCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedCounterCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedCounterCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isGeneratedCounterCellOpt(inj{GeneratedCounterCellOpt,KItem}(GeneratedCounterCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarGeneratedCounterCellOpt:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedTopCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedTopCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarGeneratedTopCell:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortGeneratedTopCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(Var'Unds'Gen0:SortGeneratedTopCellFragment{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isIOError(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortIOError{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOError{}, SortKItem{}}(Var'Unds'Gen1:SortIOError{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOError{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isIOError(inj{IOError,KItem}(IOError))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOError{}, SortKItem{}}(VarIOError:SortIOError{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOError{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isIOFile(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortIOFile{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOFile{}, SortKItem{}}(Var'Unds'Gen0:SortIOFile{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOFile{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isIOFile(inj{IOFile,KItem}(IOFile))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOFile{}, SortKItem{}}(VarIOFile:SortIOFile{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOFile{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isIOInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortIOInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOInt{}, SortKItem{}}(Var'Unds'Gen0:SortIOInt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isIOInt(inj{IOInt,KItem}(IOInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOInt{}, SortKItem{}}(VarIOInt:SortIOInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isIOString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortIOString{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOString{}, SortKItem{}}(Var'Unds'Gen1:SortIOString{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isIOString(inj{IOString,KItem}(IOString))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOString{}, SortKItem{}}(VarIOString:SortIOString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isId(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortId{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortId{}, SortKItem{}}(Var'Unds'Gen0:SortId{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisId{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isId(inj{Id,KItem}(Id))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortId{}, SortKItem{}}(VarId:SortId{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisId{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortInt{}, SortKItem{}}(Var'Unds'Gen1:SortInt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarInt:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisK{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKCell{}, SortKItem{}}(Var'Unds'Gen1:SortKCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCell{}, SortKItem{}}(VarKCell:SortKCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortKCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'Gen0:SortKCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarKCellOpt:SortKCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKConfigVar{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKConfigVar{}, SortKItem{}}(Var'Unds'Gen1:SortKConfigVar{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKConfigVar{}, SortKItem{}}(VarKConfigVar:SortKConfigVar{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKItem{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(Var'Unds'Gen1:SortKItem{},dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarKItem:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isKResult(_Gen0)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9ae4e8e91afda90defaf5ee862f05b8cd40f2b1cc709deee40824eb6bde35cb1), org.kframework.attributes.Location(Location(19,8,19,34)), org.kframework.attributes.Source(Source(/home/bruce/code/scratch/arithmetic.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen2:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortExp{}, R} (
+                  X0:SortExp{},
+                  inj{SortInt{}, SortExp{}}(Var'Unds'Gen2:SortInt{})
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortExp{}, R} (
+            X0:SortExp{},
+            Var'Unds'Gen0:SortExp{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKResult{}(X0:SortExp{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(19,8,19,34)"), owise{}(), UNIQUE'Unds'ID{}("9ae4e8e91afda90defaf5ee862f05b8cd40f2b1cc709deee40824eb6bde35cb1")]
+
+// rule isKResult(inj{Int,Exp}(_Gen0))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d097a138e6f656d012ee2464d1fa156f4c66b21007de1d529f773c64143d965d), org.kframework.attributes.Location(Location(18,8,18,33)), org.kframework.attributes.Source(Source(/home/bruce/code/scratch/arithmetic.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortExp{}, R} (
+            X0:SortExp{},
+            inj{SortInt{}, SortExp{}}(Var'Unds'Gen0:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKResult{}(X0:SortExp{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(18,8,18,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("d097a138e6f656d012ee2464d1fa156f4c66b21007de1d529f773c64143d965d")]
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortList{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortList{}, SortKItem{}}(Var'Unds'Gen0:SortList{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarList:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortMap{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMap{}, SortKItem{}}(Var'Unds'Gen1:SortMap{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarMap:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortSet{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'Gen0:SortSet{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarSet:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isStream(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortStream{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortStream{}, SortKItem{}}(Var'Unds'Gen1:SortStream{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisStream{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isStream(inj{Stream,KItem}(Stream))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortStream{}, SortKItem{}}(VarStream:SortStream{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisStream{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule isString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortString{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortString{}, SortKItem{}}(Var'Unds'Gen1:SortString{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [owise{}()]
+
+// rule isString(inj{String,KItem}(String))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortString{}, SortKItem{}}(VarString:SortString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  []
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I1 requires `_<=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6), org.kframework.attributes.Location(Location(1247,8,1247,57)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI1:SortInt{},
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1247,8,1247,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I2 requires `_>=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3), org.kframework.attributes.Location(Location(1248,8,1248,57)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI2:SortInt{},
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1248,8,1248,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3")]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415), org.kframework.attributes.Location(Location(929,8,929,29)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(929,8,929,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415")]
+
+// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c), org.kframework.attributes.Location(Location(928,8,928,29)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(928,8,928,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c")]
+
+// rule `project:#tempFile:fd`(#tempFile(K0,K1))=>K1 requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortIOFile{}, R} (
+            X0:SortIOFile{},
+            Lbl'Hash'tempFile{}(VarK0:SortString{},VarK1:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'ColnHash'tempFile'Coln'fd{}(X0:SortIOFile{}),
+     \and{SortInt{}} (
+       VarK1:SortInt{},
+        \top{SortInt{}}())))
+  []
+
+// rule `project:#tempFile:path`(#tempFile(K0,K1))=>K0 requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortIOFile{}, R} (
+            X0:SortIOFile{},
+            Lbl'Hash'tempFile{}(VarK0:SortString{},VarK1:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      Lblproject'ColnHash'tempFile'Coln'path{}(X0:SortIOFile{}),
+     \and{SortString{}} (
+       VarK0:SortString{},
+        \top{SortString{}}())))
+  []
+
+// rule `project:#unknownIOError:errno`(#unknownIOError(K0))=>K0 requires #token("true","Bool") ensures #token("true","Bool") 
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortIOError{}, R} (
+            X0:SortIOError{},
+            Lbl'Hash'unknownIOError{}(VarK0:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'ColnHash'unknownIOError'Coln'errno{}(X0:SortIOError{}),
+     \and{SortInt{}} (
+       VarK0:SortInt{},
+        \top{SortInt{}}())))
+  []
+
+// rule `project:Bool`(inj{Bool,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarK:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblproject'Coln'Bool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [projection{}()]
+
+// rule `project:Exp`(inj{Exp,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp{}, SortKItem{}}(VarK:SortExp{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortExp{},R} (
+      Lblproject'Coln'Exp{}(X0:SortK{}),
+     \and{SortExp{}} (
+       VarK:SortExp{},
+        \top{SortExp{}}())))
+  [projection{}()]
+
+// rule `project:Float`(inj{Float,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortFloat{}, SortKItem{}}(VarK:SortFloat{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortFloat{},R} (
+      Lblproject'Coln'Float{}(X0:SortK{}),
+     \and{SortFloat{}} (
+       VarK:SortFloat{},
+        \top{SortFloat{}}())))
+  [projection{}()]
+
+// rule `project:GeneratedCounterCell`(inj{GeneratedCounterCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarK:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      Lblproject'Coln'GeneratedCounterCell{}(X0:SortK{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarK:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [projection{}()]
+
+// rule `project:GeneratedCounterCellOpt`(inj{GeneratedCounterCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarK:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCellOpt{},R} (
+      Lblproject'Coln'GeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortGeneratedCounterCellOpt{}} (
+       VarK:SortGeneratedCounterCellOpt{},
+        \top{SortGeneratedCounterCellOpt{}}())))
+  [projection{}()]
+
+// rule `project:GeneratedTopCell`(inj{GeneratedTopCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarK:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      Lblproject'Coln'GeneratedTopCell{}(X0:SortK{}),
+     \and{SortGeneratedTopCell{}} (
+       VarK:SortGeneratedTopCell{},
+        \top{SortGeneratedTopCell{}}())))
+  [projection{}()]
+
+// rule `project:GeneratedTopCellFragment`(inj{GeneratedTopCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarK:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCellFragment{},R} (
+      Lblproject'Coln'GeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortGeneratedTopCellFragment{}} (
+       VarK:SortGeneratedTopCellFragment{},
+        \top{SortGeneratedTopCellFragment{}}())))
+  [projection{}()]
+
+// rule `project:IOError`(inj{IOError,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOError{}, SortKItem{}}(VarK:SortIOError{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOError{},R} (
+      Lblproject'Coln'IOError{}(X0:SortK{}),
+     \and{SortIOError{}} (
+       VarK:SortIOError{},
+        \top{SortIOError{}}())))
+  [projection{}()]
+
+// rule `project:IOFile`(inj{IOFile,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOFile{}, SortKItem{}}(VarK:SortIOFile{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOFile{},R} (
+      Lblproject'Coln'IOFile{}(X0:SortK{}),
+     \and{SortIOFile{}} (
+       VarK:SortIOFile{},
+        \top{SortIOFile{}}())))
+  [projection{}()]
+
+// rule `project:IOInt`(inj{IOInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOInt{}, SortKItem{}}(VarK:SortIOInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOInt{},R} (
+      Lblproject'Coln'IOInt{}(X0:SortK{}),
+     \and{SortIOInt{}} (
+       VarK:SortIOInt{},
+        \top{SortIOInt{}}())))
+  [projection{}()]
+
+// rule `project:IOString`(inj{IOString,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOString{}, SortKItem{}}(VarK:SortIOString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOString{},R} (
+      Lblproject'Coln'IOString{}(X0:SortK{}),
+     \and{SortIOString{}} (
+       VarK:SortIOString{},
+        \top{SortIOString{}}())))
+  [projection{}()]
+
+// rule `project:Id`(inj{Id,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortId{}, SortKItem{}}(VarK:SortId{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortId{},R} (
+      Lblproject'Coln'Id{}(X0:SortK{}),
+     \and{SortId{}} (
+       VarK:SortId{},
+        \top{SortId{}}())))
+  [projection{}()]
+
+// rule `project:Int`(inj{Int,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarK:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'Coln'Int{}(X0:SortK{}),
+     \and{SortInt{}} (
+       VarK:SortInt{},
+        \top{SortInt{}}())))
+  [projection{}()]
+
+// rule `project:K`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortK{},R} (
+      Lblproject'Coln'K{}(X0:SortK{}),
+     \and{SortK{}} (
+       VarK:SortK{},
+        \top{SortK{}}())))
+  [projection{}()]
+
+// rule `project:KCell`(inj{KCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCell{}, SortKItem{}}(VarK:SortKCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCell{},R} (
+      Lblproject'Coln'KCell{}(X0:SortK{}),
+     \and{SortKCell{}} (
+       VarK:SortKCell{},
+        \top{SortKCell{}}())))
+  [projection{}()]
+
+// rule `project:KCellOpt`(inj{KCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarK:SortKCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCellOpt{},R} (
+      Lblproject'Coln'KCellOpt{}(X0:SortK{}),
+     \and{SortKCellOpt{}} (
+       VarK:SortKCellOpt{},
+        \top{SortKCellOpt{}}())))
+  [projection{}()]
+
+// rule `project:KItem`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarK:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKItem{},R} (
+      Lblproject'Coln'KItem{}(X0:SortK{}),
+     \and{SortKItem{}} (
+       VarK:SortKItem{},
+        \top{SortKItem{}}())))
+  [projection{}()]
+
+// rule `project:List`(inj{List,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarK:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortList{},R} (
+      Lblproject'Coln'List{}(X0:SortK{}),
+     \and{SortList{}} (
+       VarK:SortList{},
+        \top{SortList{}}())))
+  [projection{}()]
+
+// rule `project:Map`(inj{Map,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarK:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMap{},R} (
+      Lblproject'Coln'Map{}(X0:SortK{}),
+     \and{SortMap{}} (
+       VarK:SortMap{},
+        \top{SortMap{}}())))
+  [projection{}()]
+
+// rule `project:Set`(inj{Set,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarK:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortSet{},R} (
+      Lblproject'Coln'Set{}(X0:SortK{}),
+     \and{SortSet{}} (
+       VarK:SortSet{},
+        \top{SortSet{}}())))
+  [projection{}()]
+
+// rule `project:Stream`(inj{Stream,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortStream{}, SortKItem{}}(VarK:SortStream{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortStream{},R} (
+      Lblproject'Coln'Stream{}(X0:SortK{}),
+     \and{SortStream{}} (
+       VarK:SortStream{},
+        \top{SortStream{}}())))
+  [projection{}()]
+
+// rule `project:String`(inj{String,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortString{}, SortKItem{}}(VarK:SortString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      Lblproject'Coln'String{}(X0:SortK{}),
+     \and{SortString{}} (
+       VarK:SortString{},
+        \top{SortString{}}())))
+  [projection{}()]
+
+// rule `replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,ToReplace,Replacement,Count)=>`_+String__STRING-COMMON_String_String_String`(`_+String__STRING-COMMON_String_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToReplace)),`lengthString(_)_STRING-COMMON_Int_String`(Source)),ToReplace,Replacement,`_-Int_`(Count,#token("1","Int")))) requires `_>Int_`(Count,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(311b80d2cb12d368f230eba968464e1fc926bd57e304059b282b82af4d9626d9), org.kframework.attributes.Location(Location(1705,8,1708,30)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-'Int'Unds'{}(VarCount:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            VarReplacement:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X3:SortInt{},
+            VarCount:SortInt{}
+          ),
+          \top{R} ()
+        ))))),
+    \equals{SortString{},R} (
+      Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortString{},X3:SortInt{}),
+     \and{SortString{}} (
+       Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})),VarToReplace:SortString{},VarReplacement:SortString{},Lbl'Unds'-Int'Unds'{}(VarCount:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortString{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1705,8,1708,30)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("311b80d2cb12d368f230eba968464e1fc926bd57e304059b282b82af4d9626d9")]
+
+// rule `replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,_Gen0,_Gen1,#token("0","Int"))=>Source requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4367434b0f61c404f7a2e926426bd23874dd547de689c5d15089967fbab2b3d5), org.kframework.attributes.Location(Location(1709,8,1709,49)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            Var'Unds'Gen1:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X3:SortInt{},
+            \dv{SortInt{}}("0")
+          ),
+          \top{R} ()
+        ))))),
+    \equals{SortString{},R} (
+      Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortString{},X3:SortInt{}),
+     \and{SortString{}} (
+       VarSource:SortString{},
+        \top{SortString{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1709,8,1709,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("4367434b0f61c404f7a2e926426bd23874dd547de689c5d15089967fbab2b3d5")]
+
+// rule `replaceAll(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,Replacement)=>`replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,ToReplace,Replacement,`countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToReplace)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(262167183c3ec2e214d12bac6e639d7ac1a9f973582e16eca6c1af1da7ecc0a5), org.kframework.attributes.Location(Location(1710,8,1710,154)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            VarReplacement:SortString{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortString{},R} (
+      LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+     \and{SortString{}} (
+       Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{})),
+        \top{SortString{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1710,8,1710,154)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("262167183c3ec2e214d12bac6e639d7ac1a9f973582e16eca6c1af1da7ecc0a5")]
+
+// rule `replaceFirst(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,Replacement)=>`_+String__STRING-COMMON_String_String_String`(`_+String__STRING-COMMON_String_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToReplace)),`lengthString(_)_STRING-COMMON_Int_String`(Source))) requires `_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(e290042e5b5b2f620c0ca1871e708c3713c62b63b283e317bb7568e13968fe0c), org.kframework.attributes.Location(Location(1698,8,1700,66)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            VarReplacement:SortString{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortString{},R} (
+      LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+     \and{SortString{}} (
+       Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{}))),
+        \top{SortString{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1698,8,1700,66)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("e290042e5b5b2f620c0ca1871e708c3713c62b63b283e317bb7568e13968fe0c")]
+
+// rule `replaceFirst(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,_Gen0)=>Source requires `_<Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(8fbd1c8efb9988236eddc95fc2af4a3e74f6ec94d696ee47209543fd0826dd34), org.kframework.attributes.Location(Location(1701,8,1702,57)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortString{},R} (
+      LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+     \and{SortString{}} (
+       VarSource:SortString{},
+        \top{SortString{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1701,8,1702,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("8fbd1c8efb9988236eddc95fc2af4a3e74f6ec94d696ee47209543fd0826dd34")]
+
+// rule `rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,S2,I)=>`maxInt(_,_)_INT-COMMON_Int_Int_Int`(`rfindString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I)) requires `_=/=String__STRING-COMMON_Bool_String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [UNIQUE_ID(b7f740050d72a847424b022a9c8217325aba8a154a42831aa3c7a3b0727f3205), org.kframework.attributes.Location(Location(1690,8,1690,182)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{})),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1690,8,1690,182)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("b7f740050d72a847424b022a9c8217325aba8a154a42831aa3c7a3b0727f3205")]
+
+// rule `rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(_Gen0,#token("\"\"","String"),_Gen1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(23b9fa88124c547d94aed32124d1ccd1069732b059f4c8b430ab4617979690f6), org.kframework.attributes.Location(Location(1691,8,1691,33)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            \dv{SortString{}}("")
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            Var'Unds'Gen1:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("-1"),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1691,8,1691,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("23b9fa88124c547d94aed32124d1ccd1069732b059f4c8b430ab4617979690f6")]
+
+// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_-Int_`(`_modInt_`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))),`_<<Int_`(#token("1","Int"),LEN)),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f), org.kframework.attributes.Location(Location(1237,8,1237,164)), org.kframework.attributes.Source(Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds'modInt'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortInt{}}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1237,8,1237,164)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/jrgmri5rl9ad3s9cfvh8cifkxv2lpx6r-k-5.6.0-dirty-maven/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f")]
+
+
+// priority groups
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(8,1,20,10)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)")]


### PR DESCRIPTION
Previously, we weren't injecting the program term (value of `$PGM`) into `KItem` when constructing interpreter input. This was a divergence from the behaviour of `llvm-krun`, and because no tests were exercising this function, we hadn't noticed.

This PR corrects for the missing injection, and adds a test to make sure that we can perform actual rewriting using the C bindings.