### PR TITLE
Patch `gdate` in Nix

### DIFF
--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -29,6 +29,9 @@ stdenv.mkDerivation {
     substituteInPlace bin/llvm-kompile \
       --replace 'python_cmd=python3' 'python_cmd="${python-env.interpreter}"'
 
+    substituteInPlace bin/utils.sh \
+      --replace 'gdate' 'date'
+
     substituteInPlace bin/llvm-kompile-clang \
       --replace 'uname' '${coreutils}/bin/uname' \
       --replace '"-lgmp"' '"-I${gmp.dev}/include" "-L${gmp}/lib" "-lgmp"' \


### PR DESCRIPTION
In Homebrew, to get a compatible version of the date command we need to use `gdate` rather than `date`. In Nix on macOS, this isn't the case and we should patch in the unprefixed `date` command.

This is a small hotfix for the LLVM backend update job (https://github.com/runtimeverification/k/pull/3498) following #793 