### PR TITLE
Inline invocations of `llc` for main module

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -254,6 +254,7 @@ if [[ "$compile" = "default" ]]; then
   else
     if [[ "$emit_ir" == "false" ]]; then
       modopt="${modopt}.o"
+      rm "${modopt_tmp}"
       modopt_tmp="${modopt}"
     fi
 

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -32,6 +32,7 @@ Options:
   --embed PATH NAME         Embed additional information into shared library
                             bindings. This is a low-level interface designed to
                             be called from kompile. Only meaningful in "c" mode.
+  -fno-omit-frame-pointer   Keep the frame pointer in compiled code for debugging purposes.
 
 Any option not listed above will be passed through to clang; use '--' to
 separate additional positional arguments to clang from those for $0.
@@ -92,6 +93,7 @@ embedded_files=()
 embedded_names=()
 use_opt=false
 emit_ir=false
+frame_pointer=false
 
 export verbose=false
 export profile=false
@@ -154,6 +156,11 @@ while [[ $# -gt 0 ]]; do
       embedded_names+=("$3")
       shift; shift; shift
       ;;
+    -fno-omit-frame-pointer)
+      kompile_clang_flags+=("$1")
+      frame_pointer=true
+      shift
+      ;;
     --)
       reading_clang_args=true
       shift
@@ -189,6 +196,9 @@ fi
 
 if [[ "$emit_ir" == "false" ]]; then
   codegen_flags+=("--emit-object")
+  if [[ "$frame_pointer" == "true" ]]; then
+    codegen_flags+=("-fno-omit-frame-pointer")
+  fi
 else
   codegen_flags+=("--binary-ir")
 fi

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -22,6 +22,8 @@ Options:
                             runtime and binding headers, then exit.
   --use-opt                 Use standalone LLVM opt to apply optimization passes
                             to the generated LLVM IR for this definition.
+  --emit-ir                 Emit LLVM IR at intermediate compilation steps, rather than
+                            directly generating an object file.
   --python PATH             The path to a Python interpreter with Pybind installed. Only
                             meaningful in "python" or "pythonast" mode.
   --python-output-dir PATH  Output directory to place automatically-named Python
@@ -89,6 +91,7 @@ python_output_dir=""
 embedded_files=()
 embedded_names=()
 use_opt=false
+emit_ir=false
 
 export verbose=false
 export profile=false
@@ -132,6 +135,10 @@ while [[ $# -gt 0 ]]; do
     --use-opt)
       use_opt=true
       codegen_flags+=("--no-optimize")
+      shift
+      ;;
+    --emit-ir)
+      emit_ir=true
       shift
       ;;
     --python)
@@ -180,6 +187,12 @@ if [[ "$profile" == "true" ]] && [[ "$verbose" == "false" ]]; then
   echo "[warning] llvm-kompile: --profile will only produce output with -v/--verbose" 1>&2
 fi
 
+if [[ "$emit_ir" == "false" ]]; then
+  codegen_flags+=("--emit-object")
+else
+  codegen_flags+=("--binary-ir")
+fi
+
 mod="$(mktemp tmp.XXXXXXXXXX)"
 modopt_tmp="$(mktemp tmp.XXXXXXXXXX)"
 tmpdir="$(mktemp -d tmp.XXXXXXXXXX)"
@@ -213,8 +226,6 @@ if [[ "$compile" = "default" ]]; then
     esac
   done
 
-  codegen_flags+=("--binary-ir")
-
   run "$(dirname "$0")"/llvm-kompile-codegen "${codegen_flags[@]}" \
     "$definition" "$dt_dir"/dt.yaml "$dt_dir" -o "$mod"
 
@@ -225,7 +236,11 @@ if [[ "$compile" = "default" ]]; then
       run @OPT@ -mem2reg -tailcallelim "$mod" -o "$modopt"
     fi
   else
-    cp "$mod" "$modopt"
+    if [[ "$emit_ir" == "false" ]]; then
+      modopt="${modopt}.o"
+    fi
+
+    run cp "$mod" "$modopt"
   fi
 elif [ "$compile" = "object" ]; then
   main="${positional_args[1]}"

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -254,9 +254,10 @@ if [[ "$compile" = "default" ]]; then
   else
     if [[ "$emit_ir" == "false" ]]; then
       modopt="${modopt}.o"
+      modopt_tmp="${modopt}"
     fi
 
-    run cp "$mod" "$modopt"
+    run mv "$mod" "$modopt"
   fi
 elif [ "$compile" = "object" ]; then
   main="${positional_args[1]}"

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -33,6 +33,7 @@ Options:
                             bindings. This is a low-level interface designed to
                             be called from kompile. Only meaningful in "c" mode.
   -fno-omit-frame-pointer   Keep the frame pointer in compiled code for debugging purposes.
+  -O[0123]                  Set the optimization level for code generation.
 
 Any option not listed above will be passed through to clang; use '--' to
 separate additional positional arguments to clang from those for $0.
@@ -159,6 +160,11 @@ while [[ $# -gt 0 ]]; do
     -fno-omit-frame-pointer)
       kompile_clang_flags+=("$1")
       frame_pointer=true
+      shift
+      ;;
+    -O*)
+      codegen_flags+=("$1")
+      kompile_clang_flags+=("$1")
       shift
       ;;
     --)

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -153,9 +153,6 @@ if [ "$main" != "python_ast" ]; then
   if [ "$lto" = "lto" ]; then
     flags+=("-flto")
     files=("$LIBDIR"/llvm/*.ll)
-    if ! $link; then
-      mv "$modopt" "$output_file"
-    fi
   else
     files=()
     if $compile; then
@@ -177,6 +174,10 @@ if [ "$main" != "python_ast" ]; then
         files+=("$tmp")
       done
     fi
+  fi
+
+  if ! $link; then
+    mv "$modopt" "$output_file"
   fi
 fi
 

--- a/include/kllvm/codegen/ApplyPasses.h
+++ b/include/kllvm/codegen/ApplyPasses.h
@@ -2,11 +2,14 @@
 #define APPLY_PASSES_H
 
 #include <llvm/IR/Module.h>
+#include <llvm/Support/raw_ostream.h>
 
 namespace kllvm {
 
 void apply_kllvm_opt_passes(llvm::Module &);
 
-}
+void generate_object_file(llvm::Module &, llvm::raw_ostream &);
+
+} // namespace kllvm
 
 #endif

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -9,6 +9,7 @@
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/MC/SubtargetFeature.h>
 #include <llvm/Pass.h>
+#include <llvm/Support/CommandLine.h>
 #include <llvm/Support/Host.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
@@ -18,6 +19,13 @@
 #include <optional>
 
 using namespace llvm;
+
+extern cl::OptionCategory CodegenCat;
+
+cl::opt<bool> FramePointer(
+    "fno-omit-frame-pointer",
+    cl::desc("Keep frame pointer in compiled code for debugging purposes"),
+    cl::cat(CodegenCat));
 
 namespace kllvm {
 
@@ -31,6 +39,12 @@ void apply_kllvm_opt_passes(llvm::Module &mod) {
 }
 
 void generate_object_file(llvm::Module &mod, llvm::raw_ostream &os) {
+  if (FramePointer) {
+    mod.setFramePointer(FramePointerKind::All);
+  } else {
+    mod.setFramePointer(FramePointerKind::None);
+  }
+
   auto triple = sys::getDefaultTargetTriple();
   mod.setTargetTriple(triple);
 

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -45,7 +45,7 @@ void generate_object_file(llvm::Module &mod, llvm::raw_ostream &os) {
 
   auto target_machine
       = std::unique_ptr<TargetMachine>(target->createTargetMachine(
-          triple, cpu, features_string, options, Reloc::PIC_, None,
+          triple, cpu, features_string, options, Reloc::PIC_, std::nullopt,
           CodeGenOpt::None));
 
   auto pm = legacy::PassManager{};

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -10,6 +10,8 @@
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Utils.h>
 
+#include <optional>
+
 using namespace llvm;
 
 namespace kllvm {
@@ -43,9 +45,15 @@ void generate_object_file(llvm::Module &mod, llvm::raw_ostream &os) {
   auto features_string = features.getString();
   auto options = TargetOptions{};
 
+#if LLVM_VERSION_MAJOR >= 16
+  std::optional<CodeModel::Model> model = std::nullopt;
+#else
+  Optional<CodeModel::Model> model = None;
+#endif
+
   auto target_machine
       = std::unique_ptr<TargetMachine>(target->createTargetMachine(
-          triple, cpu, features_string, options, Reloc::PIC_, std::nullopt,
+          triple, cpu, features_string, options, Reloc::PIC_, model,
           CodeGenOpt::None));
 
   auto pm = legacy::PassManager{};

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -1,7 +1,12 @@
 #include <kllvm/codegen/ApplyPasses.h>
 
 #include <llvm/IR/LegacyPassManager.h>
+#include <llvm/MC/SubtargetFeature.h>
+#include <llvm/MC/TargetRegistry.h>
 #include <llvm/Pass.h>
+#include <llvm/Support/Host.h>
+#include <llvm/Target/TargetMachine.h>
+#include <llvm/Target/TargetOptions.h>
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Utils.h>
 
@@ -14,6 +19,40 @@ void apply_kllvm_opt_passes(llvm::Module &mod) {
 
   pm.add(createPromoteMemoryToRegisterPass());
   pm.add(createTailCallEliminationPass());
+
+  pm.run(mod);
+}
+
+void generate_object_file(llvm::Module &mod, llvm::raw_ostream &os) {
+  auto triple = sys::getDefaultTargetTriple();
+  mod.setTargetTriple(triple);
+
+  auto error = std::string{};
+  auto target = TargetRegistry::lookupTarget(triple, error);
+  auto cpu = sys::getHostCPUName();
+
+  auto features = SubtargetFeatures{};
+  auto host_features = StringMap<bool>{};
+
+  if (sys::getHostCPUFeatures(host_features)) {
+    for (auto &feat : host_features) {
+      features.AddFeature(feat.first(), feat.second);
+    }
+  }
+
+  auto features_string = features.getString();
+  auto options = TargetOptions{};
+
+  auto target_machine
+      = std::unique_ptr<TargetMachine>(target->createTargetMachine(
+          triple, cpu, features_string, options, Reloc::PIC_, None,
+          CodeGenOpt::None));
+
+  auto pm = legacy::PassManager{};
+  mod.setDataLayout(target_machine->createDataLayout());
+  target_machine->addPassesToEmitFile(
+      pm, (raw_pwrite_stream &)os, nullptr, CodeGenFileType::CGFT_ObjectFile,
+      true, nullptr);
 
   pm.run(mod);
 }

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -1,8 +1,13 @@
 #include <kllvm/codegen/ApplyPasses.h>
 
+#if LLVM_VERSION_MAJOR >= 14
+#include <llvm/MC/TargetRegistry.h>
+#else
+#include <llvm/Support/TargetRegistry.h>
+#endif
+
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/MC/SubtargetFeature.h>
-#include <llvm/MC/TargetRegistry.h>
 #include <llvm/Pass.h>
 #include <llvm/Support/Host.h>
 #include <llvm/Target/TargetMachine.h>

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -60,9 +60,17 @@ void apply_kllvm_opt_passes(llvm::Module &mod) {
 
 void generate_object_file(llvm::Module &mod, llvm::raw_ostream &os) {
   if (FramePointer) {
+#if LLVM_VERSION_MAJOR <= 12
+    mod.setFramePointer(FramePointer::All);
+#else
     mod.setFramePointer(FramePointerKind::All);
+#endif
   } else {
+#if LLVM_VERSION_MAJOR <= 12
+    mod.setFramePointer(FramePointer::None);
+#else
     mod.setFramePointer(FramePointerKind::None);
+#endif
   }
 
   auto triple = sys::getDefaultTargetTriple();

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -59,6 +59,11 @@ cl::opt<bool> NoOptimize(
     cl::desc("Don't run optimization passes before producing output"),
     cl::cat(CodegenCat));
 
+cl::opt<bool> EmitObject(
+    "emit-object",
+    cl::desc("Directly emit an object file to avoid separately invoking llc"),
+    cl::cat(CodegenCat));
+
 cl::opt<std::string> OutputFile(
     "output", cl::desc("Output file path"), cl::init("-"), cl::cat(CodegenCat));
 
@@ -137,6 +142,14 @@ void initialize_llvm() {
   InitializeAllAsmPrinters();
 }
 
+void validate_args() {
+  if (EmitObject && (BinaryIR || NoOptimize)) {
+    std::cerr << "Cannot specify --emit-object with --binary-ir or "
+                 "--no-optimize\n";
+    std::exit(1);
+  }
+}
+
 } // namespace
 
 int main(int argc, char **argv) {
@@ -144,6 +157,8 @@ int main(int argc, char **argv) {
 
   cl::HideUnrelatedOptions({&CodegenCat});
   cl::ParseCommandLineOptions(argc, argv);
+
+  validate_args();
 
   CODEGEN_DEBUG = Debug ? 1 : 0;
 


### PR DESCRIPTION
This follows #794 in the pursuit of improving the performance of the backend's compilation pipeline; the philosophy of the change is identical (remove places where we materialize code in the compilation pipeline, and instead use the LLVM libraries to do it all in-memory).

There are a few more changes required in this PR in order to expose the full generality of the options we previously supported for `llc`, but these are largely boilerplate.

The default behaviour of `llvm-kompile` is now to use the new pipeline, but it's possible to opt back out of it for debugging.