### PR TITLE
Switch to new GH Runner based deps updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - update-deps
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - update-deps
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,25 +1,26 @@
-name: "Master Push"
+name: 'Master Push'
 on:
   push:
     branches:
       - master
 
 jobs:
+
   release:
     name: 'Publish Release'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment: production
     steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v3
-
       - name: 'Update dependents'
         env:
-          JENKINS_DEVOPS_TOKEN: ${{ secrets.JENKINS_DEVOPS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
         run: |
-          curl --fail 'https://ci.runtimeverification.com/jenkins/buildByToken/buildWithParameters' \
-            --data job=Devops/master \
-            --data token=$JENKINS_DEVOPS_TOKEN \
-            --data UPDATE_DEPS=true \
-            --data UPDATE_DEPS_REPO=runtimeverification/llvm-backend \
-            --data UPDATE_DEPS_VERSION="$(git rev-parse HEAD)"
+          set -x
+          version="${GITHUB_SHA}"
+          curl --fail                                                          \
+            -X POST                                                            \
+            -H "Accept: application/vnd.github+json"                           \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}"                         \
+            -H "X-GitHub-Api-Version: 2022-11-28"                              \
+            https://api.github.com/repos/runtimeverification/devops/dispatches \
+            -d '{"event_type":"on-demand-test","client_payload":{"repo":"runtimeverification/llvm-backend","version":"'${version}'"}}'


### PR DESCRIPTION
This switches us from the old way (using Jenkins) to update dependents downstream, to the new way using the GH Runner job in devops repo.