### PR TITLE
Fix for small papercuts in hook interface

### DIFF
--- a/include/runtime/alloc.h
+++ b/include/runtime/alloc.h
@@ -1,6 +1,8 @@
 #ifndef ALLOC_H
 #define ALLOC_H
 
+#include <cstddef>
+
 extern "C" {
 
 // The maximum single allocation size in bytes.

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -324,6 +324,8 @@ size_t hook_SET_size_long(set *);
 
 mpz_ptr hook_MINT_import(size_t *i, uint64_t bits, bool isSigned);
 
+block *dot_k();
+
 block *debruijnize(block *);
 block *incrementDebruijn(block *);
 block *alphaRename(block *);

--- a/runtime/util/util.cpp
+++ b/runtime/util/util.cpp
@@ -1,6 +1,11 @@
 #include "runtime/header.h"
 
 extern "C" {
+
+block *dot_k() {
+  return leaf_block(getTagForSymbolName("dotk{}"));
+}
+
 bool is_injection(block *term) {
   auto tag = tag_hdr(term->h.hdr);
   return tag >= first_inj_tag && tag <= last_inj_tag;


### PR DESCRIPTION
While working on a minimal hook implementation, I identified the following papercuts in usage of the LLVM backend:
* `size_t` is not defined when including `alloc.h`
* Users need to define their own `dotK` block-getter - this is a common enough task we should put it in the backend.