### PR TITLE
Fix minor memory leaks

### DIFF
--- a/bindings/c/lib.cpp
+++ b/bindings/c/lib.cpp
@@ -127,11 +127,13 @@ kore_pattern *kore_pattern_make_interpreter_input(
   auto config_sort = kore_composite_sort_new("SortKConfigVar");
   auto kitem_sort = kore_composite_sort_new("SortKItem");
 
-  auto key = kore_pattern_new_injection(
-      kore_pattern_new_token("$PGM", config_sort), config_sort, kitem_sort);
+  auto pgm_token = kore_pattern_new_token("$PGM", config_sort);
+  auto key = kore_pattern_new_injection(pgm_token, config_sort, kitem_sort);
+  kore_pattern_free(pgm_token);
 
   auto map_item = kore_composite_pattern_new("Lbl'UndsPipe'-'-GT-Unds'");
   kore_composite_pattern_add_argument(map_item, key);
+  kore_pattern_free(key);
 
   if (kore_sort_is_kitem(sort)) {
     kore_composite_pattern_add_argument(map_item, pgm);
@@ -173,7 +175,7 @@ char *kore_block_dump(block *term) {
   auto hooked_str = printConfigurationToString(term)->data;
   auto len = std::strlen(hooked_str);
 
-  auto new_str = static_cast<char *>(malloc(len * sizeof(char)));
+  auto new_str = static_cast<char *>(malloc((len + 1) * sizeof(char)));
   std::strncpy(new_str, hooked_str, len);
   new_str[len] = '\0';
 

--- a/test/c/Inputs/remove_assoc.c
+++ b/test/c/Inputs/remove_assoc.c
@@ -1,6 +1,7 @@
 #include "api.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #define N_ARGS 3
 
@@ -17,6 +18,7 @@ kore_pattern *make_list_item(struct kllvm_c_api *api, char const *arg) {
   api->kore_pattern_free(token);
   api->kore_pattern_free(inj);
   api->kore_sort_free(sort_int);
+  api->kore_sort_free(sort_kitem);
 
   return list_item;
 }
@@ -40,8 +42,9 @@ int main(int argc, char **argv) {
   kore_pattern *assoc = api.kore_composite_pattern_new("\\left-assoc");
 
   for (int i = 0; i < N_ARGS; ++i) {
-    api.kore_composite_pattern_add_argument(
-        concat, make_list_item(&api, args[i]));
+    kore_pattern *list_item = make_list_item(&api, args[i]);
+    api.kore_composite_pattern_add_argument(concat, list_item);
+    api.kore_pattern_free(list_item);
   }
 
   api.kore_composite_pattern_add_argument(assoc, concat);
@@ -53,5 +56,14 @@ int main(int argc, char **argv) {
   block *term = api.kore_pattern_construct(desugared);
   block *after = api.take_steps(-1, term);
 
-  printf("%s", api.kore_block_dump(after));
+  char *output = api.kore_block_dump(after);
+  printf("%s", output);
+  free(output);
+
+  api.kore_pattern_free(run);
+  api.kore_pattern_free(concat);
+  api.kore_pattern_free(assoc);
+  api.kore_pattern_free(input);
+  api.kore_pattern_free(desugared);
+  api.kore_sort_free(sort_foo);
 }


### PR DESCRIPTION
While debugging https://github.com/runtimeverification/llvm-backend/issues/770, I found a few small memory leaks in the C bindings and associated tests. This PR cleans up places where we were not properly freeing temporary objects.

The fixes are unrelated to the Python bindings, but allow me to check that nothing obvious is being leaked by the underlying associative desugaring code.