### PR TITLE
Reorganizing `set -x` calls for verbose execution

### DIFF
--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -69,7 +69,7 @@ Mandatory arguments to long options are mandatory for short options too.
   -i, --initializer INIT   Use INIT as the top cell initializer 
   -nm, --no-expand-macros  Don't expand macros in initial configuration
   -v, --verbose            Print major commands executed to standard error
-  -vv                      Print also commands executed by intermediate tools to
+  -vv                      Also print commands executed by intermediate tools to
                            standard error
   -vvv                     Print all commands executed by this script to
                            standard error
@@ -162,13 +162,13 @@ do
     ;;
 
     -vvv)
-    verbose+=3
-    shift;
+    verbose=$((verbose+=3))
+    shift
     ;;
 
     -vv)
-    verbose+=2
-    shift;
+    verbose=$((verbose+=2))
+    shift
     ;;
 
     -v|--verbose)
@@ -339,7 +339,6 @@ construct_binary_input()
     file_name="file_$param"
     binary_file_name="binary_$param"
 
-    set +e
     (
     if [ "$verbose" -ge 2 ]; then
       set -x

--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -162,18 +162,18 @@ do
     ;;
 
     -vvv)
-    verbose=$((verbose+=3))
+    verbose=$((verbose + 3))
     shift
     ;;
 
     -vv)
-    verbose=$((verbose+=2))
+    verbose=$((verbose + 2))
     shift
     ;;
 
     -v|--verbose)
-    verbose+=1
-    shift;
+    verbose=$((verbose + 1))
+    shift
     ;;
 
     -save-temps)

--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -204,7 +204,7 @@ for name in "${pretty[@]}"; do
   pretty_name="pretty_$name"
   set +e
   (
-  if [ $verbose -ge 1 ]; then
+  if [ "$verbose" -ge 1 ]; then
     set -x
   fi
   printf %s "${!pretty_name}" | "$dir/parser_$name" /dev/stdin > "$parser_file"
@@ -238,7 +238,7 @@ for name in "${params[@]}"; do
       temp_inputs+=("$temp_file")
 
       (
-      if [ $verbose -ge 2 ]; then
+      if [ "$verbose" -ge 2 ]; then
         set -x
       fi
       {
@@ -296,7 +296,7 @@ HERE
       cat "${!file_name}" >> "$input_file"
     elif [ -n "${!binary_file_name}" ]; then
       (
-      if [ $verbose -ge 5 ]; then
+      if [ "$verbose" -ge 5 ]; then
         set -x
       fi
       "$(dirname "$0")/kore-convert" "${!binary_file_name}" >> "$input_file"
@@ -320,7 +320,7 @@ construct_binary_input()
 {
   if [ ${#params[@]} -ne 0 ]; then
     (
-    if [ $verbose -ge 5 ]; then
+    if [ "$verbose" -ge 5 ]; then
       set -x
     fi
     echo "Lbl'Stop'Map{}()" | $convert_term >> "$input_file"
@@ -334,7 +334,7 @@ construct_binary_input()
 
     set +e
     (
-    if [ $verbose -ge 5 ]; then
+    if [ "$verbose" -ge 5 ]; then
       set -x
     fi
     echo "inj{SortKConfigVar{},SortKItem{}}(\dv{SortKConfigVar{}}(\"\$${param}\"))" \
@@ -343,7 +343,7 @@ construct_binary_input()
 
     if [ -n "${!file_name}" ]; then
       (
-      if [ $verbose -ge 5 ]; then
+      if [ "$verbose" -ge 5 ]; then
         set -x
       fi
       cat "${!file_name}" | $convert_term -k >> "$input_file"
@@ -353,7 +353,7 @@ construct_binary_input()
       temp_inputs+=("$temp_file")
 
       (
-      if [ $verbose -ge 3 ]; then
+      if [ "$verbose" -ge 3 ]; then
         set -x
       fi
       "$(dirname "$0")/kore-strip" -k -i "${!binary_file_name}" -o "$temp_file"
@@ -361,7 +361,7 @@ construct_binary_input()
       cat "$temp_file" >> "$input_file"
     else
       (
-      if [ $verbose -ge 5 ]; then
+      if [ "$verbose" -ge 5 ]; then
         set -x
       fi
       echo "${!var_name}" | $convert_term -k >> "$input_file"
@@ -369,7 +369,7 @@ construct_binary_input()
     fi
 
     (
-    if [ $verbose -ge 2 ]; then
+    if [ "$verbose" -ge 2 ]; then
       set -x
     fi
     {
@@ -383,14 +383,14 @@ construct_binary_input()
   done
 
   (
-  if [ $verbose -ge 5 ]; then
+  if [ "$verbose" -ge 5 ]; then
     set -x
   fi
   echo "$initializer()" | $convert_term -ka >> "$input_file"
   )
 
   (
-  if [ $verbose -ge 2 ]; then
+  if [ "$verbose" -ge 2 ]; then
     set -x
   fi
   "$(dirname "$0")/kore-arity" 1 >> "$input_file"
@@ -405,7 +405,7 @@ fi
 
 if $expandMacros; then
   (
-  if [ $verbose -ge 4 ]; then
+  if [ "$verbose" -ge 4 ]; then
     set -x
   fi
   "$(dirname "$0")/kore-expand-macros" "$dir" "$input_file" > "$expanded_input_file"
@@ -417,14 +417,14 @@ fi
 if $dryRun; then
   if [ $binary_input != $binary_output ] && [ -n "$real_output_file" ]; then
     (
-    if [ $verbose -ge 1 ]; then
+    if [ "$verbose" -ge 1 ]; then
       set -x
     fi
     "$(dirname "$0")/kore-convert" "$expanded_input_file" -o "$real_output_file"
     )
   elif [ $binary_input != $binary_output ]; then
     (
-    if [ $verbose -ge 1 ]; then
+    if [ "$verbose" -ge 1 ]; then
       set -x
     fi
     "$(dirname "$0")/kore-convert" -F "$expanded_input_file"
@@ -439,7 +439,7 @@ fi
 
 set +e
 (
-if [ $verbose -ge 1 ]; then
+if [ "$verbose" -ge 1 ]; then
   set -x
 fi
 $debug "$dir"/interpreter "$expanded_input_file" "$depth" "$output_file" "${interpreter_flags[@]}"
@@ -451,7 +451,7 @@ if [ -n "${real_output_file}" ]; then
   if $pretty_print; then
   set +e
   (
-  if [ $verbose -ge 1 ]; then
+  if [ "$verbose" -ge 1 ]; then
     set -x
   fi
   "$(dirname "$0")/kprint" "$dir" "$output_file" > "$real_output_file"
@@ -462,7 +462,7 @@ if [ -n "${real_output_file}" ]; then
 elif $pretty_print; then
   set +e
   (
-  if [ $verbose -ge 1 ]; then
+  if [ "$verbose" -ge 1 ]; then
     set -x
   fi
   "$(dirname "$0")/kprint" "$dir" "$output_file"

--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -19,6 +19,7 @@ initializer="LblinitGeneratedTopCell{}"
 dir=.
 debug=
 depth=-1
+verbose=0
 binary_input=false
 binary_output=false
 pretty_print=false
@@ -67,14 +68,11 @@ Mandatory arguments to long options are mandatory for short options too.
       --depth INT          Execute up to INT steps
   -i, --initializer INIT   Use INIT as the top cell initializer 
   -nm, --no-expand-macros  Don't expand macros in initial configuration
-  -v, --verbose            Print commands executed to standard error
-      --verbose-depth INT  Print commands executed by intermediate tools to
-                           standard error output as:
-                             * Level 1: Equals to --verbose
-                             * Level 2: Level 1 + kore-arity commands
-                             * Level 3: Level 2 + kore-strip commands
-                             * Level 4: Level 3 + kore-expand-macros commands
-                             * Level 5: Level 4 + all kore-convert commands
+  -v, --verbose            Print major commands executed to standard error
+  -vv                      Print also commands executed by intermediate tools to
+                           standard error
+  -vvv                     Print all commands executed by this script to
+                           standard error
       -save-temps          Do not delete temporary files on exit
   -h, --help               Display this help and exit
 HERE
@@ -163,13 +161,18 @@ do
     shift; shift
     ;;
 
-    --verbose-depth)
-    verbose="$2"
-    shift; shift
+    -vvv)
+    verbose+=3
+    shift;
+    ;;
+
+    -vv)
+    verbose+=2
+    shift;
     ;;
 
     -v|--verbose)
-    verbose=1
+    verbose+=1
     shift;
     ;;
 
@@ -194,6 +197,10 @@ do
     ;;
   esac
 done
+
+if [ "$verbose" -ge 3 ]; then
+  set -x
+fi
 
 if $binary_output; then
   interpreter_flags+=("--binary-output")
@@ -296,7 +303,7 @@ HERE
       cat "${!file_name}" >> "$input_file"
     elif [ -n "${!binary_file_name}" ]; then
       (
-      if [ "$verbose" -ge 5 ]; then
+      if [ "$verbose" -ge 2 ]; then
         set -x
       fi
       "$(dirname "$0")/kore-convert" "${!binary_file_name}" >> "$input_file"
@@ -320,7 +327,7 @@ construct_binary_input()
 {
   if [ ${#params[@]} -ne 0 ]; then
     (
-    if [ "$verbose" -ge 5 ]; then
+    if [ "$verbose" -ge 2 ]; then
       set -x
     fi
     echo "Lbl'Stop'Map{}()" | $convert_term >> "$input_file"
@@ -334,7 +341,7 @@ construct_binary_input()
 
     set +e
     (
-    if [ "$verbose" -ge 5 ]; then
+    if [ "$verbose" -ge 2 ]; then
       set -x
     fi
     echo "inj{SortKConfigVar{},SortKItem{}}(\dv{SortKConfigVar{}}(\"\$${param}\"))" \
@@ -343,7 +350,7 @@ construct_binary_input()
 
     if [ -n "${!file_name}" ]; then
       (
-      if [ "$verbose" -ge 5 ]; then
+      if [ "$verbose" -ge 2 ]; then
         set -x
       fi
       cat "${!file_name}" | $convert_term -k >> "$input_file"
@@ -353,7 +360,7 @@ construct_binary_input()
       temp_inputs+=("$temp_file")
 
       (
-      if [ "$verbose" -ge 3 ]; then
+      if [ "$verbose" -ge 2 ]; then
         set -x
       fi
       "$(dirname "$0")/kore-strip" -k -i "${!binary_file_name}" -o "$temp_file"
@@ -361,7 +368,7 @@ construct_binary_input()
       cat "$temp_file" >> "$input_file"
     else
       (
-      if [ "$verbose" -ge 5 ]; then
+      if [ "$verbose" -ge 2 ]; then
         set -x
       fi
       echo "${!var_name}" | $convert_term -k >> "$input_file"
@@ -383,16 +390,10 @@ construct_binary_input()
   done
 
   (
-  if [ "$verbose" -ge 5 ]; then
-    set -x
-  fi
-  echo "$initializer()" | $convert_term -ka >> "$input_file"
-  )
-
-  (
   if [ "$verbose" -ge 2 ]; then
     set -x
   fi
+  echo "$initializer()" | $convert_term -ka >> "$input_file"
   "$(dirname "$0")/kore-arity" 1 >> "$input_file"
   )
 }
@@ -405,7 +406,7 @@ fi
 
 if $expandMacros; then
   (
-  if [ "$verbose" -ge 4 ]; then
+  if [ "$verbose" -ge 2 ]; then
     set -x
   fi
   "$(dirname "$0")/kore-expand-macros" "$dir" "$input_file" > "$expanded_input_file"

--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -68,6 +68,13 @@ Mandatory arguments to long options are mandatory for short options too.
   -i, --initializer INIT   Use INIT as the top cell initializer 
   -nm, --no-expand-macros  Don't expand macros in initial configuration
   -v, --verbose            Print commands executed to standard error
+      --verbose-depth INT  Print commands executed by intermediate tools to
+                           standard error output as:
+                             * Level 1: Equals to --verbose
+                             * Level 2: Level 1 + kore-arity commands
+                             * Level 3: Level 2 + kore-strip commands
+                             * Level 4: Level 3 + kore-expand-macros commands
+                             * Level 5: Level 4 + all kore-convert commands
       -save-temps          Do not delete temporary files on exit
   -h, --help               Display this help and exit
 HERE
@@ -156,6 +163,11 @@ do
     shift; shift
     ;;
 
+    --verbose-depth)
+    verbose="$2"
+    shift; shift
+    ;;
+
     -v|--verbose)
     verbose=1
     shift;
@@ -192,7 +204,7 @@ for name in "${pretty[@]}"; do
   pretty_name="pretty_$name"
   set +e
   (
-  if [ -n "$verbose" ]; then
+  if [ $verbose -ge 1 ]; then
     set -x
   fi
   printf %s "${!pretty_name}" | "$dir/parser_$name" /dev/stdin > "$parser_file"
@@ -225,12 +237,16 @@ for name in "${params[@]}"; do
       temp_file="$(mktemp tmp.binary.XXXXXXXXXX)"
       temp_inputs+=("$temp_file")
 
+      (
+      if [ $verbose -ge 2 ]; then
+        set -x
+      fi
       {
         cat "${!binary_file_name}"
         echo "inj{Sort$sort{}, SortKItem{}}()" | $convert_term -ka
         "$(dirname "$0")/kore-arity" 1
       } >> "$temp_file"
-
+      )
       printf -v "$binary_file_name" %s "$temp_file"
     else
       printf -v "$var_name" %s "inj{Sort$sort{}, SortKItem{}}(${!var_name})"
@@ -279,7 +295,12 @@ HERE
     if [ -n "${!file_name}" ]; then
       cat "${!file_name}" >> "$input_file"
     elif [ -n "${!binary_file_name}" ]; then
+      (
+      if [ $verbose -ge 5 ]; then
+        set -x
+      fi
       "$(dirname "$0")/kore-convert" "${!binary_file_name}" >> "$input_file"
+      )
     else
       echo "${!var_name}" >> "$input_file"
     fi
@@ -298,7 +319,12 @@ HERE
 construct_binary_input()
 {
   if [ ${#params[@]} -ne 0 ]; then
+    (
+    if [ $verbose -ge 5 ]; then
+      set -x
+    fi
     echo "Lbl'Stop'Map{}()" | $convert_term >> "$input_file"
+    )
   fi
 
   for param in "${params[@]}"; do
@@ -306,21 +332,46 @@ construct_binary_input()
     file_name="file_$param"
     binary_file_name="binary_$param"
 
+    set +e
+    (
+    if [ $verbose -ge 5 ]; then
+      set -x
+    fi
     echo "inj{SortKConfigVar{},SortKItem{}}(\dv{SortKConfigVar{}}(\"\$${param}\"))" \
       | $convert_term -k >> "$input_file"
+    )
 
     if [ -n "${!file_name}" ]; then
+      (
+      if [ $verbose -ge 5 ]; then
+        set -x
+      fi
       cat "${!file_name}" | $convert_term -k >> "$input_file"
+      )
     elif [ -n "${!binary_file_name}" ]; then
       temp_file="$(mktemp tmp.concat.XXXXXXXXXX)"
       temp_inputs+=("$temp_file")
 
+      (
+      if [ $verbose -ge 3 ]; then
+        set -x
+      fi
       "$(dirname "$0")/kore-strip" -k -i "${!binary_file_name}" -o "$temp_file"
+      )
       cat "$temp_file" >> "$input_file"
     else
+      (
+      if [ $verbose -ge 5 ]; then
+        set -x
+      fi
       echo "${!var_name}" | $convert_term -k >> "$input_file"
+      )
     fi
 
+    (
+    if [ $verbose -ge 2 ]; then
+      set -x
+    fi
     {
       echo "Lbl'UndsPipe'-'-GT-Unds'{}()" | $convert_term -ka
       "$(dirname "$0")/kore-arity" 2
@@ -328,10 +379,22 @@ construct_binary_input()
       echo "Lbl'Unds'Map'Unds'{}()" | $convert_term -ka
       "$(dirname "$0")/kore-arity" 2
     } >> "$input_file"
+    )
   done
 
+  (
+  if [ $verbose -ge 5 ]; then
+    set -x
+  fi
   echo "$initializer()" | $convert_term -ka >> "$input_file"
+  )
+
+  (
+  if [ $verbose -ge 2 ]; then
+    set -x
+  fi
   "$(dirname "$0")/kore-arity" 1 >> "$input_file"
+  )
 }
 
 if $binary_input; then
@@ -341,7 +404,12 @@ else
 fi
 
 if $expandMacros; then
+  (
+  if [ $verbose -ge 4 ]; then
+    set -x
+  fi
   "$(dirname "$0")/kore-expand-macros" "$dir" "$input_file" > "$expanded_input_file"
+  )
 else
   cp "$input_file" "$expanded_input_file"
 fi
@@ -349,14 +417,14 @@ fi
 if $dryRun; then
   if [ $binary_input != $binary_output ] && [ -n "$real_output_file" ]; then
     (
-    if [ -n "$verbose" ]; then
+    if [ $verbose -ge 1 ]; then
       set -x
     fi
     "$(dirname "$0")/kore-convert" "$expanded_input_file" -o "$real_output_file"
     )
   elif [ $binary_input != $binary_output ]; then
     (
-    if [ -n "$verbose" ]; then
+    if [ $verbose -ge 1 ]; then
       set -x
     fi
     "$(dirname "$0")/kore-convert" -F "$expanded_input_file"
@@ -371,7 +439,7 @@ fi
 
 set +e
 (
-if [ -n "$verbose" ]; then
+if [ $verbose -ge 1 ]; then
   set -x
 fi
 $debug "$dir"/interpreter "$expanded_input_file" "$depth" "$output_file" "${interpreter_flags[@]}"
@@ -383,7 +451,7 @@ if [ -n "${real_output_file}" ]; then
   if $pretty_print; then
   set +e
   (
-  if [ -n "$verbose" ]; then
+  if [ $verbose -ge 1 ]; then
     set -x
   fi
   "$(dirname "$0")/kprint" "$dir" "$output_file" > "$real_output_file"
@@ -394,7 +462,7 @@ if [ -n "${real_output_file}" ]; then
 elif $pretty_print; then
   set +e
   (
-  if [ -n "$verbose" ]; then
+  if [ $verbose -ge 1 ]; then
     set -x
   fi
   "$(dirname "$0")/kprint" "$dir" "$output_file"


### PR DESCRIPTION
Fixes #754 

A simple PR  to improve the `--verbose` use on `llvm-krun` by outputting more steps of the execution process!