### PR TITLE
Fix mysterious unicode segfault

### DIFF
--- a/lib/codegen/CMakeLists.txt
+++ b/lib/codegen/CMakeLists.txt
@@ -11,5 +11,5 @@ add_library(Codegen
 )
 
 target_link_libraries(Codegen
-  PUBLIC  AST
+  PUBLIC  AST fmt::fmt
   PRIVATE base64)

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -5,6 +5,8 @@
 
 #include <base64/base64.h>
 
+#include <fmt/format.h>
+
 #include <yaml.h>
 
 #include <llvm/IR/DerivedTypes.h>
@@ -364,6 +366,9 @@ DecisionNode *parseYamlDecisionTreeFromString(
       &parser, (unsigned char *)yaml.c_str(), yaml.size());
   yaml_parser_load(&parser, &doc);
   yaml_node_t *root = yaml_document_get_root_node(&doc);
+  if (!root) {
+    throw std::runtime_error("Failed to parse decision tree from YAML string");
+  }
   auto result = DTPreprocessor(syms, sorts, mod, &doc)(root);
   yaml_document_delete(&doc);
   yaml_parser_delete(&parser);
@@ -381,6 +386,10 @@ DecisionNode *parseYamlDecisionTree(
   yaml_parser_set_input_file(&parser, f);
   yaml_parser_load(&parser, &doc);
   yaml_node_t *root = yaml_document_get_root_node(&doc);
+  if (!root) {
+    throw std::runtime_error(
+        fmt::format("Failed to parse decision tree from file: {}", filename));
+  }
   auto result = DTPreprocessor(syms, sorts, mod, &doc)(root);
   yaml_document_delete(&doc);
   yaml_parser_delete(&parser);
@@ -399,6 +408,10 @@ PartialStep parseYamlSpecialDecisionTree(
   yaml_parser_set_input_file(&parser, f);
   yaml_parser_load(&parser, &doc);
   yaml_node_t *root = yaml_document_get_root_node(&doc);
+  if (!root) {
+    throw std::runtime_error(fmt::format(
+        "Failed to parse special decision tree from file: {}", filename));
+  }
   auto pp = DTPreprocessor(syms, sorts, mod, &doc);
   auto dt = pp(pp.get(root, 0));
   auto result = pp.makeResiduals(pp.get(root, 1), dt);

--- a/test/defn/test-unicode.kore
+++ b/test/defn/test-unicode.kore
@@ -1,4 +1,4 @@
-// RUN: %interpreter
+// RUN: LC_ALL=en_US.UTF-8 %interpreter
 // RUN: %check-diff
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/sguest/work/k-test/emoji/emoji.k)")]
 


### PR DESCRIPTION
The issue is that on some systems `lit` defaults to the `POSIX` locale, which causes a segfault when decoding decision tree YAML. This PR fixes the issue by just forcing a UTF-8 locale for the new test case.

We can't really recover from the issue, but the PR also adds some nicer error reporting to prevent the confusing segfaults we were seeing previously.