### PR TITLE
Build Python bindings with `-fvisibility=hidden`

### DIFF
--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -196,7 +196,7 @@ elif [[ "$main" =~ "python" ]]; then
   # Don't link jemalloc when building a python library; it clashes with the
   # pymalloc implementation that Python expects you to use.
   all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi")
-  flags+=("-fPIC" "-shared" "-I${INCDIR}")
+  flags+=("-fPIC" "-shared" "-I${INCDIR}" "-fvisibility=hidden")
 
   read -r -a python_include_flags <<< "$("${python_cmd}" -m pybind11 --includes)"
   flags+=("${python_include_flags[@]}")


### PR DESCRIPTION
The change required here is smaller than discussed yesterday in the K meeting; the underlying issue was actually just that our build system wasn't adding a compiler flag that's required for `py::module_local()` to work properly.

Reference from the docs (different error, but contains the instruction to make sure that you're passing this flag): https://pybind11.readthedocs.io/en/stable/faq.html#someclass-declared-with-greater-visibility-than-the-type-of-its-field-someclass-member-wattributes

This PR adds that flag; I have verified that K built using this modified backend fixes my reproduction code from https://github.com/runtimeverification/pyk/issues/551

Fixes https://github.com/runtimeverification/pyk/issues/551