### PR TITLE
Fix shell quoting

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -177,12 +177,11 @@ esac
 if [ "$compile" = "default" ]; then
   dt_dir="${positional_args[1]}"
   main="${positional_args[2]}"
-  debug=""
 
   for arg in "${clang_args[@]}"; do
     case "$arg" in
       -g)
-        debug="--debug"
+        codegen_flags+=("--debug")
         ;;
       *)
         ;;
@@ -192,7 +191,7 @@ if [ "$compile" = "default" ]; then
   codegen_flags+=("--binary-ir")
 
   run "$(dirname "$0")"/llvm-kompile-codegen "${codegen_flags[@]}" \
-    "$definition" "$dt_dir"/dt.yaml "$dt_dir" "$debug" -o "$mod"
+    "$definition" "$dt_dir"/dt.yaml "$dt_dir" -o "$mod"
 
   if [[ "$use_opt" = "true" ]]; then
     run @OPT@ -mem2reg -tailcallelim "$mod" -o "$modopt"


### PR DESCRIPTION
On some shells, `"$debug"` seems to be passed as an empty string to the argument parser for `llvm-kompile-codegen`, rather than just being omitted. This PR fixes the issue and quotes the argument properly.