### PR TITLE
Add missing case to pattern matching for new-format rules

### DIFF
--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -157,6 +157,7 @@ object Parser {
       case Rewrites(s, And(_, Equals(_, _, pat, _), l), And(_, _, r)) => Some((None, B.Rewrites(s, l, r), Some(pat)))
       case Rewrites(s, And(_, l, Equals(_, _, pat, _)), And(_, r, _)) => Some((None, B.Rewrites(s, l, r), Some(pat)))
       case Rewrites(s, And(_, Top(_), l), And(_, _, r)) => Some((None, B.Rewrites(s, l, r), None))
+      case Rewrites(s, And(_, l, Top(_)), And(_, r, _)) => Some((None, B.Rewrites(s, l, r), None))
       case Rewrites(s, And(_, Not(_, _), And(_, Equals(_, _, pat, _), l)), And(_, _, r)) => Some((None, B.Rewrites(s, l, r), Some(pat)))
       case Rewrites(s, And(_, Not(_, _), And(_, Top(_), l)), And(_, _, r)) => Some((None, B.Rewrites(s, l, r), None))
       case Implies(_, Bottom(_), p) => splitTop(p)


### PR DESCRIPTION
This case corresponds to rules with no explicit side condition where the order of arguments has been swapped to support the new-format [no-antileft rewrites](https://github.com/runtimeverification/k/pull/3314).

The original change to support these rules added the corresponding case for rules _with_ side conditions, and the line added here was missing.

I will add a test to the frontend for this change while https://github.com/runtimeverification/llvm-backend/pull/745 is still in flight; once that is merged I will add the same test to the backend suite.

Fixes https://github.com/runtimeverification/llvm-backend/issues/747; I have confirmed by running the C semantics test suite with the new-format rewrites.