### PR TITLE
Delete `Hyph` translation as it's not part of KORE Syntax anymore

### DIFF
--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -40,7 +40,6 @@ std::string kllvm::decodeKore(std::string kore) {
     codes["Star"] = '*';
     codes["Plus"] = '+';
     codes["Comm"] = ',';
-    codes["Hyph"] = '-';
     codes["Stop"] = '.';
     codes["Slsh"] = '/';
     codes["Coln"] = ':';


### PR DESCRIPTION
This simple PR deletes the map of `Hyph` to `-` as the K frontend doesn't produce this token anymore, so the llvm backend doesn't need to translate it anymore.