### PR TITLE
Bump `install-nix-action`

### DIFF
--- a/.github/workflows/test-flake.yml
+++ b/.github/workflows/test-flake.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: 'Install Nix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/install-nix-action@v19
+        uses: cachix/install-nix-action@v22
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,7 +23,7 @@ jobs:
           git config --global user.email devops@runtimeverification.com
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v19
+        uses: cachix/install-nix-action@v22
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |


### PR DESCRIPTION
We had to do this on K recently to avoid the "System Integrity Protection" issue in CI when installing Nix; this PR propagates the same change over to the LLVM backend.