### PR TITLE
Stub implementation of `constructCompositePattern`

### DIFF
--- a/unittests/runtime-ffi/ffi.cpp
+++ b/unittests/runtime-ffi/ffi.cpp
@@ -13,6 +13,11 @@
 
 #define KCHAR char
 #define TYPETAG(type) "Lbl'Hash'ffi'Unds'" #type "{}"
+
+void *constructCompositePattern(uint32_t tag, std::vector<void *> &arguments) {
+  return nullptr;
+}
+
 extern "C" {
 
 struct point {

--- a/unittests/runtime-io/io.cpp
+++ b/unittests/runtime-io/io.cpp
@@ -13,6 +13,11 @@
 #include "unistd.h"
 
 #define KCHAR char
+
+void *constructCompositePattern(uint32_t tag, std::vector<void *> &arguments) {
+  return nullptr;
+}
+
 extern "C" {
 
 char kompiled_directory[] = "some/test/directory/path";

--- a/unittests/runtime-strings/stringtest.cpp
+++ b/unittests/runtime-strings/stringtest.cpp
@@ -11,6 +11,11 @@
 #include "runtime/header.h"
 
 #define KCHAR char
+
+void *constructCompositePattern(uint32_t tag, std::vector<void *> &arguments) {
+  return nullptr;
+}
+
 extern "C" {
 bool hook_STRING_gt(string *, string *);
 bool hook_STRING_ge(string *, string *);


### PR DESCRIPTION
This change adds an extra stub to the unit test implementations that require it to placate the linker.