### PR TITLE
Add `--profile` option to `llvm-kompile`

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -10,6 +10,7 @@ configure_file(llvm-kompile         ${CMAKE_CURRENT_BINARY_DIR} @ONLY)
 configure_file(llvm-krun            ${CMAKE_CURRENT_BINARY_DIR} @ONLY)
 configure_file(llvm-kompile-testing ${CMAKE_CURRENT_BINARY_DIR} @ONLY)
 configure_file(llvm-kompile-clang   ${CMAKE_CURRENT_BINARY_DIR} @ONLY)
+configure_file(utils.sh             ${CMAKE_CURRENT_BINARY_DIR} @ONLY)
 
 install(
   PROGRAMS
@@ -17,4 +18,10 @@ install(
     ${CMAKE_CURRENT_BINARY_DIR}/llvm-kompile-clang
     ${CMAKE_CURRENT_BINARY_DIR}/llvm-krun
   DESTINATION bin
+)
+
+install(
+  PROGRAMS
+    ${CMAKE_CURRENT_BINARY_DIR}/utils.sh
+  DESTINATION lib/scripts
 )

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+# This is configured generated code; shellcheck can't follow it properly
+# shellcheck disable=SC1091
 source "$(dirname "$0")/../lib/scripts/utils.sh"
 
 usage() {
@@ -67,8 +69,8 @@ clang_args=()
 python_cmd=python3
 python_output_dir=""
 
-verbose=false
-profile=false
+export verbose=false
+export profile=false
 save_temps=false
 
 while [[ $# -gt 0 ]]; do

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -141,6 +141,9 @@ if [[ "${#positional_args[@]}" -lt 1 || "${#positional_args[@]}" -gt 3 ]]; then
   exit 1
 fi
 
+if [[ "$profile" == "true" ]] && [[ "$verbose" == "false" ]]; then
+  echo "[warning] llvm-kompile: --profile will only produce output with -v/--verbose" 1>&2
+fi
 
 mod="$(mktemp tmp.XXXXXXXXXX)"
 modopt_tmp="$(mktemp tmp.XXXXXXXXXX)"

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source "$(dirname "$0")/../lib/scripts/utils.sh"
+
 usage() {
   cat << HERE
 Usage: $0 <definition.kore> <dt_dir> <object type> [options] [clang flags]
@@ -43,50 +45,6 @@ Valid values for a KLLVM object type are:
 
   c:          build a C bindings module rather than a standalone executable.
 HERE
-}
-
-export DEPTH=0
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  date_cmd="gdate"
-else
-  date_cmd="date"
-fi
-
-time_now_ms () {
-  "$date_cmd" "+%s%3N"
-}
-
-indented () {
-  for ((i=0; i < DEPTH; ++i)); do
-    echo -n "  " 1>&2
-  done
-
-  echo "$@" 1>&2
-}
-
-run () {
-  { set +e; } 2>/dev/null
-
-  indented "+ $@"
-
-  start=$(time_now_ms)
-
-  "$@"
-  result="$?"
-
-  end=$(time_now_ms)
-
-  { set -e; } 2>/dev/null
-
-  time=$((end - start))
-  time_s=$(bc <<< "scale=3; $time/1000" | sed -e 's/^\./0./')
-
-  indented "- time=${time_s}"
-
-  if [ "$result" -ne 0 ]; then
-    exit "$result"
-  fi
 }
 
 print_bindings_path () {

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -12,6 +12,7 @@ Usage: $0 <definition.kore> <dt_dir> <object type> [options] [clang flags]
 Options:
   -h, --help                Print this message and exit.
   -v, --verbose             Print commands executed to stderr.
+      --profile             Print profiling information to stderr.
   --save-temps              Do not delete temporary files on exit.
   --bindings-path           Print the absolute path of the compiled Python bindings for
                             the LLVM backend, then exit.
@@ -67,6 +68,7 @@ python_cmd=python3
 python_output_dir=""
 
 verbose=false
+profile=false
 save_temps=false
 
 while [[ $# -gt 0 ]]; do
@@ -84,6 +86,11 @@ while [[ $# -gt 0 ]]; do
     -v|--verbose)
       verbose=true
       kompile_clang_flags+=("-v")
+      shift
+      ;;
+    --profile)
+      profile=true
+      kompile_clang_flags+=("--profile")
       shift
       ;;
     --save-temps)

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -45,12 +45,48 @@ Valid values for a KLLVM object type are:
 HERE
 }
 
+export DEPTH=0
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  date_cmd="gdate"
+else
+  date_cmd="date"
+fi
+
+time_now_ms () {
+  "$date_cmd" "+%s%3N"
+}
+
+indented () {
+  for ((i=0; i < DEPTH; ++i)); do
+    echo -n "  " 1>&2
+  done
+
+  echo "$@" 1>&2
+}
+
 run () {
-  if [ "$verbose" = true ]; then
-    set -x
-  fi
+  { set +e; } 2>/dev/null
+
+  indented "+ $@"
+
+  start=$(time_now_ms)
+
   "$@"
-  { set +x; } 2>/dev/null
+  result="$?"
+
+  end=$(time_now_ms)
+
+  { set -e; } 2>/dev/null
+
+  time=$((end - start))
+  time_s=$(bc <<< "scale=3; $time/1000" | sed -e 's/^\./0./')
+
+  indented "- time=${time_s}"
+
+  if [ "$result" -ne 0 ]; then
+    exit "$result"
+  fi
 }
 
 print_bindings_path () {

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -12,6 +12,7 @@ llc_flags=()
 llc_opt_flags="-O0"
 link=true
 verbose=false
+profile=false
 save_temps=false
 output=false
 output_file="definition.o"
@@ -67,6 +68,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     -v)
       verbose=true
+      keep_arg=false
+      shift
+      ;;
+    --profile)
+      profile=true
       keep_arg=false
       shift
       ;;

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -17,7 +17,8 @@ python_output_dir="."
 
 run () {
   if [ "$verbose" = true ]; then
-    set -x
+    # set -x
+    echo "RUNNING $INDENT: $@"
   fi
   "$@"
   { set +x; } 2>/dev/null

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -15,6 +15,14 @@ compile=true
 python_cmd=python3
 python_output_dir="."
 
+run () {
+  if [ "$verbose" = true ]; then
+    set -x
+  fi
+  "$@"
+  { set +x; } 2>/dev/null
+}
+
 python_extension() {
   "$1" <<HERE
 import sysconfig
@@ -124,14 +132,6 @@ else
 fi
 
 llc_flags+=("--relocation-model=pic")
-
-run () {
-  if $verbose; then
-    set -x
-  fi
-  "$@"
-  { set +x; } 2>/dev/null
-}
 
 tmpdir="$(mktemp -d tmp.XXXXXXXXXX)"
 if ! $save_temps; then

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -63,6 +63,8 @@ while [[ $# -gt 0 ]]; do
       ;;
     -v)
       verbose=true
+      keep_arg=false
+      shift
       ;;
     -save-temps)
       save_temps=true	    

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -1,7 +1,11 @@
 #!/bin/bash -e
 
+# This is configured generated code; shellcheck can't follow it properly
+# shellcheck disable=SC1091
 source "$(dirname "$0")/../lib/scripts/utils.sh"
-DEPTH=1
+
+# Set the printing depth for profiling and verbose execution information
+export DEPTH=1
 
 modopt="$1"
 main="$2"
@@ -11,8 +15,8 @@ flags=()
 llc_flags=()
 llc_opt_flags="-O0"
 link=true
-verbose=false
-profile=false
+export verbose=false
+export profile=false
 save_temps=false
 output=false
 output_file="definition.o"

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -1,4 +1,8 @@
 #!/bin/bash -e
+
+source "$(dirname "$0")/../lib/scripts/utils.sh"
+DEPTH=1
+
 modopt="$1"
 main="$2"
 lto="$3"
@@ -14,15 +18,6 @@ output_file="definition.o"
 compile=true
 python_cmd=python3
 python_output_dir="."
-
-run () {
-  if [ "$verbose" = true ]; then
-    # set -x
-    echo "RUNNING $INDENT: $@"
-  fi
-  "$@"
-  { set +x; } 2>/dev/null
-}
 
 python_extension() {
   "$1" <<HERE

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -2,6 +2,9 @@
 
 export DEPTH=0
 
+verbose=${verbose:-false}
+profile=${profile:-false}
+
 if [[ "$OSTYPE" == "darwin"* ]]; then
   DATE_CMD="gdate"
 else
@@ -28,7 +31,7 @@ run () {
   { set +e; } 2>/dev/null
 
   if [ "$verbose" = "true" ]; then
-    indented "+ $@"
+    indented "+ " "$@"
   fi
 
   start=$(time_now_ms)

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+export DEPTH=0
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  DATE_CMD="gdate"
+else
+  DATE_CMD="date"
+fi
+
+time_now_ms () {
+  "$DATE_CMD" "+%s%3N"
+}
+
+indented () {
+  for ((i=0; i < DEPTH; ++i)); do
+    echo -n "  " 1>&2
+  done
+
+  echo "$@" 1>&2
+}
+
+run () {
+  { set +e; } 2>/dev/null
+
+  if [ "$verbose" = "true" ]; then
+    indented "+ $@"
+  fi
+
+  start=$(time_now_ms)
+
+  "$@"
+  result="$?"
+
+  end=$(time_now_ms)
+
+  { set -e; } 2>/dev/null
+
+  if [ "$verbose" = "true" ]; then
+    time=$((end - start))
+    time_s=$(bc <<< "scale=3; $time/1000" | sed -e 's/^\./0./')
+
+    indented "  time=${time_s}"
+  fi
+
+  if [ "$result" -ne 0 ]; then
+    exit "$result"
+  fi
+}

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -17,6 +17,10 @@ indented () {
     echo -n "  " 1>&2
   done
 
+  if [[ "$DEPTH" -gt 0 ]]; then
+    echo -n "| " 1>&2
+  fi
+
   echo "$@" 1>&2
 }
 
@@ -36,7 +40,7 @@ run () {
 
   { set -e; } 2>/dev/null
 
-  if [ "$verbose" = "true" ]; then
+  if [[ "$verbose" = "true" ]] && [[ "$profile" = "true" ]]; then
     time=$((end - start))
     time_s=$(bc <<< "scale=3; $time/1000" | sed -e 's/^\./0./')
 


### PR DESCRIPTION
This PR makes some minor refactorings to the `llvm-kompile-*` scripts, and adds an additional profiling option that (in verbose mode) prints the time taken by each step of the compilation pipeline.

I will follow this PR up with additional profiling information in the code generator.

For a small example:
```console
$ llvm-kompile test-kompiled/definition.kore test-kompiled/dt main -v --profile
+ /home/bruce/code/llvm-backend/build/install/bin/llvm-kompile-codegen test-kompiled/definition.kore test-kompiled/dt/dt.yaml test-kompiled/dt 0
  time=0.034
+ /usr/lib/llvm-14/bin/opt -mem2reg -tailcallelim -tailcallopt tmp.gsYQm9W8RC -o tmp.CTS0WVHve7
  time=0.021
+ /home/bruce/code/llvm-backend/build/install/bin/llvm-kompile-clang tmp.CTS0WVHve7 main nolto -fno-stack-protector -v --profile -fuse-ld=lld --python-output-dir test-kompiled
  | + /usr/lib/llvm-14/bin/llc -tailcallopt tmp.CTS0WVHve7 -mtriple=x86_64-pc-linux-gnu -filetype=obj -O0 --relocation-model=pic -o tmp.H3lGmLF9OO/asm.o
  |   time=0.040
  | + /usr/lib/llvm-14/bin/llc -tailcallopt /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//llvm/finish_rewriting.ll -mtriple=x86_64-pc-linux-gnu -filetype=obj -O0 --relocation-model=pic -o tmp.H3lGmLF9OO/finish_rewriting.ll.o
  |   time=0.010
  | + /usr/lib/llvm-14/bin/llc -tailcallopt /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//llvm/fresh.ll -mtriple=x86_64-pc-linux-gnu -filetype=obj -O0 --relocation-model=pic -o tmp.H3lGmLF9OO/fresh.ll.o
  |   time=0.010
  | + /usr/lib/llvm-14/bin/llc -tailcallopt /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//llvm/getTag.ll -mtriple=x86_64-pc-linux-gnu -filetype=obj -O0 --relocation-model=pic -o tmp.H3lGmLF9OO/getTag.ll.o
  |   time=0.009
  | + /usr/lib/llvm-14/bin/llc -tailcallopt /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//llvm/move_float.ll -mtriple=x86_64-pc-linux-gnu -filetype=obj -O0 --relocation-model=pic -o tmp.H3lGmLF9OO/move_float.ll.o
  |   time=0.009
  | + /usr/lib/llvm-14/bin/llc -tailcallopt /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//llvm/move_int.ll -mtriple=x86_64-pc-linux-gnu -filetype=obj -O0 --relocation-model=pic -o tmp.H3lGmLF9OO/move_int.ll.o
  |   time=0.011
  | + /usr/lib/llvm-14/bin/llc -tailcallopt /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//llvm/string_equal.ll -mtriple=x86_64-pc-linux-gnu -filetype=obj -O0 --relocation-model=pic -o tmp.H3lGmLF9OO/string_equal.ll.o
  |   time=0.009
  | + /usr/lib/llvm-14/bin/llc -tailcallopt /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//llvm/take_steps.ll -mtriple=x86_64-pc-linux-gnu -filetype=obj -O0 --relocation-model=pic -o tmp.H3lGmLF9OO/take_steps.ll.o
  |   time=0.010
  | + /usr/bin/clang++-14 -Wno-override-module -Wno-return-type-c-linkage tmp.H3lGmLF9OO/asm.o tmp.H3lGmLF9OO/finish_rewriting.ll.o tmp.H3lGmLF9OO/fresh.ll.o tmp.H3lGmLF9OO/getTag.ll.o tmp.H3lGmLF9OO/move_float.ll.o tmp.H3lGmLF9OO/move_int.ll.o tmp.H3lGmLF9OO/string_equal.ll.o tmp.H3lGmLF9OO/take_steps.ll.o /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libarithmetic.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//llvm/main/main.ll /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libutil.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libstrings.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libnumeric_strings.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libio.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libcollections.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libParser.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libAST.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libBinaryKore.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libKOREPrinter.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//liballoc.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libcollect.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libmeta.a /home/bruce/code/llvm-backend/build/install/bin/../lib/kllvm//libjson.a -Wl,-u,sort_table -ltinfo -lgmp -lgmpxx -lmpfr -lpthread -ldl -lffi -ljemalloc -I /home/bruce/code/llvm-backend/build/install/bin/../include/kllvm --std=c++17 -fno-stack-protector -fuse-ld=lld
  |   time=0.073
  time=0.204
```