### PR TITLE
Bug fix in serializeRangeMap

### DIFF
--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -144,9 +144,10 @@ void serializeRangeMap(
         file, iter->first.start(), "SortKItem{}", false, state);
     serializeConfigurationInternal(
         file, iter->first.end(), "SortKItem{}", false, state);
+    emitSymbol(instance, "LblRangemap'Coln'Range{}", 2);
     serializeConfigurationInternal(
         file, iter->second, "SortKItem{}", false, state);
-    emitSymbol(instance, element, 3);
+    emitSymbol(instance, element, 2);
 
     if (once) {
       once = false;


### PR DESCRIPTION
`serializeRangeMap` was not using the proper KORE representation for the arguments of the element function of range maps. This was leading to the serialization of configurations that included range maps to fail. This was discovered while testing with the C semantics. (joint work with @theo25)