### PR TITLE
Fixed InternalTerm.__str__ binding so that it doesn't assume null-teminated string

### DIFF
--- a/bindings/python/runtime.cpp
+++ b/bindings/python/runtime.cpp
@@ -57,7 +57,10 @@ void bind_runtime(py::module_ &m) {
       }))
       .def(
           "__str__",
-          [](block *term) { return printConfigurationToString(term)->data; })
+          [](block *term) {
+            auto k_str = printConfigurationToString(term);
+            return std::string(k_str->data, len(k_str));
+          })
       .def("step", [](block *term, int64_t n) { return take_steps(n, term); })
       .def("to_pattern", [](block *term) {
         auto raw_ptr


### PR DESCRIPTION
Closes #724

This PR fixes an issue where `InternalTerm.__str__` returns one of the strings used in the runtime directly, rather than constructing an `std::string` of the appropriate length, leading to it reading off the end and causing the issue in #724 

Unfortunately, the script in #724 no longer triggers the issue when converted to an LLVM backend test, likely due to slight differences in how the libraries are compiled, so I am submitting without a test for now. I'll open a separate PR to add a test to Pyk instead.