### PR TITLE
Update llvm-kompile-testing usage

### DIFF
--- a/bin/llvm-kompile-testing
+++ b/bin/llvm-kompile-testing
@@ -2,7 +2,7 @@
 set -e
 
 if [ $# -lt 2 ]; then
-  echo "Usage: $0 <definition.kore> [main|search|static|python] <clang flags>"
+  echo "Usage: $0 <definition.kore> [main|library|search|static|python|pythonast|c] <clang flags>"
   echo "See llvm-kompile -h for help"
   exit 1
 fi


### PR DESCRIPTION
Add options already supported by `llvm-testing`:
- `library`: generate an interpreter with no main function linked.
- `pythonast`: build a Python bindings module for the KORE AST structures only, without relying on a specific K definition.
- `c`: build a C bindings module rather than a standalone executable.