### PR TITLE
Remove spurious code

### DIFF
--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1145,13 +1145,7 @@ bool makeFunction(
   }
   CreateTerm creator = CreateTerm(subst, definition, block, Module, false);
   llvm::Value *retval = creator(pattern).first;
-  if (funcType->getReturnType()
-      == llvm::PointerType::getUnqual(retval->getType())) {
-    auto tempAlloc = allocateTerm(
-        retval->getType(), creator.getCurrentBlock(), "koreAllocAlwaysGC");
-    new llvm::StoreInst(retval, tempAlloc, creator.getCurrentBlock());
-    retval = tempAlloc;
-  }
+
   auto CurrentBlock = creator.getCurrentBlock();
   if (apply && bigStep) {
     auto ProofOutputFlag = Module->getOrInsertGlobal(


### PR DESCRIPTION
This is part of #730, and is related to the changes made in #769 to support LLVM's new opaque pointers.

The problem fixed by this PR is that in the initial draft of #759, I changed the check in this code block to use the `isCollectionSort` function. However, this conditional statement is actually universally-dead code that was made incorrectly live by the amended type-check! The correct behaviour is just to drop the block entirely. 