### PR TITLE
Deserialize pattern variables correctly

### DIFF
--- a/docs/binary-kore.md
+++ b/docs/binary-kore.md
@@ -107,6 +107,14 @@ Composite patterns encode each of their arguments (recursively, following this
 schema), then the constructor symbol (as described above). These are followed by
 the byte `04`, and a variable-length arity for the pattern.
 
+Pattern variables encode their sort argument, followed by the byte `09`, then a
+variable as described below.
+
+### Variables
+
+KORE variables are encoded as the byte `0D`, followed by a string representing
+the variable name.
+
 ## Manipulating Binary Terms
 
 This binary format is designed for easy composition through concatenation. To do

--- a/include/kllvm/binary/deserializer.h
+++ b/include/kllvm/binary/deserializer.h
@@ -186,6 +186,16 @@ sptr<KOREPattern> read(It &ptr, It end, binary_version version) {
       break;
     }
 
+    case header_byte<KOREVariablePattern>: {
+      ++ptr;
+      auto name = read_variable(ptr, end, version);
+      auto sort = sort_stack.back();
+      sort_stack.pop_back();
+
+      term_stack.push_back(KOREVariablePattern::Create(name->getName(), sort));
+      break;
+    }
+
     case header_byte<KORESymbol>: {
       ++ptr;
       symbol = read_symbol(ptr, end, sort_stack, version);

--- a/test/binary/variable_1.kore
+++ b/test/binary/variable_1.kore
@@ -1,0 +1,5 @@
+// RUN: %kore-convert %s -o %t.binary
+// RUN: %kore-convert %s -o %t.ref --to=text
+// RUN: %kore-convert %t.binary -o %t.kore
+// RUN: diff %t.kore %t.ref
+X : S

--- a/test/binary/variable_2.kore
+++ b/test/binary/variable_2.kore
@@ -1,0 +1,5 @@
+// RUN: %kore-convert %s -o %t.binary
+// RUN: %kore-convert %s -o %t.ref --to=text
+// RUN: %kore-convert %t.binary -o %t.kore
+// RUN: diff %t.kore %t.ref
+Xefj : SortInt{}


### PR DESCRIPTION
There was a missing case in the binary deserializer that meant we couldn't deserialize pattern variables (`X : Sort`) properly. This PR implements, tests and documents the missing case.

No change to the format version is required as the serializer was already handling this case properly, and all existing files that were previously valid remain so.

Fixes #779 