### PR TITLE
Convert `runtime.h` macros to real functions

### DIFF
--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -37,8 +37,6 @@ struct MatchLog {
 
 // the actual length is equal to the block header with the gc bits masked out.
 
-#define len(s) len_hdr((s)->h.hdr)
-#define len_hdr(s) ((s)&LENGTH_MASK)
 #define set_len(s, l)                                                          \
   ((s)->h.hdr                                                                  \
    = (l) | (l > BLOCK_SIZE - sizeof(char *) ? NOT_YOUNG_OBJECT_BIT : 0))
@@ -129,6 +127,21 @@ void k_hash(block *, void *);
 bool hash_enter(void);
 void hash_exit(void);
 }
+
+#define KLLVM_FORCE_INLINE [[gnu::always_inline, gnu::artificial]]
+#define KLLVM_CONSTEXPR KLLVM_FORCE_INLINE inline constexpr
+
+KLLVM_CONSTEXPR uint64_t len_hdr(uint64_t hdr) {
+  return hdr & LENGTH_MASK;
+}
+
+template <typename T>
+KLLVM_CONSTEXPR uint64_t len(T const *s) {
+  return len_hdr(s->h.hdr);
+}
+
+#undef KLLVM_CONSTEXPR
+#undef KLLVM_FORCE_INLINE
 
 class KElem {
 public:

--- a/runtime/collections/hash.cpp
+++ b/runtime/collections/hash.cpp
@@ -63,11 +63,11 @@ void hash_exit() {
 void k_hash(block *arg, void *h) {
   if (hash_enter()) {
     uint64_t argintptr = (uint64_t)arg;
-    if (is_leaf_block(argintptr)) {
+    if (is_leaf_block(arg)) {
       add_hash64(h, argintptr);
     } else {
       uint64_t arghdrcanon = arg->h.hdr & HDR_MASK;
-      if (uint16_t arglayout = layout(arg)) {
+      if (uint16_t arglayout = get_layout(arg)) {
         add_hash64(h, arghdrcanon);
         layout *layoutPtr = getLayoutData(arglayout);
         uint8_t length = layoutPtr->nargs;

--- a/runtime/collections/kelemle.cpp
+++ b/runtime/collections/kelemle.cpp
@@ -12,8 +12,8 @@ bool hook_STRING_lt(SortString, SortString);
 bool hook_KEQUAL_eq(block *arg1, block *arg2) {
   uint64_t arg1intptr = (uint64_t)arg1;
   uint64_t arg2intptr = (uint64_t)arg2;
-  bool arg1lb = is_leaf_block(arg1intptr);
-  bool arg2lb = is_leaf_block(arg2intptr);
+  bool arg1lb = is_leaf_block(arg1);
+  bool arg2lb = is_leaf_block(arg2);
   if (arg1lb == arg2lb) {
     if (arg1lb) {
       // Both arg1 and arg2 are constants.
@@ -25,7 +25,7 @@ bool hook_KEQUAL_eq(block *arg1, block *arg2) {
       if (arg1hdrcanon == arg2hdrcanon) {
         // Canonical headers of arg1 and arg2 are equal.
         // Both arg1 and arg2 are either strings or symbols.
-        uint64_t arglayout = layout(arg1);
+        uint64_t arglayout = get_layout(arg1);
         if (arglayout == 0) {
           // Both arg1 and arg2 are strings.
           return hook_STRING_eq((string *)arg1, (string *)arg2);
@@ -150,8 +150,8 @@ bool hook_KEQUAL_eq(block *arg1, block *arg2) {
 bool hook_KEQUAL_lt(block *arg1, block *arg2) {
   uint64_t arg1intptr = (uint64_t)arg1;
   uint64_t arg2intptr = (uint64_t)arg2;
-  bool isconstant1 = is_leaf_block(arg1intptr);
-  bool isconstant2 = is_leaf_block(arg2intptr);
+  bool isconstant1 = is_leaf_block(arg1);
+  bool isconstant2 = is_leaf_block(arg2);
   if (isconstant1 != isconstant2) {
     // Between arg1 and arg2, one is a constant and one is not.
     return isconstant1;
@@ -160,8 +160,8 @@ bool hook_KEQUAL_lt(block *arg1, block *arg2) {
     return arg1intptr < arg2intptr;
   } else {
     // Both arg1 and arg2 are blocks.
-    uint16_t arg1layout = layout(arg1);
-    uint16_t arg2layout = layout(arg2);
+    uint16_t arg1layout = get_layout(arg1);
+    uint16_t arg2layout = get_layout(arg2);
     if (arg1layout == 0 && arg2layout == 0) {
       // Both arg1 and arg2 are strings.
       return hook_STRING_lt((string *)arg1, (string *)arg2);

--- a/runtime/meta/substitution.cpp
+++ b/runtime/meta/substitution.cpp
@@ -105,9 +105,8 @@ block *debruijnizeInternal(block *currBlock) {
 }
 
 block *replaceBinderInternal(block *currBlock) {
-  uintptr_t ptr = (uintptr_t)currBlock;
-  if (is_variable_block(ptr)) {
-    uint64_t varIdx = ptr >> 32;
+  if (is_variable_block(currBlock)) {
+    uint64_t varIdx = ((uintptr_t)currBlock) >> 32;
     if (idx == varIdx) {
       return (block *)var;
     } else if (idx < varIdx) {
@@ -116,7 +115,7 @@ block *replaceBinderInternal(block *currBlock) {
     } else {
       return currBlock;
     }
-  } else if (is_leaf_block(ptr)) {
+  } else if (is_leaf_block(currBlock)) {
     return currBlock;
   }
   const uint64_t hdr = currBlock->h.hdr;
@@ -278,7 +277,7 @@ block *substituteInternal(block *currBlock) {
 extern "C" {
 
 block *debruijnize(block *term) {
-  auto layoutData = getLayoutData(layout(term));
+  auto layoutData = getLayoutData(get_layout(term));
   auto layoutVar = layoutData->args[0];
   auto layoutBody = layoutData->args[layoutData->nargs - 1];
   var = *(string **)(((char *)term) + layoutVar.offset);
@@ -296,16 +295,15 @@ block *debruijnize(block *term) {
 }
 
 block *incrementDebruijn(block *currBlock) {
-  uintptr_t ptr = (uintptr_t)currBlock;
-  if (is_variable_block(ptr)) {
-    uint64_t varIdx = ptr >> 32;
+  if (is_variable_block(currBlock)) {
+    uint64_t varIdx = ((uintptr_t)currBlock) >> 32;
     if (varIdx >= idx2) {
       varIdx += idx;
       return variable_block(varIdx);
     } else {
       return currBlock;
     }
-  } else if (is_leaf_block(ptr)) {
+  } else if (is_leaf_block(currBlock)) {
     return currBlock;
   }
   const uint64_t hdr = currBlock->h.hdr;

--- a/runtime/meta/substitution.cpp
+++ b/runtime/meta/substitution.cpp
@@ -376,10 +376,10 @@ block *incrementDebruijn(block *currBlock) {
 
 block *alphaRename(block *term) {
   string *var = (string *)term;
-  size_t len = len(var);
-  auto newToken = (string *)koreAllocToken(sizeof(string) + len);
-  memcpy(newToken->data, var->data, len);
-  set_len(newToken, len);
+  size_t var_len = len(var);
+  auto newToken = (string *)koreAllocToken(sizeof(string) + var_len);
+  memcpy(newToken->data, var->data, var_len);
+  set_len(newToken, var_len);
   newToken->h.hdr |= VARIABLE_BIT;
   return (block *)newToken;
 }

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -188,8 +188,8 @@ SortInt hook_BYTES_length(SortBytes a) {
   return move_int(result);
 }
 
-SortBytes hook_BYTES_padRight(SortBytes b, SortInt len, SortInt v) {
-  unsigned long ulen = get_ui(len);
+SortBytes hook_BYTES_padRight(SortBytes b, SortInt length, SortInt v) {
+  unsigned long ulen = get_ui(length);
   if (ulen <= len(b)) {
     return b;
   }
@@ -204,8 +204,8 @@ SortBytes hook_BYTES_padRight(SortBytes b, SortInt len, SortInt v) {
   return result;
 }
 
-SortBytes hook_BYTES_padLeft(SortBytes b, SortInt len, SortInt v) {
-  unsigned long ulen = get_ui(len);
+SortBytes hook_BYTES_padLeft(SortBytes b, SortInt length, SortInt v) {
+  unsigned long ulen = get_ui(length);
   if (ulen <= len(b)) {
     return b;
   }

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -206,13 +206,13 @@ SortString hook_STRING_base2string_long(SortInt input, uint64_t base) {
   // Include the null terminator in size calculations relating to allocation,
   // but not when setting the length of the string object itself. Any minus
   // signs will have been accounted for already by the intToString call.
-  auto len = str.size() + 1;
-  auto result = static_cast<string *>(koreAllocToken(sizeof(string) + len));
-  strncpy(result->data, str.c_str(), len);
+  auto str_len = str.size() + 1;
+  auto result = static_cast<string *>(koreAllocToken(sizeof(string) + str_len));
+  strncpy(result->data, str.c_str(), str_len);
   set_len(result, str.size());
 
   return static_cast<string *>(koreResizeLastAlloc(
-      result, sizeof(string) + len(result), sizeof(string) + len));
+      result, sizeof(string) + len(result), sizeof(string) + str_len));
 }
 
 SortInt hook_STRING_string2base_long(SortString input, uint64_t base) {

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -277,7 +277,7 @@ SortString hook_STRING_token2string(string *input) {
     input = (string *)strip_injection(in_block);
   }
 
-  if (layout(input) != 0) {
+  if (get_layout(input) != 0) {
     KLLVM_HOOK_INVALID_ARGUMENT(
         "token2string: input is not a string token: {}",
         std::string(input->data));

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -62,7 +62,7 @@ void *constructCompositePattern(uint32_t tag, std::vector<void *> &arguments) {
     layout *data = getLayoutData(layout_code);
     if (data->args[0].cat == SYMBOL_LAYOUT) {
       block *child = (block *)arguments[0];
-      if (!is_leaf_block(child) && layout(child) != 0) {
+      if (!is_leaf_block(child) && get_layout(child) != 0) {
         uint32_t tag = tag_hdr(child->h.hdr);
         if (tag >= first_inj_tag && tag <= last_inj_tag) {
           return child;

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -140,9 +140,9 @@ void printConfigurationInternal(
   uint16_t layout = layout(subject);
   if (!layout) {
     string *str = (string *)subject;
-    size_t len = len(subject);
+    size_t subject_len = len(subject);
     sfprintf(file, "\\dv{%s}(\"", sort);
-    for (size_t i = 0; i < len; ++i) {
+    for (size_t i = 0; i < subject_len; ++i) {
       char c = str->data[i];
       switch (c) {
       case '\\': sfprintf(file, "\\\\"); break;

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -137,7 +137,7 @@ void printConfigurationInternal(
     sfprintf(file, "%s()", symbol);
     return;
   }
-  uint16_t layout = layout(subject);
+  uint16_t layout = get_layout(subject);
   if (!layout) {
     string *str = (string *)subject;
     size_t subject_len = len(subject);

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -284,7 +284,7 @@ void serializeConfigurationInternal(
     return;
   }
 
-  uint16_t layout = layout(subject);
+  uint16_t layout = get_layout(subject);
   if (!layout) {
     string *str = (string *)subject;
     size_t subject_len = len(subject);

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -287,7 +287,7 @@ void serializeConfigurationInternal(
   uint16_t layout = layout(subject);
   if (!layout) {
     string *str = (string *)subject;
-    size_t len = len(subject);
+    size_t subject_len = len(subject);
 
     if (isVar && !state.varNames.count(str)) {
       std::string stdStr = std::string(str->data, len(str));
@@ -302,7 +302,7 @@ void serializeConfigurationInternal(
     } else if (isVar) {
       emitToken(state.instance, sort, state.varNames[str].c_str());
     } else {
-      emitToken(state.instance, sort, str->data, len);
+      emitToken(state.instance, sort, str->data, subject_len);
     }
 
     return;

--- a/unittests/runtime-io/io.cpp
+++ b/unittests/runtime-io/io.cpp
@@ -257,12 +257,12 @@ BOOST_AUTO_TEST_CASE(getc) {
 
 BOOST_AUTO_TEST_CASE(read) {
   mpz_t f;
-  mpz_t len;
+  mpz_t length;
   int fd = overwriteTestFile();
   mpz_init_set_si(f, fd);
-  mpz_init_set_si(len, 6);
+  mpz_init_set_si(length, 6);
 
-  block *b = hook_IO_read(f, len);
+  block *b = hook_IO_read(f, length);
   BOOST_CHECK_EQUAL(
       b->h.hdr, getBlockHeaderForSymbol(
                     getTagForSymbolName("inj{SortString{}, SortIOString{}}"))
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(read) {
 
   BOOST_CHECK_EQUAL(0, strncmp(str->data, "hello ", 6));
 
-  b = hook_IO_read(f, len);
+  b = hook_IO_read(f, length);
   BOOST_CHECK_EQUAL(
       b->h.hdr, getBlockHeaderForSymbol(
                     getTagForSymbolName("inj{SortString{}, SortIOString{}}"))
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(read) {
 
   ::lseek(fd, 0, SEEK_END);
 
-  b = hook_IO_read(f, len);
+  b = hook_IO_read(f, length);
   BOOST_CHECK_EQUAL(
       b->h.hdr, getBlockHeaderForSymbol(
                     getTagForSymbolName("inj{SortString{}, SortIOString{}}"))
@@ -291,7 +291,7 @@ BOOST_AUTO_TEST_CASE(read) {
 
   ::close(fd);
 
-  b = hook_IO_read(f, len);
+  b = hook_IO_read(f, length);
   BOOST_CHECK_EQUAL(
       b->h.hdr, getBlockHeaderForSymbol(
                     getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))


### PR DESCRIPTION
As part of general work towards improving and documenting the public interface of the LLVM backend, this PR converts the existing macros used for manipulating blocks and block headers into inline functions.

Making this change has a few benefits:
* Improved debugging; it can be annoying having to paste the macro definitions into gdb / lldb when trying to evaluate expressions on values in scope.
* No macro pollution; we've run into situations previously where the runtime header needs to be included in a particular order so as not to pollute other headers' definitions.
* Easier code to read; the excess parentheses required to safely implement macros make the code tricky to read.
* Improved type safety.

The change makes the backend marginally slower to build, but the performance of the test suite is unaffected; I don't think it's likely that this version will materially affect the codegen for the runtime library.

There are a few places in the backend where we need to rename variables or make / not make explicit type conversions in order to satisfy the new safer interface.