### PR TITLE
Expose GC to python bindings

### DIFF
--- a/bindings/python/runtime.cpp
+++ b/bindings/python/runtime.cpp
@@ -11,7 +11,7 @@ namespace py = pybind11;
 using namespace kllvm;
 
 extern "C" {
-void freeAllKoreMem(void);
+void resetMemory(void);
 }
 
 /*
@@ -71,7 +71,7 @@ void bind_runtime(py::module_ &m) {
         return std::shared_ptr<kllvm::KOREPattern>(raw_ptr);
       });
 
-  m.def("free_all_kore_memory", &freeAllKoreMem);
+  m.def("free_all_kllvm_memory", &resetMemory);
 }
 
 PYBIND11_MODULE(_kllvm_runtime, m) {

--- a/bindings/python/runtime.cpp
+++ b/bindings/python/runtime.cpp
@@ -10,6 +10,10 @@ namespace py = pybind11;
 
 using namespace kllvm;
 
+extern "C" {
+void freeAllKoreMem(void);
+}
+
 /*
  * We can't use the pybind default holders because they'll try to take ownership
  * of the runtime's objects. This is the minimum viable holder that does _not_
@@ -66,6 +70,8 @@ void bind_runtime(py::module_ &m) {
             = static_cast<kllvm::KOREPattern *>(termToKorePattern(term));
         return std::shared_ptr<kllvm::KOREPattern>(raw_ptr);
       });
+
+  m.def("free_all_kore_memory", &freeAllKoreMem);
 }
 
 PYBIND11_MODULE(_kllvm_runtime, m) {

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -148,4 +148,11 @@ __attribute__((always_inline)) void *koreAllocFloatingOld(size_t requested) {
   set_len(result, sizeof(floating_hdr) - sizeof(blockheader));
   return &result->f;
 }
+
+void resetMemory() {
+  freeAllMemory();
+  arenaReset(&youngspace);
+  arenaReset(&oldspace);
+  arenaReset(&alwaysgcspace);
+}
 }

--- a/test/python/test_steps.py
+++ b/test/python/test_steps.py
@@ -43,6 +43,8 @@ class TestSteps(unittest.TestCase):
         t.step(200)
         self.assertEqual(str(t), bar_output())
 
+        kllvm.runtime.free_all_kore_memory()
+
     def test_steps_2(self):
         t = kllvm.runtime.Term(start_pattern())
 
@@ -51,6 +53,8 @@ class TestSteps(unittest.TestCase):
         self.assertEqual(str(t), foo_output(50))
         t.step(-1)
         self.assertEqual(str(t), bar_output())
+
+        kllvm.runtime.free_all_kore_memory()
 
     def test_steps_3(self):
         t = kllvm.runtime.Term(start_pattern())
@@ -62,6 +66,8 @@ class TestSteps(unittest.TestCase):
         t.run()
         pat = t.to_pattern()
         self.assertEqual(str(pat), bar_output())
+
+        kllvm.runtime.free_all_kore_memory()
 
 
 if __name__ == "__main__":

--- a/test/python/test_steps.py
+++ b/test/python/test_steps.py
@@ -43,7 +43,7 @@ class TestSteps(unittest.TestCase):
         t.step(200)
         self.assertEqual(str(t), bar_output())
 
-        kllvm.runtime.free_all_kore_memory()
+        kllvm.runtime.free_all_kllvm_memory()
 
     def test_steps_2(self):
         t = kllvm.runtime.Term(start_pattern())
@@ -54,7 +54,7 @@ class TestSteps(unittest.TestCase):
         t.step(-1)
         self.assertEqual(str(t), bar_output())
 
-        kllvm.runtime.free_all_kore_memory()
+        kllvm.runtime.free_all_kllvm_memory()
 
     def test_steps_3(self):
         t = kllvm.runtime.Term(start_pattern())
@@ -67,7 +67,7 @@ class TestSteps(unittest.TestCase):
         pat = t.to_pattern()
         self.assertEqual(str(pat), bar_output())
 
-        kllvm.runtime.free_all_kore_memory()
+        kllvm.runtime.free_all_kllvm_memory()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a function `free_all_kore_memory` to the KLLVM runtime module. Calling this function will run the garbage collector once, freeing backend terms that are no longer live.

Calls are added to the existing Python test that takes execution steps to ensure that we can call the function properly.