### PR TITLE
Migrate uses of deprecated APIs

### DIFF
--- a/include/kllvm/codegen/Debug.h
+++ b/include/kllvm/codegen/Debug.h
@@ -44,7 +44,8 @@ llvm::DIType *getVoidDebugType(void);
 llvm::DIType *getBoolDebugType(void);
 llvm::DIType *getShortDebugType(void);
 llvm::DIType *getPointerDebugType(llvm::DIType *, std::string typeName);
-llvm::DIType *getArrayDebugType(llvm::DIType *ty, size_t len, size_t align);
+llvm::DIType *
+getArrayDebugType(llvm::DIType *ty, size_t len, llvm::Align align);
 llvm::DIType *getCharPtrDebugType(void);
 llvm::DIType *getCharDebugType(void);
 llvm::DIType *getForwardDecl(std::string name);

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -226,8 +226,8 @@ llvm::Value *allocateTerm(
   llvm::Instruction *Malloc = llvm::CallInst::CreateMalloc(
       block, llvm::Type::getInt64Ty(block->getContext()), AllocType, Len,
       nullptr, koreHeapAlloc(allocFn, block->getModule()));
-  setDebugLoc(&block->getInstList().back());
-  block->getInstList().push_back(Malloc);
+  setDebugLoc(&block->back());
+  Malloc->insertAfter(&block->back());
   return Malloc;
 }
 

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -254,12 +254,13 @@ llvm::DIType *getPointerDebugType(llvm::DIType *ty, std::string typeName) {
   return Dbg->createTypedef(ptrType, typeName, DbgFile, 0, DbgCU);
 }
 
-llvm::DIType *getArrayDebugType(llvm::DIType *ty, size_t len, size_t align) {
+llvm::DIType *
+getArrayDebugType(llvm::DIType *ty, size_t len, llvm::Align align) {
   if (!Dbg)
     return nullptr;
   std::vector<llvm::Metadata *> subscripts;
   auto arr = Dbg->getOrCreateArray(subscripts);
-  return Dbg->createArrayType(len, align, ty, arr);
+  return Dbg->createArrayType(len, align.value(), ty, arr);
 }
 
 llvm::DIType *getShortDebugType(void) {

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -391,7 +391,7 @@ static std::pair<llvm::Value *, llvm::BasicBlock *> getEval(
         creator.getCurrentBlock(), llvm::Type::getInt64Ty(Ctx),
         result->getType(), llvm::ConstantExpr::getSizeOf(result->getType()),
         nullptr, nullptr);
-    creator.getCurrentBlock()->getInstList().push_back(Malloc);
+    Malloc->insertAfter(&creator.getCurrentBlock()->back());
     new llvm::StoreInst(result, Malloc, creator.getCurrentBlock());
     retval = new llvm::BitCastInst(
         Malloc, llvm::Type::getInt8PtrTy(Ctx), "", creator.getCurrentBlock());
@@ -399,7 +399,7 @@ static std::pair<llvm::Value *, llvm::BasicBlock *> getEval(
   }
   case SortCategory::Uncomputed: abort();
   }
-  creator.getCurrentBlock()->getInstList().push_back(inst);
+  inst->insertAfter(&creator.getCurrentBlock()->back());
   return std::make_pair(retval, creator.getCurrentBlock());
 }
 
@@ -552,7 +552,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
       llvm::Instruction *Malloc = llvm::CallInst::CreateMalloc(
           CaseBlock, llvm::Type::getInt64Ty(Ctx), compare->getType(),
           llvm::ConstantExpr::getSizeOf(compare->getType()), nullptr, nullptr);
-      CaseBlock->getInstList().push_back(Malloc);
+      Malloc->insertAfter(&CaseBlock->back());
       new llvm::StoreInst(compare, Malloc, CaseBlock);
       auto result = new llvm::BitCastInst(
           Malloc, llvm::Type::getInt8PtrTy(Ctx), "", CaseBlock);

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -150,7 +150,7 @@ static void emitDataTableForSymbol(
   initDebugGlobal(
       "table_" + name,
       getArrayDebugType(
-          dity, syms.size(), llvm::DataLayout(module).getABITypeAlignment(ty)),
+          dity, syms.size(), llvm::DataLayout(module).getABITypeAlign(ty)),
       globalVar);
   std::vector<llvm::Constant *> values;
   for (auto iter = syms.begin(); iter != syms.end(); ++iter) {
@@ -1220,7 +1220,7 @@ static void emitSortTable(KOREDefinition *definition, llvm::Module *module) {
   initDebugGlobal(
       "sort_table",
       getArrayDebugType(
-          dity, syms.size(), llvm::DataLayout(module).getABITypeAlignment(ty)),
+          dity, syms.size(), llvm::DataLayout(module).getABITypeAlign(ty)),
       globalVar);
   std::vector<llvm::Constant *> values;
   for (auto iter = syms.begin(); iter != syms.end(); ++iter) {
@@ -1239,7 +1239,7 @@ static void emitSortTable(KOREDefinition *definition, llvm::Module *module) {
         "sorts_" + symbol->getName(),
         getArrayDebugType(
             getCharPtrDebugType(), symbol->getArguments().size(),
-            llvm::DataLayout(module).getABITypeAlignment(
+            llvm::DataLayout(module).getABITypeAlign(
                 llvm::Type::getInt8PtrTy(Ctx))),
         subtableVar);
     llvm::Constant *zero


### PR DESCRIPTION
These methods are removed in LLVM 16; this PR migrates usages to more appropriate ones.