### PR TITLE
Don't materialise code for `opt`

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -177,12 +177,12 @@ esac
 if [ "$compile" = "default" ]; then
   dt_dir="${positional_args[1]}"
   main="${positional_args[2]}"
-  debug=0
+  debug=""
 
   for arg in "${clang_args[@]}"; do
     case "$arg" in
       -g)
-        debug=1
+        debug="--debug"
         ;;
       *)
         ;;
@@ -190,7 +190,7 @@ if [ "$compile" = "default" ]; then
   done
 
   run "$(dirname "$0")"/llvm-kompile-codegen "${codegen_flags[@]}" \
-    "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug -o "$mod"
+    "$definition" "$dt_dir"/dt.yaml "$dt_dir" "$debug" -o "$mod"
 
   if [[ "$use_opt" = "true" ]]; then
     run @OPT@ -mem2reg -tailcallelim "$mod" -o "$modopt"

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -173,7 +173,8 @@ if [ "$compile" = "default" ]; then
         ;;
     esac
   done
-  run "$(dirname "$0")"/llvm-kompile-codegen "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug > "$mod"
+  run "$(dirname "$0")"/llvm-kompile-codegen --no-optimize \
+    "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug > "$mod"
   run @OPT@ -mem2reg -tailcallelim -tailcallopt "$mod" -o "$modopt"
 elif [ "$compile" = "object" ]; then
   main="${positional_args[1]}"

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -190,7 +190,7 @@ if [ "$compile" = "default" ]; then
   done
 
   run "$(dirname "$0")"/llvm-kompile-codegen "${codegen_flags[@]}" \
-    "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug > "$mod"
+    "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug -o "$mod"
 
   if [[ "$use_opt" = "true" ]]; then
     run @OPT@ -mem2reg -tailcallelim "$mod" -o "$modopt"

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -195,7 +195,7 @@ if [ "$compile" = "default" ]; then
   if [[ "$use_opt" = "true" ]]; then
     run @OPT@ -mem2reg -tailcallelim "$mod" -o "$modopt"
   else
-    mv "$mod" "$modopt"
+    cp "$mod" "$modopt"
   fi
 elif [ "$compile" = "object" ]; then
   main="${positional_args[1]}"

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -15,6 +15,8 @@ Options:
                             the LLVM backend, then exit.
   --include-dir             Print the absolute include path for the LLVM backend
                             runtime and binding headers, then exit.
+  --use-opt                 Use standalone LLVM opt to apply optimization passes
+                            to the generated LLVM IR for this definition.
   --python PATH             The path to a Python interpreter with Pybind installed. Only
                             meaningful in "python" or "pythonast" mode.
   --python-output-dir PATH  Output directory to place automatically-named Python
@@ -67,10 +69,12 @@ print_include_path () {
 
 positional_args=()
 reading_clang_args=false
+codegen_flags=()
 kompile_clang_flags=()
 clang_args=()
 python_cmd=python3
 python_output_dir=""
+use_opt=false
 
 verbose=false
 save_temps=false
@@ -104,6 +108,11 @@ while [[ $# -gt 0 ]]; do
     --include-dir)
       print_include_path
       exit 0
+      ;;
+    --use-opt)
+      use_opt=true
+      codegen_flags+=("--no-optimize")
+      shift
       ;;
     --python)
       python_cmd="$2"
@@ -173,9 +182,14 @@ if [ "$compile" = "default" ]; then
         ;;
     esac
   done
-  run "$(dirname "$0")"/llvm-kompile-codegen --no-optimize \
+  run "$(dirname "$0")"/llvm-kompile-codegen "${codegen_flags[@]}" \
     "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug > "$mod"
-  run @OPT@ -mem2reg -tailcallelim -tailcallopt "$mod" -o "$modopt"
+
+  if [[ "$use_opt" = "true" ]]; then
+    run @OPT@ -mem2reg -tailcallelim -tailcallopt "$mod" -o "$modopt"
+  else
+    mv "$mod" "$modopt"
+  fi
 elif [ "$compile" = "object" ]; then
   main="${positional_args[1]}"
   modopt="$definition"

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -189,6 +189,8 @@ if [ "$compile" = "default" ]; then
     esac
   done
 
+  codegen_flags+=("--binary-ir")
+
   run "$(dirname "$0")"/llvm-kompile-codegen "${codegen_flags[@]}" \
     "$definition" "$dt_dir"/dt.yaml "$dt_dir" "$debug" -o "$mod"
 

--- a/include/kllvm/codegen/ApplyPasses.h
+++ b/include/kllvm/codegen/ApplyPasses.h
@@ -1,0 +1,12 @@
+#ifndef APPLY_PASSES_H
+#define APPLY_PASSES_H
+
+#include <llvm/IR/Module.h>
+
+namespace kllvm {
+
+void apply_kllvm_opt_passes(llvm::Module &);
+
+}
+
+#endif

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -1,7 +1,40 @@
 #include <kllvm/codegen/ApplyPasses.h>
 
+#include <llvm/IR/PassManager.h>
+#include <llvm/Passes/OptimizationLevel.h>
+#include <llvm/Passes/PassBuilder.h>
+#include <llvm/Transforms/Scalar/TailRecursionElimination.h>
+#include <llvm/Transforms/Utils/Mem2Reg.h>
+
+using namespace llvm;
+
 namespace kllvm {
 
-void apply_kllvm_opt_passes(llvm::Module &) { }
+/*
+ * Boilerplate pass manager setup code derived from the official LLVM
+ * documentation:
+ *  https://llvm.org/docs/NewPassManager.html#just-tell-me-how-to-run-the-default-optimization-pipeline-with-the-new-pass-manager
+ */
+void apply_kllvm_opt_passes(llvm::Module &mod) {
+  auto LAM = LoopAnalysisManager();
+  auto FAM = FunctionAnalysisManager();
+  auto CGAM = CGSCCAnalysisManager();
+  auto MAM = ModuleAnalysisManager();
+
+  auto PB = PassBuilder();
+
+  PB.registerModuleAnalyses(MAM);
+  PB.registerCGSCCAnalyses(CGAM);
+  PB.registerFunctionAnalyses(FAM);
+  PB.registerLoopAnalyses(LAM);
+  PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+  auto MPM = PB.buildO0DefaultPipeline(OptimizationLevel::O0);
+
+  MPM.addPass(createModuleToFunctionPassAdaptor(PromotePass()));
+  MPM.addPass(createModuleToFunctionPassAdaptor(TailCallElimPass()));
+
+  MPM.run(mod, MAM);
+}
 
 } // namespace kllvm

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -1,0 +1,7 @@
+#include <kllvm/codegen/ApplyPasses.h>
+
+namespace kllvm {
+
+void apply_kllvm_opt_passes(llvm::Module &) { }
+
+} // namespace kllvm

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -1,40 +1,21 @@
 #include <kllvm/codegen/ApplyPasses.h>
 
-#include <llvm/IR/PassManager.h>
-#include <llvm/Passes/OptimizationLevel.h>
-#include <llvm/Passes/PassBuilder.h>
-#include <llvm/Transforms/Scalar/TailRecursionElimination.h>
-#include <llvm/Transforms/Utils/Mem2Reg.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/Pass.h>
+#include <llvm/Transforms/Scalar.h>
+#include <llvm/Transforms/Utils.h>
 
 using namespace llvm;
 
 namespace kllvm {
 
-/*
- * Boilerplate pass manager setup code derived from the official LLVM
- * documentation:
- *  https://llvm.org/docs/NewPassManager.html#just-tell-me-how-to-run-the-default-optimization-pipeline-with-the-new-pass-manager
- */
 void apply_kllvm_opt_passes(llvm::Module &mod) {
-  auto LAM = LoopAnalysisManager();
-  auto FAM = FunctionAnalysisManager();
-  auto CGAM = CGSCCAnalysisManager();
-  auto MAM = ModuleAnalysisManager();
+  auto pm = legacy::PassManager();
 
-  auto PB = PassBuilder();
+  pm.add(createPromoteMemoryToRegisterPass());
+  pm.add(createTailCallEliminationPass());
 
-  PB.registerModuleAnalyses(MAM);
-  PB.registerCGSCCAnalyses(CGAM);
-  PB.registerFunctionAnalyses(FAM);
-  PB.registerLoopAnalyses(LAM);
-  PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
-
-  auto MPM = PB.buildO0DefaultPipeline(OptimizationLevel::O0);
-
-  MPM.addPass(createModuleToFunctionPassAdaptor(PromotePass()));
-  MPM.addPass(createModuleToFunctionPassAdaptor(TailCallElimPass()));
-
-  MPM.run(mod, MAM);
+  pm.run(mod);
 }
 
 } // namespace kllvm

--- a/lib/codegen/CMakeLists.txt
+++ b/lib/codegen/CMakeLists.txt
@@ -2,6 +2,7 @@ configure_file(CreateTerm.cpp CreateTerm.cpp @ONLY)
 
 add_library(Codegen
   ${CMAKE_CURRENT_BINARY_DIR}/CreateTerm.cpp
+  ApplyPasses.cpp
   CreateStaticTerm.cpp
   Debug.cpp
   Decision.cpp

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -49,9 +49,8 @@ cl::opt<std::string> DecisionTree(
 cl::opt<std::string> Directory(
     cl::Positional, cl::desc("<dir>"), cl::Required, cl::cat(CodegenCat));
 
-cl::opt<bool> Debug(
-    "debug", cl::desc("Enable debug information"), cl::Required,
-    cl::cat(CodegenCat));
+cl::opt<bool>
+    Debug("debug", cl::desc("Enable debug information"), cl::cat(CodegenCat));
 
 cl::opt<bool> NoOptimize(
     "no-optimize",
@@ -65,12 +64,8 @@ cl::alias OutputFileAlias(
     "o", cl::desc("Alias for --output"), cl::aliasopt(OutputFile),
     cl::cat(CodegenCat));
 
-cl::opt<bool> TextualIR(
-    "textual-ir", cl::desc("Emit textual IR rather than bitcode"),
-    cl::cat(CodegenCat));
-
-cl::alias TextualIRAlias(
-    "S", cl::desc("Alias for --textual-ir"), cl::aliasopt(TextualIR),
+cl::opt<bool> BinaryIR(
+    "binary-ir", cl::desc("Emit binary IR rather than text"),
     cl::cat(CodegenCat));
 
 cl::opt<bool> ForceBinary(
@@ -103,18 +98,19 @@ std::map<std::string, std::string> read_index_file() {
 }
 
 void write_output(Module const &mod, raw_ostream &os) {
-  if (TextualIR) {
-    mod.print(os, nullptr);
-  } else {
+  if (BinaryIR) {
     WriteBitcodeToFile(mod, os);
+  } else {
+    mod.print(os, nullptr);
   }
 }
 
 void write_output(Module const &mod) {
   if (OutputFile == "-") {
-    if (!TextualIR && !ForceBinary) {
-      throw std::runtime_error("Not printing binary output to stdout; use -S "
-                               "for textual output or force binary with -f\n");
+    if (BinaryIR && !ForceBinary) {
+      throw std::runtime_error(
+          "Not printing binary output to stdout; use -o to specify output path "
+          "or force binary with -f\n");
     }
 
     write_output(mod, llvm::outs());

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -49,9 +49,9 @@ cl::opt<std::string> DecisionTree(
 cl::opt<std::string> Directory(
     cl::Positional, cl::desc("<dir>"), cl::Required, cl::cat(CodegenCat));
 
-cl::opt<int, true> Debug(
-    cl::Positional, cl::desc("[0|1]"), cl::Required, cl::cat(CodegenCat),
-    cl::location(CODEGEN_DEBUG));
+cl::opt<bool> Debug(
+    "debug", cl::desc("Enable debug information"), cl::Required,
+    cl::cat(CodegenCat));
 
 cl::opt<bool> NoOptimize(
     "no-optimize",
@@ -136,6 +136,8 @@ void write_output(Module const &mod) {
 int main(int argc, char **argv) {
   cl::HideUnrelatedOptions({&CodegenCat});
   cl::ParseCommandLineOptions(argc, argv);
+
+  CODEGEN_DEBUG = Debug ? 1 : 0;
 
   KOREParser parser(Definition);
   ptr<KOREDefinition> definition = parser.definition();

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -1,11 +1,11 @@
-#include "kllvm/ast/AST.h"
-#include "kllvm/codegen/CreateTerm.h"
-#include "kllvm/codegen/Debug.h"
-#include "kllvm/codegen/Decision.h"
-#include "kllvm/codegen/DecisionParser.h"
-#include "kllvm/codegen/EmitConfigParser.h"
-#include "kllvm/parser/KOREParser.h"
-#include "kllvm/parser/location.h"
+#include <kllvm/ast/AST.h>
+#include <kllvm/codegen/CreateTerm.h>
+#include <kllvm/codegen/Debug.h>
+#include <kllvm/codegen/Decision.h>
+#include <kllvm/codegen/DecisionParser.h>
+#include <kllvm/codegen/EmitConfigParser.h>
+#include <kllvm/parser/KOREParser.h>
+#include <kllvm/parser/location.h>
 
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -1,4 +1,5 @@
 #include <kllvm/ast/AST.h>
+#include <kllvm/codegen/ApplyPasses.h>
 #include <kllvm/codegen/CreateTerm.h>
 #include <kllvm/codegen/Debug.h>
 #include <kllvm/codegen/Decision.h>
@@ -49,6 +50,11 @@ cl::opt<std::string> Directory(
 cl::opt<int, true> Debug(
     cl::Positional, cl::desc("[0|1]"), cl::Required, cl::cat(CodegenCat),
     cl::location(CODEGEN_DEBUG));
+
+cl::opt<bool> NoOptimize(
+    "no-optimize",
+    cl::desc("Don't run optimization passes before producing output"),
+    cl::cat(CodegenCat));
 
 static fs::path dt_dir() {
   return fs::path(Directory.getValue());
@@ -154,6 +160,10 @@ int main(int argc, char **argv) {
 
   if (CODEGEN_DEBUG) {
     finalizeDebugInfo();
+  }
+
+  if (!NoOptimize) {
+    apply_kllvm_opt_passes(*mod);
   }
 
   mod->print(llvm::outs(), nullptr);


### PR DESCRIPTION
The new profiling option for `llvm-kompile` reveals that we're spending a lot of time materialising IR to disk between the code generator, `opt` and `llc`.

We can probably shave a reasonable chunk of time by keeping the module in memory, and running passes on it directly via the LLVM API. This PR is a prototype implementation of that change.

Rough performance numbers for the `llvm-kompile` part of the C semantics:
* Before: **30s**
* After: **20s**

Eventually, in a separate change we may want to drop `llc` for the generated module as well following something like this: https://stackoverflow.com/questions/34822212/generate-machine-code-directly-via-llvm-api