### PR TITLE
Update `.gitignore` to ignore dev directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,12 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# VS Code Stuff
+.vscode/
+
+# CLion Stuff
+cmake-build-*
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore


### PR DESCRIPTION
Updating `.gitignore` file to ignore directories created by the IDES: CLion (from JetBrains) and VS Code (from Microsoft).