### PR TITLE
Enforce UTF-8 for decision tree YAML

### DIFF
--- a/lib/codegen/CMakeLists.txt
+++ b/lib/codegen/CMakeLists.txt
@@ -11,5 +11,5 @@ add_library(Codegen
 )
 
 target_link_libraries(Codegen
-  PUBLIC  AST
+  PUBLIC  AST fmt::fmt
   PRIVATE base64)

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -5,6 +5,8 @@
 
 #include <base64/base64.h>
 
+#include <fmt/format.h>
+
 #include <yaml.h>
 
 #include <llvm/IR/DerivedTypes.h>
@@ -364,6 +366,9 @@ DecisionNode *parseYamlDecisionTreeFromString(
       &parser, (unsigned char *)yaml.c_str(), yaml.size());
   yaml_parser_load(&parser, &doc);
   yaml_node_t *root = yaml_document_get_root_node(&doc);
+  if (!root) {
+    throw std::runtime_error("Failed to parse decision tree from YAML string");
+  }
   auto result = DTPreprocessor(syms, sorts, mod, &doc)(root);
   yaml_document_delete(&doc);
   yaml_parser_delete(&parser);
@@ -381,6 +386,10 @@ DecisionNode *parseYamlDecisionTree(
   yaml_parser_set_input_file(&parser, f);
   yaml_parser_load(&parser, &doc);
   yaml_node_t *root = yaml_document_get_root_node(&doc);
+  if (!root) {
+    throw std::runtime_error(
+        fmt::format("Failed to parse decision tree from file: {}", filename));
+  }
   auto result = DTPreprocessor(syms, sorts, mod, &doc)(root);
   yaml_document_delete(&doc);
   yaml_parser_delete(&parser);
@@ -399,6 +408,10 @@ PartialStep parseYamlSpecialDecisionTree(
   yaml_parser_set_input_file(&parser, f);
   yaml_parser_load(&parser, &doc);
   yaml_node_t *root = yaml_document_get_root_node(&doc);
+  if (!root) {
+    throw std::runtime_error(fmt::format(
+        "Failed to parse special decision tree from file: {}", filename));
+  }
   auto pp = DTPreprocessor(syms, sorts, mod, &doc);
   auto dt = pp(pp.get(root, 0));
   auto result = pp.makeResiduals(pp.get(root, 1), dt);

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -362,6 +362,7 @@ DecisionNode *parseYamlDecisionTreeFromString(
   yaml_parser_t parser;
   yaml_document_t doc;
   yaml_parser_initialize(&parser);
+  yaml_parser_set_encoding(&parser, YAML_UTF8_ENCODING);
   yaml_parser_set_input_string(
       &parser, (unsigned char *)yaml.c_str(), yaml.size());
   yaml_parser_load(&parser, &doc);

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/dt/DecisionTree.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/dt/DecisionTree.scala
@@ -2,22 +2,29 @@ package org.kframework.backend.llvm.matching.dt
 
 import org.kframework.backend.llvm.matching.Occurrence
 import org.kframework.backend.llvm.matching.pattern._
-import java.io.File
-import java.io.FileWriter
+
+import java.io.{File, FileOutputStream, OutputStreamWriter}
 import java.util
 import java.util.concurrent.ConcurrentHashMap
-
 import org.yaml.snakeyaml.Yaml
+
+import java.nio.charset.Charset
 
 sealed trait DecisionTree {
   def serializeToYaml(file: File): Unit = {
-    val writer = new FileWriter(file)
+    val writer = new OutputStreamWriter(
+      new FileOutputStream(file),
+      Charset.forName("UTF-8").newEncoder()
+    );
     new Yaml().dump(representation, writer)
     writer.close()
   }
 
   def serializeToYaml(file: File, residuals: Seq[(Pattern[String], Occurrence)]): Unit = {
-    val writer = new FileWriter(file)
+    val writer = new OutputStreamWriter(
+      new FileOutputStream(file),
+      Charset.forName("UTF-8").newEncoder()
+    );
     val residualRepr = new util.ArrayList[AnyRef]()
     for (entry <- residuals) {
       val pair = new util.ArrayList[AnyRef]()

--- a/test/defn/test-unicode.kore
+++ b/test/defn/test-unicode.kore
@@ -1,4 +1,4 @@
-// RUN: %interpreter
+// RUN: LC_ALL=en_US.UTF-8 %interpreter
 // RUN: %check-diff
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/sguest/work/k-test/emoji/emoji.k)")]
 

--- a/test/defn/test-unicode.kore
+++ b/test/defn/test-unicode.kore
@@ -1,4 +1,4 @@
-// RUN: LC_ALL=en_US.UTF-8 %interpreter
+// RUN: %interpreter
 // RUN: %check-diff
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/sguest/work/k-test/emoji/emoji.k)")]
 


### PR DESCRIPTION
Previously, the decision tree YAML file was encoded based on the system locale, but `libyaml` would always try to read it as UTF-8 regardless. This caused segfaults on some systems, particularly due to `lit` setting the locale to `POSIX` in the testing environment.

This PR addresses this by explicitly setting the YAML file encoding to UTF-8 and adding error checking in case the read fails.