### PR TITLE
Improvements to C binding tests

### DIFF
--- a/test/c/Inputs/api.c
+++ b/test/c/Inputs/api.c
@@ -1,0 +1,57 @@
+#include "api.h"
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <stdlib.h>
+
+// Uses a GNU extension (fully supported by clang) to make the cast from dlsym
+// nicer, but this is only ever compiled as test code so it's not an issue.
+#define API_FUNCTION(name)                                                     \
+  do {                                                                         \
+    api.name = (__typeof__(name) *)dlsym(lib, #name);                          \
+    assert(api.name && "Failed to load API function: " #name);                 \
+  } while (false);
+
+struct kllvm_c_api load_c_api(char const *path) {
+  void *lib = dlopen(path, RTLD_NOW);
+  if (!lib) {
+    abort();
+  }
+
+  struct kllvm_c_api api;
+
+  API_FUNCTION(kore_pattern_dump);
+  API_FUNCTION(kore_pattern_serialize);
+  API_FUNCTION(kore_pattern_free);
+  API_FUNCTION(kore_pattern_parse);
+  API_FUNCTION(kore_pattern_new_token);
+  API_FUNCTION(kore_pattern_new_token_with_len);
+  API_FUNCTION(kore_pattern_new_injection);
+  API_FUNCTION(kore_pattern_make_interpreter_input);
+  API_FUNCTION(kore_composite_pattern_new);
+  API_FUNCTION(kore_composite_pattern_from_symbol);
+  API_FUNCTION(kore_composite_pattern_add_argument);
+  API_FUNCTION(kore_string_pattern_new);
+  API_FUNCTION(kore_string_pattern_new_with_len);
+  API_FUNCTION(kore_pattern_construct);
+  API_FUNCTION(kore_block_dump);
+  API_FUNCTION(kore_block_get_bool);
+  API_FUNCTION(kore_simplify_bool);
+  API_FUNCTION(kore_simplify);
+  API_FUNCTION(kore_simplify_binary);
+  API_FUNCTION(take_steps);
+  API_FUNCTION(kore_sort_dump);
+  API_FUNCTION(kore_sort_free);
+  API_FUNCTION(kore_sort_is_concrete);
+  API_FUNCTION(kore_sort_is_kitem);
+  API_FUNCTION(kore_sort_is_k);
+  API_FUNCTION(kore_composite_sort_new);
+  API_FUNCTION(kore_composite_sort_add_argument);
+  API_FUNCTION(kore_symbol_new);
+  API_FUNCTION(kore_symbol_free);
+  API_FUNCTION(kore_symbol_add_formal_argument);
+  API_FUNCTION(kllvm_init);
+  API_FUNCTION(kllvm_free_all_memory);
+
+  return api;
+}

--- a/test/c/Inputs/api.h
+++ b/test/c/Inputs/api.h
@@ -1,0 +1,50 @@
+#ifndef C_TEST_API_H
+#define C_TEST_API_H
+
+#include <kllvm-c/kllvm-c.h>
+
+struct kllvm_c_api {
+  char *(*kore_pattern_dump)(kore_pattern const *);
+  void (*kore_pattern_serialize)(kore_pattern const *, char **, size_t *);
+  void (*kore_pattern_free)(kore_pattern const *);
+  kore_pattern *(*kore_pattern_parse)(char const *);
+  kore_pattern *(*kore_pattern_new_token)(char const *, kore_sort const *);
+  kore_pattern *(*kore_pattern_new_token_with_len)(
+      char const *, size_t, kore_sort const *);
+  kore_pattern *(*kore_pattern_new_injection)(
+      kore_pattern const *, kore_sort const *, kore_sort const *);
+  kore_pattern *(*kore_pattern_make_interpreter_input)(
+      kore_pattern const *, kore_sort const *);
+  kore_pattern *(*kore_composite_pattern_new)(char const *);
+  kore_pattern *(*kore_composite_pattern_from_symbol)(kore_symbol *);
+  void (*kore_composite_pattern_add_argument)(
+      kore_pattern *, kore_pattern const *);
+  kore_pattern *(*kore_string_pattern_new)(char const *);
+  kore_pattern *(*kore_string_pattern_new_with_len)(char const *, size_t);
+  block *(*kore_pattern_construct)(kore_pattern const *);
+  char *(*kore_block_dump)(block *);
+  bool (*kore_block_get_bool)(block *);
+  bool (*kore_simplify_bool)(kore_pattern const *);
+  void (*kore_simplify)(
+      kore_pattern const *pattern, kore_sort const *sort, char **, size_t *);
+  void (*kore_simplify_binary)(
+      char *, size_t, kore_sort const *, char **, size_t *);
+  block *(*take_steps)(int64_t depth, block *term);
+  char *(*kore_sort_dump)(kore_sort const *);
+  void (*kore_sort_free)(kore_sort const *);
+  bool (*kore_sort_is_concrete)(kore_sort const *);
+  bool (*kore_sort_is_kitem)(kore_sort const *);
+  bool (*kore_sort_is_k)(kore_sort const *);
+  kore_sort *(*kore_composite_sort_new)(char const *);
+  void (*kore_composite_sort_add_argument)(
+      kore_sort const *, kore_sort const *);
+  kore_symbol *(*kore_symbol_new)(char const *);
+  void (*kore_symbol_free)(kore_symbol const *);
+  void (*kore_symbol_add_formal_argument)(kore_symbol *, kore_sort const *);
+  void (*kllvm_init)(void);
+  void (*kllvm_free_all_memory)(void);
+};
+
+struct kllvm_c_api load_c_api(char const *);
+
+#endif

--- a/test/c/Inputs/binary_simplify.c
+++ b/test/c/Inputs/binary_simplify.c
@@ -1,82 +1,48 @@
-#include <assert.h>
-#include <dlfcn.h>
-#include <kllvm-c/kllvm-c.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "api.h"
 
-typedef kore_pattern *new_comp_t(char const *);
-typedef kore_pattern *new_token_t(char const *, kore_sort const *);
-typedef void *add_arg_t(kore_pattern *, kore_pattern const *);
-typedef kore_sort *new_sort_t(char const *);
-typedef void simplify_t(char *, size_t, kore_sort const *, char **, size_t *);
-typedef void free_all_t(void);
-typedef void init_t(void);
-typedef void pattern_free_t(kore_pattern *);
-typedef void sort_free_t(kore_sort *);
-typedef void serialize_t(kore_pattern const *, char **, size_t *);
+#include <assert.h>
+#include <stdio.h>
+
+/*
+  module TEST
+    imports INT
+
+    syntax Foo ::= bar(Int)      [klabel(bar), symbol]
+                 | foo(Int, Int) [function, klabel(foo), symbol]
+
+    rule foo(A, 0) => bar(A)
+    rule foo(A, B) => foo(A +Int 1, absInt(B) -Int 1) [owise]
+  endmodule
+*/
 
 int main(int argc, char **argv) {
   if (argc <= 2) {
     return 1;
   }
 
-  void *lib = dlopen(argv[1], RTLD_NOW);
-  if (!lib) {
-    return 2;
-  }
+  struct kllvm_c_api api = load_c_api(argv[1]);
 
-  new_comp_t *new_comp = dlsym(lib, "kore_composite_pattern_new");
-  new_token_t *new_token = dlsym(lib, "kore_pattern_new_token");
-  add_arg_t *add_arg = dlsym(lib, "kore_composite_pattern_add_argument");
-  new_sort_t *new_sort = dlsym(lib, "kore_composite_sort_new");
-  simplify_t *simplify = dlsym(lib, "kore_simplify_binary");
-  free_all_t *free_all = dlsym(lib, "kllvm_free_all_memory");
-  init_t *init = dlsym(lib, "kllvm_init");
-  serialize_t *serialize = dlsym(lib, "kore_pattern_serialize");
+  api.kllvm_init();
 
-  pattern_free_t *pattern_free
-      = (pattern_free_t *)dlsym(lib, "kore_pattern_free");
-  sort_free_t *sort_free = (sort_free_t *)dlsym(lib, "kore_sort_free");
+  kore_sort *sort_int = api.kore_composite_sort_new("SortInt");
+  kore_sort *sort_foo = api.kore_composite_sort_new("SortFoo");
 
-  if (!new_comp || !new_token || !add_arg || !new_sort || !simplify || !free_all
-      || !init || !serialize) {
-    return 3;
-  }
-
-  init();
-
-  kore_sort *sort_int = new_sort("SortInt");
-  kore_sort *sort_foo = new_sort("SortFoo");
-
-  /*
-    module TEST
-      imports INT
-
-      syntax Foo ::= bar(Int)      [klabel(bar), symbol]
-                   | foo(Int, Int) [function, klabel(foo), symbol]
-
-      rule foo(A, 0) => bar(A)
-      rule foo(A, B) => foo(A +Int 1, absInt(B) -Int 1) [owise]
-    endmodule
-  */
-  kore_pattern *pat = new_comp("Lblfoo");
+  kore_pattern *pat = api.kore_composite_pattern_new("Lblfoo");
   assert(sort_int && pat && "Bad sort or pattern");
 
-  kore_pattern *a = new_token("12", sort_int);
-  add_arg(pat, a);
-  pattern_free(a);
+  kore_pattern *a = api.kore_pattern_new_token("12", sort_int);
+  api.kore_composite_pattern_add_argument(pat, a);
+  api.kore_pattern_free(a);
 
-  kore_pattern *b = new_token("5", sort_int);
-  add_arg(pat, b);
-  pattern_free(b);
+  kore_pattern *b = api.kore_pattern_new_token("5", sort_int);
+  api.kore_composite_pattern_add_argument(pat, b);
+  api.kore_pattern_free(b);
 
   char *data_in, *data_out;
   size_t size_in, size_out;
 
-  serialize(pat, &data_in, &size_in);
-  simplify(data_in, size_in, sort_foo, &data_out, &size_out);
+  api.kore_pattern_serialize(pat, &data_in, &size_in);
+  api.kore_simplify_binary(data_in, size_in, sort_foo, &data_out, &size_out);
 
   FILE *f = fopen(argv[2], "wb");
   if (!f) {
@@ -86,7 +52,7 @@ int main(int argc, char **argv) {
   fwrite(data_out, size_out, 1, f);
   fclose(f);
 
-  pattern_free(pat);
-  sort_free(sort_int);
-  sort_free(sort_foo);
+  api.kore_pattern_free(pat);
+  api.kore_sort_free(sort_int);
+  api.kore_sort_free(sort_foo);
 }

--- a/test/c/Inputs/bytes.c
+++ b/test/c/Inputs/bytes.c
@@ -1,58 +1,36 @@
-#include <assert.h>
-#include <dlfcn.h>
-#include <kllvm-c/kllvm-c.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "api.h"
 
-typedef kore_pattern *new_comp_t(char const *);
-typedef kore_pattern *new_token_len_t(char const *, size_t, kore_sort const *);
-typedef void *add_pattern_arg_t(kore_pattern *, kore_pattern *);
-typedef kore_sort *new_sort_t(char const *);
-typedef void simplify_t(kore_pattern *, kore_sort *, char **, size_t *);
+#include <assert.h>
+#include <stdio.h>
+
+/*
+  module TEST
+    imports BYTES
+
+    syntax Bytes ::= foo(Bytes) [function, klabel(foo), symbol]
+    rule foo(B) => B
+  endmodule
+*/
 
 int main(int argc, char **argv) {
   if (argc <= 2) {
     return 1;
   }
 
-  void *lib = dlopen(argv[1], RTLD_NOW);
-  if (!lib) {
-    return 2;
-  }
+  struct kllvm_c_api api = load_c_api(argv[1]);
 
-  new_comp_t *new_comp = (new_comp_t *)dlsym(lib, "kore_composite_pattern_new");
-  new_token_len_t *new_token_len
-      = (new_token_len_t *)dlsym(lib, "kore_pattern_new_token_with_len");
-  add_pattern_arg_t *add_arg
-      = (add_pattern_arg_t *)dlsym(lib, "kore_composite_pattern_add_argument");
-  new_sort_t *new_sort = (new_sort_t *)dlsym(lib, "kore_composite_sort_new");
-  simplify_t *simplify = (simplify_t *)dlsym(lib, "kore_simplify");
-
-  if (!new_comp || !new_token_len || !new_sort || !simplify || !add_arg) {
-    return 3;
-  }
-
-  /*
-    module TEST
-        imports BYTES
-
-        syntax Bytes ::= foo(Bytes) [function, klabel(foo), symbol]
-        rule foo(B) => B
-    endmodule
-  */
-  kore_pattern *pat = new_comp("Lblfoo");
-  kore_sort *bytes = new_sort("SortBytes");
+  kore_pattern *pat = api.kore_composite_pattern_new("Lblfoo");
+  kore_sort *bytes = api.kore_composite_sort_new("SortBytes");
   assert(bytes && pat && "Bad sort or pattern");
 
   char bytes_data[4] = {'\x00', '\x01', '\x00', '\x02'};
-  kore_pattern *token = new_token_len(bytes_data, 4, bytes);
-  add_arg(pat, token);
+  kore_pattern *token
+      = api.kore_pattern_new_token_with_len(bytes_data, 4, bytes);
+  api.kore_composite_pattern_add_argument(pat, token);
 
   char *data;
   size_t size;
-  simplify(pat, bytes, &data, &size);
+  api.kore_simplify(pat, bytes, &data, &size);
 
   FILE *f = fopen(argv[2], "wb");
   if (!f) {

--- a/test/c/Inputs/k.c
+++ b/test/c/Inputs/k.c
@@ -1,51 +1,34 @@
-#include <assert.h>
-#include <dlfcn.h>
-#include <kllvm-c/kllvm-c.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "api.h"
 
-typedef kore_pattern *new_comp_t(char const *);
-typedef kore_sort *new_sort_t(char const *);
-typedef void simplify_t(kore_pattern *, kore_sort *, char **, size_t *);
+#include <assert.h>
+#include <stdio.h>
+
+/*
+  module TEST
+    imports DOMAINS
+
+    syntax KItem ::= bar() [klabel(bar), symbol]
+
+    syntax K ::= foo() [function, klabel(foo), symbol]
+    rule foo() => bar()
+  endmodule
+*/
 
 int main(int argc, char **argv) {
   if (argc <= 2) {
     return 1;
   }
 
-  void *lib = dlopen(argv[1], RTLD_NOW);
-  if (!lib) {
-    return 2;
-  }
+  struct kllvm_c_api api = load_c_api(argv[1]);
 
-  new_comp_t *new_comp = (new_comp_t *)dlsym(lib, "kore_composite_pattern_new");
-  new_sort_t *new_sort = (new_sort_t *)dlsym(lib, "kore_composite_sort_new");
-  simplify_t *simplify = (simplify_t *)dlsym(lib, "kore_simplify");
+  kore_sort *k_sort = api.kore_composite_sort_new("SortK");
 
-  if (!new_comp || !new_sort || !simplify) {
-    return 3;
-  }
-
-  kore_sort *k_sort = new_sort("SortK");
-
-  /*
-    module TEST
-        imports DOMAINS
-
-        syntax KItem ::= bar() [klabel(bar), symbol]
-
-        syntax K ::= foo() [function, klabel(foo), symbol]
-        rule foo() => bar()
-    endmodule
-  */
-  kore_pattern *pat = new_comp("Lblfoo");
+  kore_pattern *pat = api.kore_composite_pattern_new("Lblfoo");
   assert(k_sort && pat && "Bad sort or pattern");
 
   char *data;
   size_t size;
-  simplify(pat, k_sort, &data, &size);
+  api.kore_simplify(pat, k_sort, &data, &size);
 
   FILE *f = fopen(argv[2], "wb");
   if (!f) {

--- a/test/c/Inputs/kitem.c
+++ b/test/c/Inputs/kitem.c
@@ -1,51 +1,34 @@
-#include <assert.h>
-#include <dlfcn.h>
-#include <kllvm-c/kllvm-c.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "api.h"
 
-typedef kore_pattern *new_comp_t(char const *);
-typedef kore_sort *new_sort_t(char const *);
-typedef void simplify_t(kore_pattern *, kore_sort *, char **, size_t *);
+#include <assert.h>
+#include <stdio.h>
+
+/*
+  module TEST
+    imports INT
+
+    syntax KItem ::= foo() [function, klabel(foo), symbol]
+                   | bar() [klabel(bar), symbol]
+
+    rule foo() => bar()
+  endmodule
+*/
 
 int main(int argc, char **argv) {
   if (argc <= 2) {
     return 1;
   }
 
-  void *lib = dlopen(argv[1], RTLD_NOW);
-  if (!lib) {
-    return 2;
-  }
+  struct kllvm_c_api api = load_c_api(argv[1]);
 
-  new_comp_t *new_comp = (new_comp_t *)dlsym(lib, "kore_composite_pattern_new");
-  new_sort_t *new_sort = (new_sort_t *)dlsym(lib, "kore_composite_sort_new");
-  simplify_t *simplify = (simplify_t *)dlsym(lib, "kore_simplify");
+  kore_sort *sort = api.kore_composite_sort_new("SortKItem");
 
-  if (!new_comp || !new_sort || !simplify) {
-    return 3;
-  }
-
-  kore_sort *sort = new_sort("SortKItem");
-
-  /*
-    module TEST
-      imports INT
-
-      syntax KItem ::= foo() [function, klabel(foo), symbol]
-                     | bar() [klabel(bar), symbol]
-
-      rule foo() => bar()
-    endmodule
-  */
-  kore_pattern *pat = new_comp("Lblfoo");
+  kore_pattern *pat = api.kore_composite_pattern_new("Lblfoo");
   assert(sort && pat && "Bad sort or pattern");
 
   char *data;
   size_t size;
-  simplify(pat, sort, &data, &size);
+  api.kore_simplify(pat, sort, &data, &size);
 
   FILE *f = fopen(argv[2], "wb");
   if (!f) {

--- a/test/c/Inputs/parse.c
+++ b/test/c/Inputs/parse.c
@@ -1,38 +1,21 @@
-#include <assert.h>
-#include <dlfcn.h>
-#include <kllvm-c/kllvm-c.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "api.h"
 
-typedef kore_pattern *parse_t(char const *);
-typedef char *dump_t(kore_pattern const *);
+#include <stdio.h>
+
+/*
+  module TEST
+    syntax Foo ::= foo() | bar()
+    rule foo() => bar()
+  endmodule
+*/
 
 int main(int argc, char **argv) {
   if (argc <= 1) {
     return 1;
   }
 
-  void *lib = dlopen(argv[1], RTLD_NOW);
-  if (!lib) {
-    return 2;
-  }
+  struct kllvm_c_api api = load_c_api(argv[1]);
 
-  parse_t *parse = (parse_t *)dlsym(lib, "kore_pattern_parse");
-  dump_t *dump = (dump_t *)dlsym(lib, "kore_pattern_dump");
-
-  if (!parse || !dump) {
-    return 3;
-  }
-
-  /*
-    module TEST
-      syntax Foo ::= foo() | bar()
-      rule foo() => bar()
-    endmodule
-  */
-
-  kore_pattern *pat = parse("Lblfoo{}()");
-  printf("%s", dump(pat));
+  kore_pattern *pat = api.kore_pattern_parse("Lblfoo{}()");
+  printf("%s", api.kore_pattern_dump(pat));
 }

--- a/test/c/Inputs/simplify.c
+++ b/test/c/Inputs/simplify.c
@@ -1,69 +1,41 @@
-#include <assert.h>
-#include <dlfcn.h>
-#include <kllvm-c/kllvm-c.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "api.h"
 
-typedef kore_pattern *new_comp_t(char const *);
-typedef kore_sort *new_sort_t(char const *);
-typedef void simplify_t(kore_pattern *, kore_sort *, char **, size_t *);
-typedef void free_all_t(void);
-typedef void init_t(void);
-typedef void pattern_free_t(kore_pattern *);
-typedef void sort_free_t(kore_sort *);
+#include <assert.h>
+#include <stdio.h>
+
+/*
+  module TEST
+    imports INT
+
+    syntax Int ::= foo() [function, klabel(foo), symbol]
+                 | bar() [function, klabel(bar), symbol]
+
+    rule foo() => 328
+    rule bar() => 562
+  endmodule
+*/
 
 int main(int argc, char **argv) {
   if (argc <= 3) {
     return 1;
   }
 
-  void *lib = dlopen(argv[1], RTLD_NOW);
-  if (!lib) {
-    return 2;
-  }
+  struct kllvm_c_api api = load_c_api(argv[1]);
 
-  new_comp_t *new_comp = (new_comp_t *)dlsym(lib, "kore_composite_pattern_new");
-  new_sort_t *new_sort = (new_sort_t *)dlsym(lib, "kore_composite_sort_new");
-  simplify_t *simplify = (simplify_t *)dlsym(lib, "kore_simplify");
-  free_all_t *free_all = (free_all_t *)dlsym(lib, "kllvm_free_all_memory");
-  init_t *init = (init_t *)dlsym(lib, "kllvm_init");
+  api.kllvm_init();
 
-  pattern_free_t *pattern_free
-      = (pattern_free_t *)dlsym(lib, "kore_pattern_free");
-  sort_free_t *sort_free = (sort_free_t *)dlsym(lib, "kore_sort_free");
-
-  if (!new_comp || !new_sort || !simplify || !free_all || !init) {
-    return 3;
-  }
-
-  init();
-
-  kore_sort *sort = new_sort("SortInt");
-
-  /*
-    module TEST
-      imports INT
-
-      syntax Int ::= foo() [function, klabel(foo), symbol]
-                   | bar() [function, klabel(bar), symbol]
-
-      rule foo() => 328
-      rule bar() => 562
-    endmodule
-  */
-  kore_pattern *pat = new_comp(argv[3]);
+  kore_sort *sort = api.kore_composite_sort_new("SortInt");
+  kore_pattern *pat = api.kore_composite_pattern_new(argv[3]);
   assert(sort && pat && "Bad sort or pattern");
 
   char *data;
   size_t size;
-  simplify(pat, sort, &data, &size);
+  api.kore_simplify(pat, sort, &data, &size);
 
   // Do the simplification twice to make sure GC works
-  free_all();
+  api.kllvm_free_all_memory();
 
-  simplify(pat, sort, &data, &size);
+  api.kore_simplify(pat, sort, &data, &size);
 
   FILE *f = fopen(argv[2], "wb");
   if (!f) {
@@ -73,6 +45,6 @@ int main(int argc, char **argv) {
   fwrite(data, size, 1, f);
   fclose(f);
 
-  pattern_free(pat);
-  sort_free(sort);
+  api.kore_pattern_free(pat);
+  api.kore_sort_free(sort);
 }

--- a/test/c/Inputs/steps.c
+++ b/test/c/Inputs/steps.c
@@ -1,13 +1,6 @@
 #include "api.h"
 
-#include <kllvm-c/kllvm-c.h>
-
-#include <assert.h>
-#include <dlfcn.h>
-#include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 /*
   module ARITHMETIC-SYNTAX

--- a/test/c/Inputs/steps.c
+++ b/test/c/Inputs/steps.c
@@ -1,80 +1,56 @@
+#include "api.h"
+
+#include <kllvm-c/kllvm-c.h>
+
 #include <assert.h>
 #include <dlfcn.h>
-#include <kllvm-c/kllvm-c.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-typedef void init_t(void);
-typedef kore_pattern *parse_t(char const *);
-typedef char *dump_t(kore_pattern const *);
-typedef char *block_dump_t(block *);
-typedef kore_sort *new_sort_t(char const *);
-typedef kore_pattern *make_input_t(kore_pattern const *, kore_sort const *);
-typedef block *construct_t(kore_pattern const *);
-typedef block *step_t(int64_t, block *);
+/*
+  module ARITHMETIC-SYNTAX
+    imports UNSIGNED-INT-SYNTAX
+
+    syntax Exp ::= Int
+                 | Exp "+" Exp [left, strict]
+  endmodule
+
+  module ARITHMETIC
+    imports ARITHMETIC-SYNTAX
+    imports DOMAINS
+
+    configuration
+      <k> $PGM:Exp </k>
+
+    rule A + B => A +Int B
+
+    syntax Bool ::= isKResult(Exp) [function, symbol]
+    rule isKResult(_::Int) => true
+    rule isKResult(_)      => false [owise]
+  endmodule
+*/
 
 int main(int argc, char **argv) {
   if (argc <= 1) {
     return 1;
   }
 
-  void *lib = dlopen(argv[1], RTLD_NOW);
-  if (!lib) {
-    return 2;
-  }
+  struct kllvm_c_api api = load_c_api(argv[1]);
 
-  init_t *init = (init_t *)dlsym(lib, "kllvm_init");
-  parse_t *parse = (parse_t *)dlsym(lib, "kore_pattern_parse");
-  dump_t *dump = (dump_t *)dlsym(lib, "kore_pattern_dump");
-  block_dump_t *block_dump = (block_dump_t *)dlsym(lib, "kore_block_dump");
-  new_sort_t *new_sort = (new_sort_t *)dlsym(lib, "kore_composite_sort_new");
-  make_input_t *make_input
-      = (make_input_t *)dlsym(lib, "kore_pattern_make_interpreter_input");
-  construct_t *construct = (construct_t *)dlsym(lib, "kore_pattern_construct");
-  step_t *steps = (step_t *)dlsym(lib, "take_steps");
+  api.kllvm_init();
 
-  if (!init || !parse || !dump || !block_dump || !new_sort || !make_input
-      || !construct || !steps) {
-    return 3;
-  }
-
-  /*
-    module ARITHMETIC-SYNTAX
-      imports UNSIGNED-INT-SYNTAX
-
-      syntax Exp ::= Int
-                   | Exp "+" Exp [left, strict]
-    endmodule
-
-    module ARITHMETIC
-      imports ARITHMETIC-SYNTAX
-      imports DOMAINS
-
-      configuration
-        <k> $PGM:Exp </k>
-
-      rule A + B => A +Int B
-
-      syntax Bool ::= isKResult(Exp) [function, symbol]
-      rule isKResult(_::Int) => true
-      rule isKResult(_)      => false [owise]
-    endmodule
-  */
-
-  init();
-
-  kore_pattern *pat = parse(
+  kore_pattern *pat = api.kore_pattern_parse(
       "Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}("
       "inj{SortInt{}, SortExp{}}(\\dv{SortInt{}}(\"75\")),inj{SortInt{}, "
       "SortExp{}}(\\dv{SortInt{}}(\"12\")))");
 
-  kore_sort *sort_exp = new_sort("SortExp");
-  kore_pattern *input = make_input(pat, sort_exp);
+  kore_sort *sort_exp = api.kore_composite_sort_new("SortExp");
+  kore_pattern *input = api.kore_pattern_make_interpreter_input(pat, sort_exp);
 
-  block *term = construct(input);
-  block *after = steps(-1, term);
+  block *term = api.kore_pattern_construct(input);
+  block *after = api.take_steps(-1, term);
 
-  printf("%s", block_dump(after));
+  printf("%s", api.kore_block_dump(after));
 }

--- a/test/c/test_binary_simplify.kore
+++ b/test/c/test_binary_simplify.kore
@@ -1,6 +1,6 @@
 // RUN: mkdir -p %t.dir
 // RUN: %kompile %s c -o %t.dir/libtest.so
-// RUN: clang -I %include-path Inputs/binary_simplify.c -o %t -O0 -g
+// RUN: %kllvm-clang Inputs/binary_simplify.c -o %t
 
 // RUN: %t %t.dir/libtest.so %t.foo.bin
 // RUN: %kore-convert %t.foo.bin | grep -q 'Lblbar{}(\\dv{SortInt{}}("17"))'

--- a/test/c/test_bytes.kore
+++ b/test/c/test_bytes.kore
@@ -1,6 +1,6 @@
 // RUN: mkdir -p %t.dir
 // RUN: %kompile %s c -o %t.dir/libtest.so
-// RUN: clang -I %include-path Inputs/bytes.c -o %t
+// RUN: %kllvm-clang Inputs/bytes.c -o %t
 
 // RUN: %t %t.dir/libtest.so %t.foo.bin
 // RUN: %kore-convert %t.foo.bin | grep -q '\\dv{SortBytes{}}("\\x00\\x01\\x00\\x02")'

--- a/test/c/test_c.kore
+++ b/test/c/test_c.kore
@@ -1,6 +1,6 @@
 // RUN: mkdir -p %t.dir
 // RUN: %kompile %s c -o %t.dir/libtest.so
-// RUN: clang -I %include-path Inputs/bool.c -o %t
+// RUN: %kllvm-clang Inputs/bool.c -o %t
 // RUN: %t %t.dir/libtest.so
 
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/bindings-demo/test.k)")]

--- a/test/c/test_k.kore
+++ b/test/c/test_k.kore
@@ -1,6 +1,6 @@
 // RUN: mkdir -p %t.dir
 // RUN: %kompile %s c -o %t.dir/libtest.so
-// RUN: clang -I %include-path Inputs/k.c -o %t
+// RUN: %kllvm-clang Inputs/k.c -o %t
 
 // RUN: %t %t.dir/libtest.so %t.foo.bin
 // RUN: %kore-convert %t.foo.bin | grep -q 'kseq{}(Lblbar{}(),dotk{}())'

--- a/test/c/test_kitem.kore
+++ b/test/c/test_kitem.kore
@@ -1,6 +1,6 @@
 // RUN: mkdir -p %t.dir
 // RUN: %kompile %s c -o %t.dir/libtest.so
-// RUN: clang -I %include-path Inputs/kitem.c -o %t
+// RUN: %kllvm-clang Inputs/kitem.c -o %t
 
 // RUN: %t %t.dir/libtest.so %t.foo.bin
 // RUN: %kore-convert %t.foo.bin | grep -q 'Lblbar{}()'

--- a/test/c/test_parse.kore
+++ b/test/c/test_parse.kore
@@ -1,6 +1,6 @@
 // RUN: mkdir -p %t.dir
 // RUN: %kompile %s c -o %t.dir/libtest.so
-// RUN: clang -I %include-path Inputs/parse.c -o %t
+// RUN: %kllvm-clang Inputs/parse.c -o %t
 // RUN: %t %t.dir/libtest.so | grep -wq 'Lblfoo{}()'
 
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/test.k)")]

--- a/test/c/test_simplify.kore
+++ b/test/c/test_simplify.kore
@@ -1,6 +1,6 @@
 // RUN: mkdir -p %t.dir
 // RUN: %kompile %s c -o %t.dir/libtest.so
-// RUN: clang -I %include-path Inputs/simplify.c -o %t
+// RUN: %kllvm-clang Inputs/simplify.c -o %t
 
 // RUN: %t %t.dir/libtest.so %t.foo.bin Lblfoo
 // RUN: %kore-convert %t.foo.bin | grep -q 'inj{SortInt{}, SortKItem{}}(\\dv{SortInt{}}("328"))'

--- a/test/c/test_steps.kore
+++ b/test/c/test_steps.kore
@@ -1,6 +1,6 @@
 // RUN: mkdir -p %t.dir
 // RUN: %kompile %s c -o %t.dir/libtest.so
-// RUN: clang -I %include-path Inputs/steps.c -o %t
+// RUN: %kllvm-clang Inputs/steps.c -o %t
 // RUN: %t %t.dir/libtest.so | grep -q '\\dv{SortInt{}}("87")'
 
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/scratch/arithmetic.k)")]

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -69,7 +69,7 @@ config.substitutions.extend([
     ('%strip-binary', 'kore-strip'),
     ('%arity', 'kore-arity'),
 
-    ('%kllvm-clang', 'clang -I %include-path -I Inputs'),
+    ('%kllvm-clang', 'clang -I %include-path -I Inputs Inputs/api.c'),
 
     ('%bindings-path', BINDINGS_INSTALL_PATH),
     ('%include-path', INCLUDE_INSTALL_PATH),

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -69,6 +69,8 @@ config.substitutions.extend([
     ('%strip-binary', 'kore-strip'),
     ('%arity', 'kore-arity'),
 
+    ('%kllvm-clang', 'clang -I %include-path -I Inputs'),
+
     ('%bindings-path', BINDINGS_INSTALL_PATH),
     ('%include-path', INCLUDE_INSTALL_PATH),
     ('%py-interpreter', PYTHON_INTERPRETER),


### PR DESCRIPTION
These tests were using a lot of duplicate boilerplate code for handling `dlopen`, `dlsym` etc. This PR refactors the tests to avoid this, making them easier to write and maintain in the process.

Each test is changed only mechanically to invoke the dynamically loaded functions via the `api` shim, rather than getting the required symbols in each test by hand. The invocations made by the actual KORE test cases are changed to use a `lit.cfg.py` entry, but the tested behaviour is identical in each case.