### PR TITLE
Initialise llvm

### DIFF
--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -13,6 +13,7 @@
 #include <llvm/IR/Module.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/FileSystem.h>
+#include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/raw_ostream.h>
 
 #include <fmt/format.h>
@@ -127,9 +128,19 @@ void write_output(Module const &mod) {
   }
 }
 
+void initialize_llvm() {
+  InitializeAllTargetInfos();
+  InitializeAllTargets();
+  InitializeAllTargetMCs();
+  InitializeAllAsmParsers();
+  InitializeAllAsmPrinters();
+}
+
 } // namespace
 
 int main(int argc, char **argv) {
+  initialize_llvm();
+
   cl::HideUnrelatedOptions({&CodegenCat});
   cl::ParseCommandLineOptions(argc, argv);
 


### PR DESCRIPTION
This is a small fix for a broken submodule job: https://github.com/runtimeverification/k/actions/runs/5534103289/jobs/10098638343?pr=3508

The issue is that on some platforms (macOS / arm64), the optimisation passes we run inline with the code generator require some target information to be initialised; this PR performs the necessary initialisation in `llvm-kompile-codegen`.

See https://github.com/llvm-hs/llvm-hs/issues/250 for similar issues faced by other projects, with the same solution.