### PR TITLE
Add missing structural features to AST module

### DIFF
--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -108,7 +108,8 @@ void bind_ast(py::module_ &m) {
           py::init(&KORECompositeSort::Create), py::arg("name"),
           py::arg("cat") = ValueType{SortCategory::Uncomputed, 0})
       .def("add_argument", &KORECompositeSort::addArgument)
-      .def_property_readonly("name", &KORECompositeSort::getName);
+      .def_property_readonly("name", &KORECompositeSort::getName)
+      .def_property_readonly("arguments", &KORECompositeSort::getArguments);
 
   /* Symbols */
 
@@ -116,6 +117,11 @@ void bind_ast(py::module_ &m) {
       .def(py::init(&KORESymbol::Create))
       .def("__repr__", print_repr_adapter<KORESymbol>())
       .def("add_formal_argument", &KORESymbol::addFormalArgument)
+      .def_property_readonly(
+          "formal_arguments", &KORESymbol::getFormalArguments)
+      .def_property_readonly("name", &KORESymbol::getName)
+      .def_property_readonly("is_concrete", &KORESymbol::isConcrete)
+      .def_property_readonly("is_builtin", &KORESymbol::isBuiltin)
       .def(py::self == py::self)
       .def(py::self != py::self);
 
@@ -130,6 +136,7 @@ void bind_ast(py::module_ &m) {
       = py::class_<KOREPattern, std::shared_ptr<KOREPattern>>(ast, "Pattern")
             .def(py::init(&KOREPattern::load))
             .def("__repr__", print_repr_adapter<KOREPattern>())
+            .def_property_readonly("sort", &KOREPattern::getSort)
             .def("substitute", &KOREPattern::substitute);
 
   py::class_<KORECompositePattern, std::shared_ptr<KORECompositePattern>>(
@@ -138,13 +145,15 @@ void bind_ast(py::module_ &m) {
           &KORECompositePattern::Create)))
       .def(py::init(
           py::overload_cast<KORESymbol *>(&KORECompositePattern::Create)))
-      .def("add_argument", &KORECompositePattern::addArgument);
+      .def_property_readonly(
+          "constructor", &KORECompositePattern::getConstructor)
+      .def("add_argument", &KORECompositePattern::addArgument)
+      .def_property_readonly("arguments", &KORECompositePattern::getArguments);
 
   py::class_<KOREVariablePattern, std::shared_ptr<KOREVariablePattern>>(
       ast, "VariablePattern", pattern_base)
       .def(py::init(&KOREVariablePattern::Create))
-      .def_property_readonly("name", &KOREVariablePattern::getName)
-      .def_property_readonly("sort", &KOREVariablePattern::getSort);
+      .def_property_readonly("name", &KOREVariablePattern::getName);
 
   py::class_<KOREStringPattern, std::shared_ptr<KOREStringPattern>>(
       ast, "StringPattern", pattern_base)

--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -99,7 +99,8 @@ void bind_ast(py::module_ &m) {
 
   py::class_<KORESortVariable, std::shared_ptr<KORESortVariable>>(
       ast, "SortVariable", sort_base)
-      .def(py::init(&KORESortVariable::Create));
+      .def(py::init(&KORESortVariable::Create))
+      .def_property_readonly("name", &KORESortVariable::getName);
 
   py::class_<KORECompositeSort, std::shared_ptr<KORECompositeSort>>(
       ast, "CompositeSort", sort_base)

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -389,8 +389,8 @@ public:
   virtual sptr<KOREPattern> substitute(const substitution &) = 0;
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) = 0;
 
-  virtual void prettyPrint(std::ostream &, PrettyPrintData const &data) const
-      = 0;
+  virtual void
+  prettyPrint(std::ostream &, PrettyPrintData const &data) const = 0;
   virtual sptr<KOREPattern> sortCollections(PrettyPrintData const &data) = 0;
   std::set<std::string> gatherSingletonVars(void);
   virtual std::map<std::string, int> gatherVarCounts(void) = 0;

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -166,6 +166,8 @@ public:
   virtual void serialize_to(serializer &s) const override;
   virtual bool operator==(const KORESort &other) const override;
 
+  std::vector<sptr<KORESort>> const &getArguments() const { return arguments; }
+
 private:
   KORECompositeSort(const std::string &Name, ValueType category)
       : name(Name)

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -104,6 +104,8 @@ public:
 
   virtual bool operator==(const KORESort &other) const override;
 
+  std::string const &getName() const { return name; }
+
 private:
   KORESortVariable(const std::string &Name)
       : name(Name) { }
@@ -385,8 +387,8 @@ public:
   virtual sptr<KOREPattern> substitute(const substitution &) = 0;
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) = 0;
 
-  virtual void
-  prettyPrint(std::ostream &, PrettyPrintData const &data) const = 0;
+  virtual void prettyPrint(std::ostream &, PrettyPrintData const &data) const
+      = 0;
   virtual sptr<KOREPattern> sortCollections(PrettyPrintData const &data) = 0;
   std::set<std::string> gatherSingletonVars(void);
   virtual std::map<std::string, int> gatherVarCounts(void) = 0;

--- a/test/python/test_patterns.py
+++ b/test/python/test_patterns.py
@@ -23,10 +23,12 @@ class TestPatterns(unittest.TestCase):
 
         pat.add_argument(kllvm.ast.CompositePattern("X"))
         self.assertEqual(str(pat), "ABC{}(X{}())")
+        self.assertEqual(str(pat.arguments[0]), "X{}()")
 
         pat.add_argument(kllvm.ast.VariablePattern(
             "Z", kllvm.ast.CompositeSort("S")))
         self.assertEqual(str(pat), "ABC{}(X{}(),Z : S{})")
+        self.assertEqual(str(pat.arguments[1]), "Z : S{}")
 
         subbed = pat.substitute({"Z": kllvm.ast.CompositePattern("Target")})
         self.assertEqual(str(subbed), "ABC{}(X{}(),Target{}())")

--- a/test/python/test_sorts.py
+++ b/test/python/test_sorts.py
@@ -37,6 +37,9 @@ class TestSorts(unittest.TestCase):
 
         self.assertEqual(str(top), "Top{A{},B}")
 
+        self.assertEqual(top.arguments[0], a)
+        self.assertEqual(top.arguments[1], b)
+
     def test_substitution(self):
         a = kllvm.ast.SortVariable("A")
         target = kllvm.ast.CompositeSort("Target")

--- a/test/python/test_symbols.py
+++ b/test/python/test_symbols.py
@@ -10,9 +10,14 @@ class TestSymbols(unittest.TestCase):
     def test_str(self):
         sym = kllvm.ast.Symbol("Lbl'Plus")
         self.assertEqual(str(sym), "Lbl'Plus{}")
+        self.assertTrue(sym.is_concrete)
+        self.assertFalse(sym.is_builtin)
 
         sym.add_formal_argument(kllvm.ast.CompositeSort("A"))
         self.assertEqual(str(sym), "Lbl'Plus{A{}}")
+        self.assertTrue(sym.is_concrete)
+        self.assertFalse(sym.is_builtin)
+        self.assertEqual(sym.formal_arguments[0], kllvm.ast.CompositeSort("A"))
 
     def test_equal(self):
         a1 = kllvm.ast.Symbol("A")


### PR DESCRIPTION
This PR adds some missing bindings to the Python AST module to facilitate a conversion <-> the Pyk AST types. Lightweight tests are added for the new features.

Fixes https://github.com/runtimeverification/llvm-backend/issues/736