### PR TITLE
Improving `get_ui` error message

### DIFF
--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -71,7 +71,7 @@ SortInt hook_BYTES_bytes2int(
   return move_int(result);
 }
 
-unsigned long get_ui_named(mpz_t i, std::string const& caller) {
+unsigned long get_ui_named(mpz_t i, std::string const &caller) {
   if (!mpz_fits_ulong_p(i)) {
     std::string const error_msg
         = "Integer overflow from " + caller + ": " + intToString(i);

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -10,6 +10,8 @@
 
 extern "C" {
 
+#undef get_ui
+#define get_ui(x) get_ui_named(x, __PRETTY_FUNCTION__)
 #define KCHAR char
 
 mpz_ptr move_int(mpz_t);
@@ -69,9 +71,10 @@ SortInt hook_BYTES_bytes2int(
   return move_int(result);
 }
 
-unsigned long get_ui(mpz_t i) {
+unsigned long get_ui_named(mpz_t i, std::string caller) {
   if (!mpz_fits_ulong_p(i)) {
-    KLLVM_HOOK_INVALID_ARGUMENT("Integer overflow");
+    KLLVM_HOOK_INVALID_ARGUMENT(
+        "Integer overflow from " + caller + ": ", intToString(i));
   }
   return mpz_get_ui(i);
 }

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -11,7 +11,7 @@
 extern "C" {
 
 #undef get_ui
-#define get_ui(x) get_ui_named(x, __PRETTY_FUNCTION__)
+#define get_ui(x) get_ui_named(x, __func__)
 #define KCHAR char
 
 mpz_ptr move_int(mpz_t);
@@ -71,10 +71,11 @@ SortInt hook_BYTES_bytes2int(
   return move_int(result);
 }
 
-unsigned long get_ui_named(mpz_t i, std::string caller) {
+unsigned long get_ui_named(mpz_t i, std::string const& caller) {
   if (!mpz_fits_ulong_p(i)) {
-    KLLVM_HOOK_INVALID_ARGUMENT(
-        "Integer overflow from " + caller + ": ", intToString(i));
+    std::string const error_msg
+        = "Integer overflow from " + caller + ": " + intToString(i);
+    KLLVM_HOOK_INVALID_ARGUMENT(error_msg);
   }
   return mpz_get_ui(i);
 }

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -73,9 +73,8 @@ SortInt hook_BYTES_bytes2int(
 
 unsigned long get_ui_named(mpz_t i, std::string const &caller) {
   if (!mpz_fits_ulong_p(i)) {
-    std::string const error_msg
-        = "Integer overflow from " + caller + ": " + intToString(i);
-    KLLVM_HOOK_INVALID_ARGUMENT(error_msg);
+    KLLVM_HOOK_INVALID_ARGUMENT(
+        "Integer overflow from {}: {}", caller, intToString(i));
   }
   return mpz_get_ui(i);
 }


### PR DESCRIPTION
Fixes #771 

This simple PR modifies the `get_ui` function to `get_ui_named` while keeping its interface the same as the previous one. The new function receives a string representing the name of the caller function that will be used to improve the error message if the integer has an overflow!