### PR TITLE
Add flag to get backend include dir from `llvm-kompile`

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -13,6 +13,8 @@ Options:
   --save-temps              Do not delete temporary files on exit.
   --bindings-path           Print the absolute path of the compiled Python bindings for
                             the LLVM backend, then exit.
+  --include-dir             Print the absolute include path for the LLVM backend
+                            runtime and binding headers, then exit.
   --python PATH             The path to a Python interpreter with Pybind installed. Only
                             meaningful in "python" or "pythonast" mode.
   --python-output-dir PATH  Output directory to place automatically-named Python
@@ -52,9 +54,15 @@ run () {
 }
 
 print_bindings_path () {
-  bin_dir=$(dirname "$0")
-  bindings_dir=$(realpath "$bin_dir/../lib/kllvm/python")
+  bin_dir="$(dirname "$0")"
+  bindings_dir="$(realpath "$bin_dir/../lib/kllvm/python")"
   echo "$bindings_dir"
+}
+
+print_include_path () {
+  bin_dir="$(dirname "$0")"
+  include_dir="$(realpath "$bin_dir/../include")"
+  echo "$include_dir"
 }
 
 positional_args=()
@@ -91,6 +99,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --bindings-path)
       print_bindings_path
+      exit 0
+      ;;
+    --include-dir)
+      print_include_path
       exit 0
       ;;
     --python)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -20,7 +20,7 @@ BINDINGS_INSTALL_PATH = os.environ.get(
 
 INCLUDE_INSTALL_PATH = os.environ.get(
     'INCLUDE_INSTALL_PATH',
-    os.path.join(ROOT_PATH, 'build', 'install', 'include'))
+    '$(llvm-kompile --include-dir)')
 
 PYTHON_INTERPRETER = os.environ.get('PYTHON_INTERPRETER', 'python3')
 
@@ -55,8 +55,6 @@ if os.getenv('LIT_USE_NIX'):
 # An interaction between lit and the shell on macOS means that we can't have
 # multiline substitutions natively. This function sanitizes them so that we can
 # use them cross-platform while retaining nice source code.
-
-
 def one_line(s):
     return s.strip().replace('\n', ' ; ').replace('do ;', 'do').replace("' ; '", r"'\\n'")
 


### PR DESCRIPTION
This makes it easier to integrate the backend bindings into a larger app: if you can compile the bindings from a definition, you can then get the right include path to find `<kllvm-c/kllvm-c.h>`