### PR TITLE
Replacing fastcc with tailcc

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -180,7 +180,7 @@ if [ "$compile" = "default" ]; then
     esac
   done
   run "$(dirname "$0")"/llvm-kompile-codegen "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug > "$mod"
-  run @OPT@ -mem2reg -tailcallelim -tailcallopt "$mod" -o "$modopt"
+  run @OPT@ -mem2reg -tailcallelim "$mod" -o "$modopt"
 elif [ "$compile" = "object" ]; then
   main="${positional_args[1]}"
   modopt="$definition"

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -149,7 +149,7 @@ fi
 # straight to invoking the C++ compiler.
 if [ "$main" != "python_ast" ]; then
   if [ "$lto" = "lto" ]; then
-    flags+=("-flto" "-Wl,-mllvm,-tailcallopt")
+    flags+=("-flto" "-Wl,-mllvm")
     files=("$LIBDIR"/llvm/*.ll)
     if ! $link; then
       mv "$modopt" "$output_file"
@@ -162,7 +162,7 @@ if [ "$main" != "python_ast" ]; then
         modasm="$output_file"
       fi
       run @LLC@ \
-        -tailcallopt "$modopt" -mtriple=@BACKEND_TARGET_TRIPLE@ \
+        "$modopt" -mtriple=@BACKEND_TARGET_TRIPLE@ \
         -filetype=obj "$llc_opt_flags" "${llc_flags[@]}" -o "$modasm"
       modopt="$modasm"
     fi
@@ -170,7 +170,7 @@ if [ "$main" != "python_ast" ]; then
       for file in "$LIBDIR"/llvm/*.ll; do
         tmp="$tmpdir/$(basename "$file").o"
         run @LLC@ \
-          -tailcallopt "$file" -mtriple=@BACKEND_TARGET_TRIPLE@ \
+          "$file" -mtriple=@BACKEND_TARGET_TRIPLE@ \
           -filetype=obj "$llc_opt_flags" "${llc_flags[@]}" -o "$tmp"
         files+=("$tmp")
       done

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -149,7 +149,7 @@ fi
 # straight to invoking the C++ compiler.
 if [ "$main" != "python_ast" ]; then
   if [ "$lto" = "lto" ]; then
-    flags+=("-flto" "-Wl,-mllvm")
+    flags+=("-flto")
     files=("$LIBDIR"/llvm/*.ll)
     if ! $link; then
       mv "$modopt" "$output_file"

--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -48,20 +48,20 @@ public:
      indicating whether the resulting term could be an injection. */
   std::pair<llvm::Value *, bool> operator()(KOREPattern *pattern);
 
-  /* creates a call instructin calling a particular llvm function, abstracting
-     certain abi and calling convention details. 
-      - name: the nmae of the function to call in llvm
+  /* creates a call instruction calling a particular LLVM function, abstracting
+     certain ABI and calling convention details:
+      - name: the name of the function to call
       - returnCat: the value category of the return type of the function
-      - args: the arguments to pass to the functgion
+      - args: the arguments to pass to the function
       - sret: if true, this is a function that returns a struct constant via the
-              C abi, ie, the function actually returns void and the return value
-              is via a pointe. Note that this can be set to true even if the
+              C ABI (that is, the function actually returns void and the return value
+              is via a pointer). Note that this can be set to true even if the
               function does not return a struct, in which case its value is
               ignored.
-      - load: if the function returns a struct via sret, then if load is true,
-              we load the value
-      - tailcc: true if we should use the tailcc calling convention returned
-                from the function before returning it.*/
+      - load: if the function returns a struct via sret and load is true,
+              we load the value on return.
+      - tailcc: true if the call should be made via the tailcc calling convention.
+    */
   llvm::Value *createFunctionCall(
       std::string name, ValueType returnCat,
       const std::vector<llvm::Value *> &args, bool sret, bool tailcc);

--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -23,7 +23,7 @@ private:
   llvm::Value *
   createHook(KORECompositePattern *hookAtt, KORECompositePattern *pattern);
   llvm::Value *createFunctionCall(
-      std::string name, KORECompositePattern *pattern, bool sret, bool fastcc);
+      std::string name, KORECompositePattern *pattern, bool sret, bool tailcc);
   llvm::Value *
   notInjectionCase(KORECompositePattern *constructor, llvm::Value *val);
   bool populateStaticSet(KOREPattern *pattern);
@@ -47,20 +47,24 @@ public:
      specified definition, and returns the value itself, along with a boolean
      indicating whether the resulting term could be an injection. */
   std::pair<llvm::Value *, bool> operator()(KOREPattern *pattern);
+
   /* creates a call instructin calling a particular llvm function, abstracting
-   * certain abi and calling convention details. name: the nmae of the function
-   * to call in llvm returnCat: the value category of the return type of the
-   * function args: the arguments to pass to the functgion sret: if true, this
-   * is a function that returns a struct constant via the C abi, ie, the
-   * function actually returns void and the return value is via a pointe. Note
-   * that this can be set to true even if the function does not return a struct,
-   * in which case its value is ignored. load: if the function returns a struct
-   * via sret, then if load is true, we load the value fastcc: true if we should
-   * use the fastcc calling convention returned from the function before
-   * returning it. */
+     certain abi and calling convention details. 
+      - name: the nmae of the function to call in llvm
+      - returnCat: the value category of the return type of the function
+      - args: the arguments to pass to the functgion
+      - sret: if true, this is a function that returns a struct constant via the
+              C abi, ie, the function actually returns void and the return value
+              is via a pointe. Note that this can be set to true even if the
+              function does not return a struct, in which case its value is
+              ignored.
+      - load: if the function returns a struct via sret, then if load is true,
+              we load the value
+      - tailcc: true if we should use the tailcc calling convention returned
+                from the function before returning it.*/
   llvm::Value *createFunctionCall(
       std::string name, ValueType returnCat,
-      const std::vector<llvm::Value *> &args, bool sret, bool fastcc);
+      const std::vector<llvm::Value *> &args, bool sret, bool tailcc);
 
   llvm::BasicBlock *getCurrentBlock() const { return CurrentBlock; }
 };

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1,5 +1,5 @@
-#include "kllvm/codegen/CreateTerm.h"
 #include "kllvm/codegen/CreateStaticTerm.h"
+#include "kllvm/codegen/CreateTerm.h"
 #include "kllvm/codegen/Debug.h"
 #include "kllvm/codegen/Util.h"
 
@@ -824,7 +824,7 @@ llvm::Value *CreateTerm::createFunctionCall(
   auto call = llvm::CallInst::Create(func, realArgs, "", CurrentBlock);
   setDebugLoc(call);
   if (tailcc) {
-    call->setCallingConv(llvm::CallingConv::Fast);
+    call->setCallingConv(llvm::CallingConv::Tail);
   }
   if (sret) {
 #if LLVM_VERSION_MAJOR >= 12
@@ -1128,7 +1128,7 @@ bool makeFunction(
       getDebugFunctionType(getDebugType(returnCat, Out.str()), debugArgs),
       definition, applyRule);
   if (tailcc) {
-    applyRule->setCallingConv(llvm::CallingConv::Fast);
+    applyRule->setCallingConv(llvm::CallingConv::Tail);
   }
   llvm::StringMap<llvm::Value *> subst;
   llvm::BasicBlock *block
@@ -1246,7 +1246,7 @@ bool makeFunction(
         llvm::FunctionType::get(blockType, {blockType}, false));
     auto call = llvm::CallInst::Create(step, {retval}, "", CurrentBlock);
     setDebugLoc(call);
-    call->setCallingConv(llvm::CallingConv::Fast);
+    call->setCallingConv(llvm::CallingConv::Tail);
     retval = call;
   }
   auto ret
@@ -1326,7 +1326,7 @@ std::string makeApplyRuleFunction(
           getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}"),
           debugArgs),
       definition, applyRule);
-  applyRule->setCallingConv(llvm::CallingConv::Fast);
+  applyRule->setCallingConv(llvm::CallingConv::Tail);
   llvm::StringMap<llvm::Value *> subst;
   llvm::BasicBlock *block
       = llvm::BasicBlock::Create(Module->getContext(), "entry", applyRule);
@@ -1372,7 +1372,7 @@ std::string makeApplyRuleFunction(
   auto retval
       = llvm::CallInst::Create(step, args, "", creator.getCurrentBlock());
   setDebugLoc(retval);
-  retval->setCallingConv(llvm::CallingConv::Fast);
+  retval->setCallingConv(llvm::CallingConv::Tail);
   llvm::ReturnInst::Create(
       Module->getContext(), retval, creator.getCurrentBlock());
   return name;

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -751,7 +751,7 @@ llvm::Value *CreateTerm::createHook(
   }
 }
 
-// We use tailcc calling convention for apply_rule_* and eval_* functions to 
+// We use tailcc calling convention for apply_rule_* and eval_* functions to
 // make these K functions tail recursive when their K definitions are tail
 // recursive.
 llvm::Value *CreateTerm::createFunctionCall(

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1,5 +1,5 @@
-#include "kllvm/codegen/CreateStaticTerm.h"
 #include "kllvm/codegen/CreateTerm.h"
+#include "kllvm/codegen/CreateStaticTerm.h"
 #include "kllvm/codegen/Debug.h"
 #include "kllvm/codegen/Util.h"
 

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -532,7 +532,7 @@ void LeafNode::codegen(Decision *d) {
           d->Module, name, llvm::FunctionType::get(type, types, false)),
       args, "", d->CurrentBlock);
   setDebugLoc(Call);
-  Call->setCallingConv(llvm::CallingConv::Fast);
+  Call->setCallingConv(llvm::CallingConv::Tail);
   if (child == nullptr) {
     llvm::ReturnInst::Create(d->Ctx, Call, d->CurrentBlock);
   } else {
@@ -705,7 +705,7 @@ void makeEvalOrAnywhereFunction(
   initDebugFunction(
       function->getName(), name,
       getDebugFunctionType(debugReturnType, debugArgs), definition, matchFunc);
-  matchFunc->setCallingConv(llvm::CallingConv::Fast);
+  matchFunc->setCallingConv(llvm::CallingConv::Tail);
   llvm::BasicBlock *block
       = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
   llvm::BasicBlock *stuck
@@ -1017,7 +1017,7 @@ void makeStepFunction(
         name, name, getDebugFunctionType(debugType, {debugType}), definition,
         matchFunc);
   }
-  matchFunc->setCallingConv(llvm::CallingConv::Fast);
+  matchFunc->setCallingConv(llvm::CallingConv::Tail);
   auto val = matchFunc->arg_begin();
   llvm::BasicBlock *block
       = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
@@ -1091,7 +1091,7 @@ void makeMatchReasonFunctionWrapper(
       debugName, debugName,
       getDebugFunctionType(getVoidDebugType(), {debugType}), definition,
       matchFunc);
-  matchFunc->setCallingConv(llvm::CallingConv::Fast);
+  matchFunc->setCallingConv(llvm::CallingConv::Tail);
   llvm::BasicBlock *entry
       = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
 
@@ -1232,7 +1232,7 @@ void makeStepFunction(
   initDebugFunction(
       name, name, getDebugFunctionType(blockDebugType, debugTypes), definition,
       matchFunc);
-  matchFunc->setCallingConv(llvm::CallingConv::Fast);
+  matchFunc->setCallingConv(llvm::CallingConv::Tail);
 
   llvm::StringMap<llvm::Value *> stuckSubst;
   llvm::BasicBlock *block

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -1082,7 +1082,7 @@ void makeMatchReasonFunctionWrapper(
       = getOrInsertFunction(module, wrapperName, funcType);
   std::string debugName = name;
   if (axiom->getAttributes().count("label")) {
-    debugName = axiom->getStringAttribute("label") + "_fastcc_" + ".match";
+    debugName = axiom->getStringAttribute("label") + "_tailcc_" + ".match";
   }
   auto debugType
       = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -1070,6 +1070,7 @@ void makeStepFunction(
   codegen(dt);
 }
 
+// TODO: As we're not using fastcc, we must check if we can remove this wrapper
 void makeMatchReasonFunctionWrapper(
     KOREDefinition *definition, llvm::Module *module,
     KOREAxiomDeclaration *axiom, std::string name) {

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -1070,7 +1070,6 @@ void makeStepFunction(
   codegen(dt);
 }
 
-// TODO: As we're not using fastcc, we must check if we can remove this wrapper
 void makeMatchReasonFunctionWrapper(
     KOREDefinition *definition, llvm::Module *module,
     KOREAxiomDeclaration *axiom, std::string name) {

--- a/runtime/finish_rewriting.ll
+++ b/runtime/finish_rewriting.ll
@@ -20,7 +20,7 @@ declare i8* @getStderr()
 @exit_int_0 = global %mpz { i32 0, i32 0, i64* getelementptr inbounds ([0 x i64], [0 x i64]* @exit_int_0_limbs, i32 0, i32 0) }
 @exit_int_0_limbs = global [0 x i64] zeroinitializer
 
-define weak fastcc %mpz* @"eval_LblgetExitCode{SortGeneratedTopCell{}}"(%block*) {
+define weak tailcc %mpz* @"eval_LblgetExitCode{SortGeneratedTopCell{}}"(%block*) {
   ret %mpz* @exit_int_0
 }
 
@@ -62,7 +62,7 @@ printConfig:
 tail:
   br i1 %error, label %exit, label %exitCode
 exitCode:
-  %exit_z = call fastcc %mpz* @"eval_LblgetExitCode{SortGeneratedTopCell{}}"(%block* %subject)
+  %exit_z = call tailcc %mpz* @"eval_LblgetExitCode{SortGeneratedTopCell{}}"(%block* %subject)
   %exit_ul = call i64 @__gmpz_get_ui(%mpz* %exit_z)
   %exit_trunc = trunc i64 %exit_ul to i32
   br label %exit

--- a/runtime/fresh.ll
+++ b/runtime/fresh.ll
@@ -8,7 +8,7 @@ target triple = "@BACKEND_TARGET_TRIPLE@"
 
 declare void @abort() #0
 
-define weak fastcc %block* @"eval_LblgetGeneratedCounterCell{SortGeneratedTopCell{}}"(%block*) {
+define weak tailcc %block* @"eval_LblgetGeneratedCounterCell{SortGeneratedTopCell{}}"(%block*) {
   call void @abort()
   unreachable
 }
@@ -23,7 +23,7 @@ declare i8* @getTerminatedString(%string*)
 
 define i8* @get_fresh_constant(%string* %sort, %block* %top) {
 entry:
-  %counterCell = call fastcc %block* @"eval_LblgetGeneratedCounterCell{SortGeneratedTopCell{}}"(%block* %top)
+  %counterCell = call tailcc %block* @"eval_LblgetGeneratedCounterCell{SortGeneratedTopCell{}}"(%block* %top)
   %counterCellPointer = getelementptr %block, %block* %counterCell, i64 0, i32 1, i64 0
   %mpzPtrPtr = bitcast i64** %counterCellPointer to %mpz**
   %currCounter = load %mpz*, %mpz** %mpzPtrPtr

--- a/runtime/take_steps.ll
+++ b/runtime/take_steps.ll
@@ -4,8 +4,8 @@ target triple = "@BACKEND_TARGET_TRIPLE@"
 %blockheader = type { i64 } 
 %block = type { %blockheader, [0 x i64 *] } ; 16-bit layout, 8-bit length, 32-bit tag, children
 
-declare fastcc %block* @k_step(%block*)
-declare fastcc %block** @stepAll(%block*, i64*)
+declare tailcc %block* @k_step(%block*)
+declare tailcc %block** @stepAll(%block*, i64*)
 declare void @serializeConfigurationToFile(i8*, %block*)
 declare void @writeUInt64ToFile(i8*, i64)
 
@@ -56,13 +56,13 @@ if:
   br label %merge
 merge:
   store i64 %depth, i64* @depth
-  %result = call fastcc %block* @k_step(%block* %subject)
+  %result = call tailcc %block* @k_step(%block* %subject)
   ret %block* %result
 }
 
 define %block** @take_search_step(%block* %subject, i64* %count) {
   store i64 -1, i64* @depth
-  %result = call fastcc %block** @stepAll(%block* %subject, i64* %count)
+  %result = call tailcc %block** @stepAll(%block* %subject, i64* %count)
   ret %block** %result
 }
 


### PR DESCRIPTION
This PR replaces the LLVM `CallingConv` from `Fast` to `Tail`. By doing so, we no more need to call the `tailcallopt` optimization pass and decrease the kompilation time.

Fixes: #795 