### PR TITLE
Test `kore_simplify` with KEVM's `definition.kore` on a real-world input

### DIFF
--- a/test/c/Inputs/evm.c
+++ b/test/c/Inputs/evm.c
@@ -1,0 +1,15 @@
+#include "api.h"
+
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+  if (argc <= 1) {
+    return 1;
+  }
+
+  struct kllvm_c_api api = load_c_api(argv[1]);
+
+  api.kllvm_init();
+
+#include "llvm_calls.c"
+}

--- a/test/c/Inputs/llvm_calls.c
+++ b/test/c/Inputs/llvm_calls.c
@@ -1,0 +1,36 @@
+kore_symbol* v0x0000000002260730 = api.kore_symbol_new("inj");
+kore_sort* v0x00000000022875c0 = api.kore_composite_sort_new("SortInternalOp");
+api.kore_symbol_add_formal_argument(v0x0000000002260730,v0x00000000022875c0);
+kore_sort* v0x0000000002287620 = api.kore_composite_sort_new("SortKItem");
+api.kore_symbol_add_formal_argument(v0x0000000002260730,v0x0000000002287620);
+kore_pattern* v0x0000000002287600 = api.kore_composite_pattern_from_symbol(v0x0000000002260730);
+kore_symbol* v0x0000000002287810 = api.kore_symbol_new("Lbl'Hash'next'LSqBUndsRSqBUnds'EVM'Unds'InternalOp'Unds'MaybeOpCode");
+kore_pattern* v0x0000000002287920 = api.kore_composite_pattern_from_symbol(v0x0000000002287810);
+kore_symbol* v0x0000000002287a20 = api.kore_symbol_new("Lbl'Hash'lookupOpCode'LParUndsCommUndsCommUndsRParUnds'EVM'Unds'MaybeOpCode'Unds'Bytes'Unds'Int'Unds'Schedule");
+kore_pattern* v0x0000000002287be0 = api.kore_composite_pattern_from_symbol(v0x0000000002287a20);
+kore_symbol* v0x0000000002287ce0 = api.kore_symbol_new("Lbl'Hash'parseByteStack'LParUndsRParUnds'SERIALIZATION'Unds'Bytes'Unds'String");
+kore_pattern* v0x0000000002287e00 = api.kore_composite_pattern_from_symbol(v0x0000000002287ce0);
+kore_sort* v0x0000000002287f00 = api.kore_composite_sort_new("SortString");
+kore_pattern* v0x00000000022880b0 = api.kore_pattern_new_token_with_len("",116746,v0x0000000002287f00);
+api.kore_composite_pattern_add_argument(v0x0000000002287e00,v0x00000000022880b0);
+api.kore_composite_pattern_add_argument(v0x0000000002287be0,v0x0000000002287e00);
+kore_sort* vv0x0000000002287e00 = api.kore_composite_sort_new("SortInt");
+kore_pattern* v0x0000000002288300 = api.kore_pattern_new_token_with_len("0",1,vv0x0000000002287e00);
+api.kore_composite_pattern_add_argument(v0x0000000002287be0,v0x0000000002288300);
+kore_symbol* vv0x0000000002288300 = api.kore_symbol_new("LblLONDON'Unds'EVM");
+kore_pattern* vv0x00000000022880b0 = api.kore_composite_pattern_from_symbol(vv0x0000000002288300);
+api.kore_composite_pattern_add_argument(v0x0000000002287be0,vv0x00000000022880b0);
+api.kore_composite_pattern_add_argument(v0x0000000002287920,v0x0000000002287be0);
+api.kore_composite_pattern_add_argument(v0x0000000002287600,v0x0000000002287920);
+char * data_out;
+size_t len_out;
+api.kore_simplify(v0x0000000002287600,v0x0000000002287620,&data_out,&len_out);
+/* 0x0000000002287600 |-> #next[_]_EVM_InternalOp_MaybeOpCode(
+    #lookupOpCode(_,_,_)_EVM_MaybeOpCode_Bytes_Int_Schedule(
+        #parseByteStack(_)_SERIALIZATION_Bytes_String(
+            ""
+        ),
+        "0",
+        LONDON_EVM()
+    )
+) */

--- a/test/c/test_evm_leak.kore
+++ b/test/c/test_evm_leak.kore
@@ -1,0 +1,6296 @@
+// RUN: mkdir -p %t.dir
+// RUN: %kompile %s c -o %t.dir/libtest.so
+// RUN: %kllvm-clang %S/Inputs/evm.c -o %t
+// RUN: %t %t.dir/libtest.so
+
+[topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)")]
+
+module BASIC-K
+    sort SortK{} []
+    sort SortKItem{} []
+endmodule
+[]
+module KSEQ
+    import BASIC-K []
+    symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol dotk{}() : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol append{}(SortK{}, SortK{}) : SortK{} [function{}(), functional{}()]
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, dotk{}()),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                TAIL:SortK{},
+                \top{SortK{}}()
+            )
+        )
+    ) []
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, kseq{}(K:SortKItem{}, KS:SortK{})),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                kseq{}(K:SortKItem{}, append{}(KS:SortK{}, TAIL:SortK{})),
+                \top{SortK{}}()
+            )
+        )
+    ) []
+endmodule
+[]
+module INJ
+    symbol inj{From, To}(From) : To [sortInjection{}()]
+    axiom {S1, S2, S3, R} \equals{S3, R}(inj{S2, S3}(inj{S1, S2}(T:S1)), inj{S1, S3}(T:S1)) [simplification{}()]
+endmodule
+[]
+module K
+    import KSEQ []
+    import INJ []
+    alias weakExistsFinally{A}(A) : A where weakExistsFinally{A}(@X:A) := @X:A []
+    alias weakAlwaysFinally{A}(A) : A where weakAlwaysFinally{A}(@X:A) := @X:A []
+    alias allPathGlobally{A}(A) : A where allPathGlobally{A}(@X:A) := @X:A []
+endmodule
+[]
+
+module STEPS
+
+// imports
+  import K []
+
+// sorts
+  sort SortKCellOpt{} []
+  sort SortIOInt{} []
+  sort SortGeneratedTopCellFragment{} []
+  sort SortIOFile{} []
+  hooked-sort SortList{} [concat{}(Lbl'Unds'List'Unds'{}()), element{}(LblListItem{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(695,3,695,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'List{}())]
+  sort SortKCell{} []
+  sort SortGeneratedTopCell{} []
+  sort SortGeneratedCounterCell{} []
+  hooked-sort SortFloat{} [hasDomainValues{}(), hook{}("FLOAT.Float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1254,3,1254,35)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-sort SortMap{} [concat{}(Lbl'Unds'Map'Unds'{}()), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(218,3,218,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Map{}())]
+  hooked-sort SortString{} [hasDomainValues{}(), hook{}("STRING.String"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1467,3,1467,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  sort SortIOString{} []
+  sort SortId{} [hasDomainValues{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2004,3,2004,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), token{}()]
+  sort SortGeneratedCounterCellOpt{} []
+  sort SortKConfigVar{} [hasDomainValues{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(40,3,40,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/kast.md)"), token{}()]
+  sort SortExp{} []
+  hooked-sort SortInt{} [hasDomainValues{}(), hook{}("INT.Int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(971,3,971,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  sort SortIOError{} []
+  hooked-sort SortSet{} [concat{}(Lbl'Unds'Set'Unds'{}()), element{}(LblSetItem{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(482,3,482,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Set{}())]
+  sort SortStream{} []
+  hooked-sort SortBool{} [hasDomainValues{}(), hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(850,3,850,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// symbols
+  symbol Lbl'Hash'E2BIG{}() : SortIOError{} [constructor{}(), format{}("%c#E2BIG%r"), functional{}(), injective{}(), klabel{}("#E2BIG"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2155,22,2155,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EACCES{}() : SortIOError{} [constructor{}(), format{}("%c#EACCES%r"), functional{}(), injective{}(), klabel{}("#EACCES"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2156,22,2156,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EADDRINUSE{}() : SortIOError{} [constructor{}(), format{}("%c#EADDRINUSE%r"), functional{}(), injective{}(), klabel{}("#EADDRINUSE"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2205,22,2205,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EADDRNOTAVAIL{}() : SortIOError{} [constructor{}(), format{}("%c#EADDRNOTAVAIL%r"), functional{}(), injective{}(), klabel{}("#EADDRNOTAVAIL"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2206,22,2206,71)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EAFNOSUPPORT{}() : SortIOError{} [constructor{}(), format{}("%c#EAFNOSUPPORT%r"), functional{}(), injective{}(), klabel{}("#EAFNOSUPPORT"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2204,22,2204,69)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EAGAIN{}() : SortIOError{} [constructor{}(), format{}("%c#EAGAIN%r"), functional{}(), injective{}(), klabel{}("#EAGAIN"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2157,22,2157,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EALREADY{}() : SortIOError{} [constructor{}(), format{}("%c#EALREADY%r"), functional{}(), injective{}(), klabel{}("#EALREADY"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2194,22,2194,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EBADF{}() : SortIOError{} [constructor{}(), format{}("%c#EBADF%r"), functional{}(), injective{}(), klabel{}("#EBADF"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2158,22,2158,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EBUSY{}() : SortIOError{} [constructor{}(), format{}("%c#EBUSY%r"), functional{}(), injective{}(), klabel{}("#EBUSY"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2159,22,2159,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ECHILD{}() : SortIOError{} [constructor{}(), format{}("%c#ECHILD%r"), functional{}(), injective{}(), klabel{}("#ECHILD"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2160,22,2160,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ECONNABORTED{}() : SortIOError{} [constructor{}(), format{}("%c#ECONNABORTED%r"), functional{}(), injective{}(), klabel{}("#ECONNABORTED"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2210,22,2210,69)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ECONNREFUSED{}() : SortIOError{} [constructor{}(), format{}("%c#ECONNREFUSED%r"), functional{}(), injective{}(), klabel{}("#ECONNREFUSED"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2218,22,2218,69)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ECONNRESET{}() : SortIOError{} [constructor{}(), format{}("%c#ECONNRESET%r"), functional{}(), injective{}(), klabel{}("#ECONNRESET"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2211,22,2211,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EDEADLK{}() : SortIOError{} [constructor{}(), format{}("%c#EDEADLK%r"), functional{}(), injective{}(), klabel{}("#EDEADLK"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2161,22,2161,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EDESTADDRREQ{}() : SortIOError{} [constructor{}(), format{}("%c#EDESTADDRREQ%r"), functional{}(), injective{}(), klabel{}("#EDESTADDRREQ"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2196,22,2196,69)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EDOM{}() : SortIOError{} [constructor{}(), format{}("%c#EDOM%r"), functional{}(), injective{}(), klabel{}("#EDOM"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2162,22,2162,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EEXIST{}() : SortIOError{} [constructor{}(), format{}("%c#EEXIST%r"), functional{}(), injective{}(), klabel{}("#EEXIST"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2163,22,2163,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EFAULT{}() : SortIOError{} [constructor{}(), format{}("%c#EFAULT%r"), functional{}(), injective{}(), klabel{}("#EFAULT"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2164,22,2164,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EFBIG{}() : SortIOError{} [constructor{}(), format{}("%c#EFBIG%r"), functional{}(), injective{}(), klabel{}("#EFBIG"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2165,22,2165,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EHOSTDOWN{}() : SortIOError{} [constructor{}(), format{}("%c#EHOSTDOWN%r"), functional{}(), injective{}(), klabel{}("#EHOSTDOWN"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2219,22,2219,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EHOSTUNREACH{}() : SortIOError{} [constructor{}(), format{}("%c#EHOSTUNREACH%r"), functional{}(), injective{}(), klabel{}("#EHOSTUNREACH"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2220,22,2220,69)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EINPROGRESS{}() : SortIOError{} [constructor{}(), format{}("%c#EINPROGRESS%r"), functional{}(), injective{}(), klabel{}("#EINPROGRESS"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2193,22,2193,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EINTR{}() : SortIOError{} [constructor{}(), format{}("%c#EINTR%r"), functional{}(), injective{}(), klabel{}("#EINTR"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2166,22,2166,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EINVAL{}() : SortIOError{} [constructor{}(), format{}("%c#EINVAL%r"), functional{}(), injective{}(), klabel{}("#EINVAL"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2167,22,2167,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EIO{}() : SortIOError{} [constructor{}(), format{}("%c#EIO%r"), functional{}(), injective{}(), klabel{}("#EIO"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2168,22,2168,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EISCONN{}() : SortIOError{} [constructor{}(), format{}("%c#EISCONN%r"), functional{}(), injective{}(), klabel{}("#EISCONN"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2213,22,2213,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EISDIR{}() : SortIOError{} [constructor{}(), format{}("%c#EISDIR%r"), functional{}(), injective{}(), klabel{}("#EISDIR"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2169,22,2169,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ELOOP{}() : SortIOError{} [constructor{}(), format{}("%c#ELOOP%r"), functional{}(), injective{}(), klabel{}("#ELOOP"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2221,22,2221,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EMFILE{}() : SortIOError{} [constructor{}(), format{}("%c#EMFILE%r"), functional{}(), injective{}(), klabel{}("#EMFILE"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2170,22,2170,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EMLINK{}() : SortIOError{} [constructor{}(), format{}("%c#EMLINK%r"), functional{}(), injective{}(), klabel{}("#EMLINK"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2171,22,2171,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EMSGSIZE{}() : SortIOError{} [constructor{}(), format{}("%c#EMSGSIZE%r"), functional{}(), injective{}(), klabel{}("#EMSGSIZE"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2197,22,2197,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENAMETOOLONG{}() : SortIOError{} [constructor{}(), format{}("%c#ENAMETOOLONG%r"), functional{}(), injective{}(), klabel{}("#ENAMETOOLONG"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2172,22,2172,69)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENETDOWN{}() : SortIOError{} [constructor{}(), format{}("%c#ENETDOWN%r"), functional{}(), injective{}(), klabel{}("#ENETDOWN"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2207,22,2207,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENETRESET{}() : SortIOError{} [constructor{}(), format{}("%c#ENETRESET%r"), functional{}(), injective{}(), klabel{}("#ENETRESET"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2209,22,2209,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENETUNREACH{}() : SortIOError{} [constructor{}(), format{}("%c#ENETUNREACH%r"), functional{}(), injective{}(), klabel{}("#ENETUNREACH"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2208,22,2208,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENFILE{}() : SortIOError{} [constructor{}(), format{}("%c#ENFILE%r"), functional{}(), injective{}(), klabel{}("#ENFILE"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2173,22,2173,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOBUFS{}() : SortIOError{} [constructor{}(), format{}("%c#ENOBUFS%r"), functional{}(), injective{}(), klabel{}("#ENOBUFS"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2212,22,2212,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENODEV{}() : SortIOError{} [constructor{}(), format{}("%c#ENODEV%r"), functional{}(), injective{}(), klabel{}("#ENODEV"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2174,22,2174,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOENT{}() : SortIOError{} [constructor{}(), format{}("%c#ENOENT%r"), functional{}(), injective{}(), klabel{}("#ENOENT"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2175,22,2175,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOEXEC{}() : SortIOError{} [constructor{}(), format{}("%c#ENOEXEC%r"), functional{}(), injective{}(), klabel{}("#ENOEXEC"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2176,22,2176,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOLCK{}() : SortIOError{} [constructor{}(), format{}("%c#ENOLCK%r"), functional{}(), injective{}(), klabel{}("#ENOLCK"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2177,22,2177,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOMEM{}() : SortIOError{} [constructor{}(), format{}("%c#ENOMEM%r"), functional{}(), injective{}(), klabel{}("#ENOMEM"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2178,22,2178,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOPROTOOPT{}() : SortIOError{} [constructor{}(), format{}("%c#ENOPROTOOPT%r"), functional{}(), injective{}(), klabel{}("#ENOPROTOOPT"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2199,22,2199,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOSPC{}() : SortIOError{} [constructor{}(), format{}("%c#ENOSPC%r"), functional{}(), injective{}(), klabel{}("#ENOSPC"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2179,22,2179,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOSYS{}() : SortIOError{} [constructor{}(), format{}("%c#ENOSYS%r"), functional{}(), injective{}(), klabel{}("#ENOSYS"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2180,22,2180,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOTCONN{}() : SortIOError{} [constructor{}(), format{}("%c#ENOTCONN%r"), functional{}(), injective{}(), klabel{}("#ENOTCONN"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2214,22,2214,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOTDIR{}() : SortIOError{} [constructor{}(), format{}("%c#ENOTDIR%r"), functional{}(), injective{}(), klabel{}("#ENOTDIR"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2181,22,2181,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOTEMPTY{}() : SortIOError{} [constructor{}(), format{}("%c#ENOTEMPTY%r"), functional{}(), injective{}(), klabel{}("#ENOTEMPTY"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2182,22,2182,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOTSOCK{}() : SortIOError{} [constructor{}(), format{}("%c#ENOTSOCK%r"), functional{}(), injective{}(), klabel{}("#ENOTSOCK"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2195,22,2195,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENOTTY{}() : SortIOError{} [constructor{}(), format{}("%c#ENOTTY%r"), functional{}(), injective{}(), klabel{}("#ENOTTY"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2183,22,2183,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ENXIO{}() : SortIOError{} [constructor{}(), format{}("%c#ENXIO%r"), functional{}(), injective{}(), klabel{}("#ENXIO"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2184,22,2184,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EOF{}() : SortIOError{} [constructor{}(), format{}("%c#EOF%r"), functional{}(), injective{}(), klabel{}("#EOF"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2154,22,2154,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EOPNOTSUPP{}() : SortIOError{} [constructor{}(), format{}("%c#EOPNOTSUPP%r"), functional{}(), injective{}(), klabel{}("#EOPNOTSUPP"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2202,22,2202,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EOVERFLOW{}() : SortIOError{} [constructor{}(), format{}("%c#EOVERFLOW%r"), functional{}(), injective{}(), klabel{}("#EOVERFLOW"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2222,22,2222,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EPERM{}() : SortIOError{} [constructor{}(), format{}("%c#EPERM%r"), functional{}(), injective{}(), klabel{}("#EPERM"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2185,22,2185,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EPFNOSUPPORT{}() : SortIOError{} [constructor{}(), format{}("%c#EPFNOSUPPORT%r"), functional{}(), injective{}(), klabel{}("#EPFNOSUPPORT"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2203,22,2203,69)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EPIPE{}() : SortIOError{} [constructor{}(), format{}("%c#EPIPE%r"), functional{}(), injective{}(), klabel{}("#EPIPE"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2186,22,2186,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EPROTONOSUPPORT{}() : SortIOError{} [constructor{}(), format{}("%c#EPROTONOSUPPORT%r"), functional{}(), injective{}(), klabel{}("#EPROTONOSUPPORT"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2200,22,2200,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EPROTOTYPE{}() : SortIOError{} [constructor{}(), format{}("%c#EPROTOTYPE%r"), functional{}(), injective{}(), klabel{}("#EPROTOTYPE"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2198,22,2198,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ERANGE{}() : SortIOError{} [constructor{}(), format{}("%c#ERANGE%r"), functional{}(), injective{}(), klabel{}("#ERANGE"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2187,22,2187,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EROFS{}() : SortIOError{} [constructor{}(), format{}("%c#EROFS%r"), functional{}(), injective{}(), klabel{}("#EROFS"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2188,22,2188,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ESHUTDOWN{}() : SortIOError{} [constructor{}(), format{}("%c#ESHUTDOWN%r"), functional{}(), injective{}(), klabel{}("#ESHUTDOWN"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2215,22,2215,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ESOCKTNOSUPPORT{}() : SortIOError{} [constructor{}(), format{}("%c#ESOCKTNOSUPPORT%r"), functional{}(), injective{}(), klabel{}("#ESOCKTNOSUPPORT"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2201,22,2201,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ESPIPE{}() : SortIOError{} [constructor{}(), format{}("%c#ESPIPE%r"), functional{}(), injective{}(), klabel{}("#ESPIPE"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2189,22,2189,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ESRCH{}() : SortIOError{} [constructor{}(), format{}("%c#ESRCH%r"), functional{}(), injective{}(), klabel{}("#ESRCH"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2190,22,2190,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ETIMEDOUT{}() : SortIOError{} [constructor{}(), format{}("%c#ETIMEDOUT%r"), functional{}(), injective{}(), klabel{}("#ETIMEDOUT"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2217,22,2217,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'ETOOMANYREFS{}() : SortIOError{} [constructor{}(), format{}("%c#ETOOMANYREFS%r"), functional{}(), injective{}(), klabel{}("#ETOOMANYREFS"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2216,22,2216,69)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EWOULDBLOCK{}() : SortIOError{} [constructor{}(), format{}("%c#EWOULDBLOCK%r"), functional{}(), injective{}(), klabel{}("#EWOULDBLOCK"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2192,22,2192,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  symbol Lbl'Hash'EXDEV{}() : SortIOError{} [constructor{}(), format{}("%c#EXDEV%r"), functional{}(), injective{}(), klabel{}("#EXDEV"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2191,22,2191,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1")]
+  hooked-symbol Lbl'Hash'accept'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [format{}("%c#accept%r %c(%r %1 %c)%r"), function{}(), hook{}("IO.accept"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2320,20,2320,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(SortK{}) : SortStream{} [constructor{}(), format{}("%c#buffer%r %c(%r %1 %c)%r"), functional{}(), injective{}(), klabel{}("#buffer"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2424,21,2424,31)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbl'Hash'close'LParUndsRParUnds'K-IO'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [format{}("%c#close%r %c(%r %1 %c)%r"), function{}(), hook{}("IO.close"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2294,16,2294,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(SortK{}) : SortKItem{} [constructor{}(), format{}("%c#freezer_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp0_%r %c(%r %1 %c)%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(SortK{}) : SortKItem{} [constructor{}(), format{}("%c#freezer_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp1_%r %c(%r %1 %c)%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbl'Hash'getc'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [format{}("%c#getc%r %c(%r %1 %c)%r"), function{}(), hook{}("IO.getc"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2275,20,2275,89)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(SortBool{}, SortSort, SortSort) : SortSort [format{}("%c#if%r %1 %c#then%r %2 %c#else%r %3 %c#fi%r"), function{}(), functional{}(), hook{}("KEQUAL.ite"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2046,26,2046,121)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("ite"), terminals{}("1010101"), total{}()]
+  symbol Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(SortInt{}) : SortStream{} [constructor{}(), format{}("%c#istream%r %c(%r %1 %c)%r"), functional{}(), injective{}(), klabel{}("#istream"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2425,21,2425,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbl'Hash'lock'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [format{}("%c#lock%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), hook{}("IO.lock"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2306,16,2306,91)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol Lbl'Hash'log{}(SortString{}) : SortK{} [format{}("%c#log%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("IO.logString"), impure{}(), klabel{}("#log"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2400,16,2400,102)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), returnsUnit{}(), right{}(), symbol'Kywd'{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lbl'Hash'logToFile{}(SortString{}, SortString{}) : SortK{} [format{}("%c#logToFile%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("IO.log"), impure{}(), klabel{}("#logToFile"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2391,16,2391,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), returnsUnit{}(), right{}(), symbol'Kywd'{}(), terminals{}("110101"), total{}()]
+  hooked-symbol Lbl'Hash'mkstemp'LParUndsRParUnds'K-IO'Unds'IOFile'Unds'String{}(SortString{}) : SortIOFile{} [format{}("%c#mkstemp%r %c(%r %1 %c)%r"), function{}(), hook{}("IO.mkstemp"), impure{}(), klabel{}("#mkstemp"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2368,21,2368,84)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lbl'Hash'open'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'String{}(SortString{}) : SortIOInt{} [format{}("%c#open%r %c(%r %1 %c)%r"), function{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2245,20,2245,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'Unds'IOInt'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortIOInt{} [format{}("%c#open%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), hook{}("IO.open"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2246,18,2246,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  symbol Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(SortInt{}) : SortStream{} [constructor{}(), format{}("%c#ostream%r %c(%r %1 %c)%r"), functional{}(), injective{}(), klabel{}("#ostream"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2427,21,2427,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortStream{} [constructor{}(), format{}("%c#parseInput%r %c(%r %1 %c,%r %2 %c)%r"), functional{}(), injective{}(), klabel{}("#parseInput"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2426,21,2426,48)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol Lbl'Hash'putc'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [format{}("%c#putc%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), hook{}("IO.putc"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2285,16,2285,93)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol Lbl'Hash'read'LParUndsCommUndsRParUnds'K-IO'Unds'IOString'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortIOString{} [format{}("%c#read%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), hook{}("IO.read"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2276,23,2276,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol Lbl'Hash'remove'LParUndsRParUnds'K-IO'Unds'K'Unds'String{}(SortString{}) : SortK{} [format{}("%c#remove%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("IO.remove"), impure{}(), klabel{}("#remove"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2379,16,2379,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lbl'Hash'seek'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [format{}("%c#seek%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), hook{}("IO.seek"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2261,16,2261,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol Lbl'Hash'seekEnd'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [format{}("%c#seekEnd%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), hook{}("IO.seekEnd"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2262,16,2262,96)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol Lbl'Hash'shutdownWrite'LParUndsRParUnds'K-IO'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [format{}("%c#shutdownWrite%r %c(%r %1 %c)%r"), function{}(), hook{}("IO.shutdownWrite"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2321,16,2321,91)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}() : SortInt{} [format{}("%c#stderr%r"), function{}(), functional{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2341,19,2341,46)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1"), total{}()]
+  symbol Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}() : SortInt{} [format{}("%c#stdin%r"), function{}(), functional{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2339,18,2339,46)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1"), total{}()]
+  symbol Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}() : SortInt{} [format{}("%c#stdout%r"), function{}(), functional{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2340,19,2340,46)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1"), total{}()]
+  hooked-symbol Lbl'Hash'system'LParUndsRParUnds'K-IO'Unds'KItem'Unds'String{}(SortString{}) : SortKItem{} [format{}("%c#system%r %c(%r %1 %c)%r"), function{}(), hook{}("IO.system"), impure{}(), klabel{}("#system"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2357,20,2357,74)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lbl'Hash'systemResult{}(SortInt{}, SortString{}, SortString{}) : SortKItem{} [constructor{}(), format{}("%c#systemResult%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), functional{}(), injective{}(), klabel{}("#systemResult"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2358,20,2358,143)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("11010101")]
+  hooked-symbol Lbl'Hash'tell'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [format{}("%c#tell%r %c(%r %1 %c)%r"), function{}(), hook{}("IO.tell"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2260,20,2260,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lbl'Hash'tempFile{}(SortString{}, SortInt{}) : SortIOFile{} [constructor{}(), format{}("%c#tempFile%r %c(%r %1 %c,%r %2 %c)%r"), functional{}(), injective{}(), klabel{}("#tempFile"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2370,21,2370,93)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("110101")]
+  hooked-symbol Lbl'Hash'time'LParRParUnds'K-IO'Unds'Int{}() : SortInt{} [format{}("%c#time%r %c(%r %c)%r"), function{}(), hook{}("IO.time"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2330,18,2330,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("111")]
+  hooked-symbol Lbl'Hash'trace{}(SortKItem{}) : SortK{} [format{}("%c#trace%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("IO.traceTerm"), impure{}(), klabel{}("#trace"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2411,16,2411,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), returnsUnit{}(), right{}(), symbol'Kywd'{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lbl'Hash'traceK{}(SortK{}) : SortK{} [format{}("%c#traceK%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("IO.traceTerm"), impure{}(), klabel{}("#traceK"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2412,16,2412,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), returnsUnit{}(), right{}(), symbol'Kywd'{}(), terminals{}("1101"), total{}()]
+  symbol Lbl'Hash'unknownIOError{}(SortInt{}) : SortIOError{} [constructor{}(), format{}("%c#unknownIOError%r %c(%r %1 %c)%r"), functional{}(), injective{}(), klabel{}("#unknownIOError"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2154,54,2154,90)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1101")]
+  hooked-symbol Lbl'Hash'unlock'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [format{}("%c#unlock%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), hook{}("IO.unlock"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2307,16,2307,95)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol Lbl'Hash'write'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'String{}(SortInt{}, SortString{}) : SortK{} [format{}("%c#write%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), hook{}("IO.write"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2286,16,2286,93)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [format{}("%c.List%r"), function{}(), functional{}(), hook{}("LIST.unit"), klabel{}(".List"), latex{}("\\dotCt{List}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(719,19,719,142)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_nil"), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [format{}("%c.Map%r"), function{}(), functional{}(), hook{}("MAP.unit"), klabel{}(".Map"), latex{}("\\dotCt{Map}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(248,18,248,124)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [format{}("%c.Set%r"), function{}(), functional{}(), hook{}("SET.unit"), klabel{}(".Set"), latex{}("\\dotCt{Set}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(511,18,511,118)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [cell{}(), cellName{}("generatedCounter"), constructor{}(), format{}("%c<generatedCounter>%r%i%n%1%d%n%c</generatedCounter>%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("101")]
+  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortKCell{}, SortGeneratedCounterCell{}) : SortGeneratedTopCell{} [cell{}(), cellName{}("generatedTop"), constructor{}(), format{}("%1"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1001"), topcell{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortKCellOpt{}, SortGeneratedCounterCellOpt{}) : SortGeneratedTopCellFragment{} [cellFragment{}("GeneratedTopCell"), constructor{}(), format{}("%c<generatedTop>-fragment%r %1 %2 %c</generatedTop>-fragment%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1001")]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [cell{}(), cellName{}("k"), constructor{}(), format{}("%c<k>%r%i%n%1%d%n%c</k>%r"), functional{}(), injective{}(), left{}(), maincell{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(13,5,13,22)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), priorities{}(), right{}(), terminals{}("101"), topcell{}()]
+  hooked-symbol LblBase2String'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortString{} [format{}("%cBase2String%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), hook{}("STRING.base2string"), klabel{}("Base2String"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1596,21,1596,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  symbol LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(SortBool{}) : SortString{} [format{}("%cBool2String%r %c(%r %1 %c)%r"), function{}(), functional{}(), klabel{}("Bool2String"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1546,21,1546,56)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblFloat2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float{}(SortFloat{}) : SortString{} [format{}("%cFloat2String%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("STRING.float2string"), klabel{}("Float2String"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1573,21,1573,101)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblFloat2String'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float'Unds'String{}(SortFloat{}, SortString{}) : SortString{} [format{}("%cFloat2String%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), hook{}("STRING.floatFormat"), klabel{}("FloatFormat"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1574,21,1574,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol LblId2String'LParUndsRParUnds'ID-COMMON'Unds'String'Unds'Id{}(SortId{}) : SortString{} [format{}("%cId2String%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("STRING.token2string"), klabel{}("Id2String"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2011,21,2011,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(SortInt{}) : SortString{} [format{}("%cInt2String%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("STRING.int2string"), klabel{}("Int2String"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1595,21,1595,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [format{}("%1 %c[%r %2 %c]%r"), function{}(), hook{}("LIST.get"), klabel{}("List:get"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(738,20,738,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("0101")]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [format{}("%crange%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("LIST.range"), klabel{}("List:range"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(785,19,785,120)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("11010101")]
+  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [format{}("%cListItem%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("LIST.element"), klabel{}("ListItem"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(727,19,727,132)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_elem"), symbol'Kywd'{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [format{}("%1 %c[%r %2 %c]%r"), function{}(), hook{}("MAP.lookup"), klabel{}("Map:lookup"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(271,20,271,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("0101")]
+  hooked-symbol LblMap'Coln'update{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}(), functional{}(), hook{}("MAP.update"), klabel{}("Map:update"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,18,290,140)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), prefer{}(), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010101"), total{}()]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [format{}("%1 %c-Set%r %2"), function{}(), functional{}(), hook{}("SET.difference"), klabel{}("Set:difference"), latex{}("{#1}-_{\\it Set}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(551,18,551,142)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [format{}("%1 %cin%r %2"), function{}(), functional{}(), hook{}("SET.in"), klabel{}("Set:in"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(559,19,559,102)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [format{}("%cSetItem%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("SET.element"), injective{}(), klabel{}("SetItem"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(519,18,519,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblString2Base'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'Int{}(SortString{}, SortInt{}) : SortInt{} [format{}("%cString2Base%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), hook{}("STRING.string2base"), klabel{}("String2Base"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1597,21,1597,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  symbol LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(SortString{}) : SortBool{} [format{}("%cString2Bool%r %c(%r %1 %c)%r"), function{}(), klabel{}("String2Bool"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1552,19,1552,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblString2Float'LParUndsRParUnds'STRING-COMMON'Unds'Float'Unds'String{}(SortString{}) : SortFloat{} [format{}("%cString2Float%r %c(%r %1 %c)%r"), function{}(), hook{}("STRING.string2float"), klabel{}("String2Float"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1575,21,1575,94)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(SortString{}) : SortId{} [format{}("%cString2Id%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("STRING.string2token"), klabel{}("String2Id"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2012,17,2012,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblString2Int'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [format{}("%cString2Int%r %c(%r %1 %c)%r"), function{}(), hook{}("STRING.string2int"), klabel{}("String2Int"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1594,21,1594,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbl'UndsPerc'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c%%Int%r %2"), function{}(), hook{}("INT.tmod"), klabel{}("_%Int_"), latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1019,18,1019,171)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("mod"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'UndsAnd-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c&Int%r %2"), function{}(), functional{}(), hook{}("INT.and"), klabel{}("_&Int_"), latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsAnd-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1030,18,1030,184)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("andInt"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsStar'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c*Int%r %2"), function{}(), functional{}(), hook{}("INT.mul"), klabel{}("_*Int_"), latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds'modInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1015,18,1015,183)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("*"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c+Int%r %2"), function{}(), functional{}(), hook{}("INT.add"), klabel{}("_+Int_"), latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1024,18,1024,180)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smt-hook{}("+"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortString{} [format{}("%1 %c+String%r %2"), function{}(), functional{}(), hook{}("STRING.concat"), latex{}("{#1}+_{\\scriptstyle\\it String}{#2}"), left{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1485,21,1485,135)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  symbol Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(SortExp{}, SortExp{}) : SortExp{} [constructor{}(), format{}("%1 %c+%r %2"), functional{}(), injective{}(), left{}(Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,18,5,44)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)"), priorities{}(), right{}(), strict{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'-Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c-Int%r %2"), function{}(), functional{}(), hook{}("INT.sub"), klabel{}("_-Int_"), latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1025,18,1025,174)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smt-hook{}("-"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [format{}("%1 %c-Map%r %2"), function{}(), functional{}(), hook{}("MAP.difference"), latex{}("{#1}-_{\\it Map}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,18,311,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsSlsh'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c/Int%r %2"), function{}(), hook{}("INT.tdiv"), klabel{}("_/Int_"), latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1018,18,1018,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("div"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c<<Int%r %2"), function{}(), hook{}("INT.shl"), klabel{}("_<<Int_"), latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1028,18,1028,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shlInt"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c<=Int%r %2"), function{}(), functional{}(), hook{}("INT.le"), klabel{}("_<=Int_"), latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds-LT-Eqls'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1086,19,1086,172)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("<="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [format{}("%1 %c<=Map%r %2"), function{}(), functional{}(), hook{}("MAP.inclusion"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,19,383,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [format{}("%1 %c<=Set%r %2"), function{}(), functional{}(), hook{}("SET.inclusion"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(568,19,568,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [format{}("%1 %c<=String%r %2"), function{}(), functional{}(), hook{}("STRING.le"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1630,19,1630,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c<Int%r %2"), function{}(), functional{}(), hook{}("INT.lt"), klabel{}("_<Int_"), latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds-LT-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1087,19,1087,167)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("<"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [format{}("%1 %c<String%r %2"), function{}(), functional{}(), hook{}("STRING.lt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1629,19,1629,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [comm{}(), format{}("%1 %c=/=Bool%r %2"), function{}(), functional{}(), hook{}("BOOL.ne"), klabel{}("_=/=Bool_"), left{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(891,19,891,134)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("distinct"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [comm{}(), format{}("%1 %c=/=Int%r %2"), function{}(), functional{}(), hook{}("INT.ne"), klabel{}("_=/=Int_"), latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsEqlsSlshEqls'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1091,19,1091,190)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("distinct"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [comm{}(), format{}("%1 %c=/=K%r %2"), function{}(), functional{}(), hook{}("KEQUAL.ne"), klabel{}("_=/=K_"), latex{}("{#1}\\mathrel{\\neq_K}{#2}"), left{}(Lbl'UndsEqlsEqls'K'Unds'{}(),Lbl'UndsEqlsSlshEqls'K'Unds'{}()), notEqualEqualK{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2042,19,2042,172)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), right{}(), smt-hook{}("distinct"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [comm{}(), format{}("%1 %c=/=String%r %2"), function{}(), functional{}(), hook{}("STRING.ne"), left{}(Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1626,19,1626,96)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [comm{}(), format{}("%1 %c==Bool%r %2"), function{}(), functional{}(), hook{}("BOOL.eq"), klabel{}("_==Bool_"), left{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(890,19,890,126)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [comm{}(), format{}("%1 %c==Int%r %2"), function{}(), functional{}(), hook{}("INT.eq"), klabel{}("_==Int_"), latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsEqlsEqls'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1090,19,1090,179)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [comm{}(), equalEqualK{}(), format{}("%1 %c==K%r %2"), function{}(), functional{}(), hook{}("KEQUAL.eq"), klabel{}("_==K_"), latex{}("{#1}\\mathrel{=_K}{#2}"), left{}(Lbl'UndsEqlsSlshEqls'K'Unds'{}(),Lbl'UndsEqlsEqls'K'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2041,19,2041,158)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), right{}(), smt-hook{}("="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [comm{}(), format{}("%1 %c==String%r %2"), function{}(), functional{}(), hook{}("STRING.eq"), left{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1625,19,1625,90)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c>=Int%r %2"), function{}(), functional{}(), hook{}("INT.ge"), klabel{}("_>=Int_"), latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds-GT-Eqls'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1088,19,1088,172)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}(">="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [format{}("%1 %c>=String%r %2"), function{}(), functional{}(), hook{}("STRING.ge"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1632,19,1632,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c>>Int%r %2"), function{}(), hook{}("INT.shr"), klabel{}("_>>Int_"), latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1027,18,1027,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shrInt"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds-GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c>Int%r %2"), function{}(), functional{}(), hook{}("INT.gt"), klabel{}("_>Int_"), latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds-GT-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1089,19,1089,167)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}(">"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [format{}("%1 %c>String%r %2"), function{}(), functional{}(), hook{}("STRING.gt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1631,19,1631,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [assoc{}(), element{}(LblListItem{}()), format{}("%1%n%2"), function{}(), functional{}(), hook{}("LIST.concat"), klabel{}("_List_"), left{}(Lbl'Unds'List'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(711,19,711,188)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_concat"), symbol'Kywd'{}(), terminals{}("00"), total{}(), unit{}(Lbl'Stop'List{}())]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [assoc{}(), comm{}(), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), format{}("%1%n%2"), function{}(), hook{}("MAP.concat"), index{}("0"), klabel{}("_Map_"), left{}(Lbl'Unds'Map'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,18,240,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("00"), unit{}(Lbl'Stop'Map{}())]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [assoc{}(), comm{}(), element{}(LblSetItem{}()), format{}("%1%n%2"), function{}(), hook{}("SET.concat"), idem{}(), klabel{}("_Set_"), left{}(Lbl'Unds'Set'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(503,18,503,165)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("00"), unit{}(Lbl'Stop'Set{}())]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}(), hook{}("LIST.update"), klabel{}("List:set"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(747,19,747,108)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010101")]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [format{}("%1 %c[%r %2 %c<-%r %cundef%r %c]%r"), function{}(), functional{}(), hook{}("MAP.remove"), klabel{}("_[_<-undef]"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(299,18,299,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010111"), total{}()]
+  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'Unds'KItem'Unds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [format{}("%1 %c[%r %2 %c]%r %corDefault%r %3"), function{}(), functional{}(), hook{}("MAP.lookupOrDefault"), klabel{}("Map:lookupOrDefault"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(281,20,281,134)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010110"), total{}()]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUnds'{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c^%%Int%r %2 %3"), function{}(), hook{}("INT.powmod"), klabel{}("_^%Int__"), left{}(Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'UndsXor-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1013,18,1013,139)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("(mod (^ #1 #2) #3)"), symbol'Kywd'{}(), terminals{}("0100")]
+  hooked-symbol Lbl'UndsXor-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c^Int%r %2"), function{}(), hook{}("INT.pow"), klabel{}("_^Int_"), latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsXor-'Int'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1012,18,1012,178)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("^"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [boolOperation{}(), format{}("%1 %candBool%r %2"), function{}(), functional{}(), hook{}("BOOL.and"), klabel{}("_andBool_"), latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), left{}(Lbl'Unds'andBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(883,19,883,185)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("and"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'andThenBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [boolOperation{}(), format{}("%1 %candThenBool%r %2"), function{}(), functional{}(), hook{}("BOOL.andThen"), klabel{}("_andThenBool_"), left{}(Lbl'Unds'andThenBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(884,19,884,147)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("and"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'divInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %cdivInt%r %2"), function{}(), hook{}("INT.ediv"), klabel{}("_divInt_"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1021,18,1021,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("div"), symbol'Kywd'{}(), terminals{}("010")]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %cdividesInt%r %2"), function{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1100,19,1100,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'impliesBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [boolOperation{}(), format{}("%1 %cimpliesBool%r %2"), function{}(), functional{}(), hook{}("BOOL.implies"), klabel{}("_impliesBool_"), left{}(Lbl'Unds'impliesBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(888,19,888,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("=>"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(SortKItem{}, SortList{}) : SortBool{} [format{}("%1 %cin%r %2"), function{}(), functional{}(), hook{}("LIST.in"), klabel{}("_inList_"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(794,19,794,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [format{}("%1 %cin_keys%r %c(%r %2 %c)%r"), function{}(), functional{}(), hook{}("MAP.in_keys"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(357,19,357,89)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("01101"), total{}()]
+  hooked-symbol Lbl'Unds'modInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %cmodInt%r %2"), function{}(), hook{}("INT.emod"), klabel{}("_modInt_"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1022,18,1022,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("mod"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'orBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [boolOperation{}(), format{}("%1 %corBool%r %2"), function{}(), functional{}(), hook{}("BOOL.or"), klabel{}("_orBool_"), latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), left{}(Lbl'Unds'orBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(886,19,886,180)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("or"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'orElseBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [boolOperation{}(), format{}("%1 %corElseBool%r %2"), function{}(), functional{}(), hook{}("BOOL.orElse"), klabel{}("_orElseBool_"), left{}(Lbl'Unds'orElseBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(887,19,887,144)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("or"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'xorBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [boolOperation{}(), format{}("%1 %cxorBool%r %2"), function{}(), functional{}(), hook{}("BOOL.xor"), klabel{}("_xorBool_"), left{}(Lbl'Unds'xorBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(885,19,885,139)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("xor"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'xorInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %cxorInt%r %2"), function{}(), functional{}(), hook{}("INT.xor"), klabel{}("_xorInt_"), latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds'xorInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1032,18,1032,190)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("xorInt"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [format{}("%1 %c|->%r %2"), function{}(), functional{}(), hook{}("MAP.element"), injective{}(), klabel{}("_|->_"), latex{}("{#1}\\mapsto{#2}"), left{}(Lbl'UndsPipe'-'-GT-Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(257,18,257,151)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Stop'Map{}(),Lbl'Unds'Map'Unds'{}()), right{}(Lbl'UndsPipe'-'-GT-Unds'{}()), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c|Int%r %2"), function{}(), functional{}(), hook{}("INT.or"), klabel{}("_|Int_"), latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsPipe'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1034,18,1034,181)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("orInt"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [comm{}(), format{}("%1 %c|Set%r %2"), function{}(), functional{}(), hook{}("SET.union"), left{}(Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(530,18,530,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%cabsInt%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("INT.abs"), klabel{}("absInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1051,18,1051,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("(ite (< #1 0) (- 0 #1) #1)"), terminals{}("1101"), total{}()]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [format{}("%cbitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("INT.bitRange"), klabel{}("bitRangeInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1076,18,1076,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol LblcategoryChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'String{}(SortString{}) : SortString{} [format{}("%ccategoryChar%r %c(%r %1 %c)%r"), function{}(), hook{}("STRING.category"), klabel{}("categoryChar"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1642,21,1642,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'Unds'KItem'Unds'Map{}(SortMap{}) : SortKItem{} [format{}("%cchoice%r %c(%r %1 %c)%r"), function{}(), hook{}("MAP.choice"), klabel{}("Map:choice"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,20,393,101)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'SET'Unds'KItem'Unds'Set{}(SortSet{}) : SortKItem{} [format{}("%cchoice%r %c(%r %1 %c)%r"), function{}(), hook{}("SET.choice"), klabel{}("Set:choice"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(586,20,586,95)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblchrChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(SortInt{}) : SortString{} [format{}("%cchrChar%r %c(%r %1 %c)%r"), function{}(), hook{}("STRING.chr"), klabel{}("chrChar"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1502,21,1502,70)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortInt{} [format{}("%ccountAllOccurrences%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("STRING.countAllOccurrences"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1615,18,1615,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  hooked-symbol LbldirectionalityChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'String{}(SortString{}) : SortString{} [format{}("%cdirectionalityChar%r %c(%r %1 %c)%r"), function{}(), hook{}("STRING.directionality"), klabel{}("directionalityChar"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1643,21,1643,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [format{}("%cfillList%r %c(%r %1 %c,%r %2 %c,%r %3 %c,%r %4 %c)%r"), function{}(), hook{}("LIST.fill"), klabel{}("fillList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(775,19,775,100)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101010101")]
+  hooked-symbol LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [format{}("%cfindChar%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("STRING.findChar"), klabel{}("findChar"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1539,18,1539,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [format{}("%cfindString%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("STRING.find"), klabel{}("findString"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1528,18,1528,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  symbol LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(SortInt{}) : SortId{} [format{}("%cfreshId%r %c(%r %1 %c)%r"), freshGenerator{}(), function{}(), functional{}(), klabel{}("freshId"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2013,17,2013,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), private{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%cfreshInt%r %c(%r %1 %c)%r"), freshGenerator{}(), function{}(), functional{}(), klabel{}("freshInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1216,18,1216,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), private{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblgetGeneratedCounterCell{}(SortGeneratedTopCell{}) : SortGeneratedCounterCell{} [format{}("%cgetGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [format{}("%cinitGeneratedCounterCell%r"), function{}(), initializer{}(), left{}(), noThread{}(), priorities{}(), right{}(), terminals{}("1")]
+  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [format{}("%cinitGeneratedTopCell%r %c(%r %1 %c)%r"), function{}(), initializer{}(), left{}(), noThread{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [format{}("%cinitKCell%r %c(%r %1 %c)%r"), function{}(), initializer{}(), left{}(), noThread{}(), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [comm{}(), format{}("%cintersectSet%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("SET.intersection"), klabel{}("intersectSet"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(541,18,541,90)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  symbol LblisBool{}(SortK{}) : SortBool{} [format{}("%cisBool%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Bool"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisExp{}(SortK{}) : SortBool{} [format{}("%cisExp%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Exp"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisFloat{}(SortK{}) : SortBool{} [format{}("%cisFloat%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Float"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [format{}("%cisGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedCounterCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [format{}("%cisGeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedCounterCellOpt"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [format{}("%cisGeneratedTopCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedTopCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [format{}("%cisGeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedTopCellFragment"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisIOError{}(SortK{}) : SortBool{} [format{}("%cisIOError%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("IOError"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisIOFile{}(SortK{}) : SortBool{} [format{}("%cisIOFile%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("IOFile"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisIOInt{}(SortK{}) : SortBool{} [format{}("%cisIOInt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("IOInt"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisIOString{}(SortK{}) : SortBool{} [format{}("%cisIOString%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("IOString"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisId{}(SortK{}) : SortBool{} [format{}("%cisId%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Id"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisInt{}(SortK{}) : SortBool{} [format{}("%cisInt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Int"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisK{}(SortK{}) : SortBool{} [format{}("%cisK%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("K"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [format{}("%cisKCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [format{}("%cisKCellOpt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KCellOpt"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [format{}("%cisKConfigVar%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KConfigVar"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [format{}("%cisKItem%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KItem"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKResult{}(SortExp{}) : SortBool{} [format{}("%cisKResult%r %c(%r %1 %c)%r"), function{}(), klabel{}("isKResult"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(17,19,17,52)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1101")]
+  symbol LblisList{}(SortK{}) : SortBool{} [format{}("%cisList%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("List"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisMap{}(SortK{}) : SortBool{} [format{}("%cisMap%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Map"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [format{}("%cisSet%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Set"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisStream{}(SortK{}) : SortBool{} [format{}("%cisStream%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Stream"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisString{}(SortK{}) : SortBool{} [format{}("%cisString%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("String"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(SortMap{}) : SortSet{} [format{}("%ckeys%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("MAP.keys"), klabel{}("keys"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,18,341,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [format{}("%ckeys_list%r %c(%r %1 %c)%r"), function{}(), hook{}("MAP.keys_list"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,19,349,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [format{}("%clengthString%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("STRING.length"), klabel{}("lengthString"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1493,18,1493,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%clog2Int%r %c(%r %1 %c)%r"), function{}(), hook{}("INT.log2"), klabel{}("log2Int"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1062,18,1062,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'Unds'List'Unds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [format{}("%cmakeList%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), hook{}("LIST.make"), klabel{}("makeList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(756,19,756,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%cmaxInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("INT.max"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1043,18,1043,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("(ite (< #1 #2) #2 #1)"), terminals{}("110101"), total{}()]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%cminInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("INT.min"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1042,18,1042,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("(ite (< #1 #2) #1 #2)"), terminals{}("110101"), total{}()]
+  hooked-symbol LblnewUUID'Unds'STRING-COMMON'Unds'String{}() : SortString{} [format{}("%cnewUUID%r"), function{}(), hook{}("STRING.uuid"), impure{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1645,21,1645,68)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1")]
+  symbol LblnoGeneratedCounterCell{}() : SortGeneratedCounterCellOpt{} [cellOptAbsent{}("GeneratedCounterCell"), constructor{}(), format{}("%cnoGeneratedCounterCell%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  symbol LblnoKCell{}() : SortKCellOpt{} [cellOptAbsent{}("KCell"), constructor{}(), format{}("%cnoKCell%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [boolOperation{}(), format{}("%cnotBool%r %1"), function{}(), functional{}(), hook{}("BOOL.not"), klabel{}("notBool_"), latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(882,19,882,172)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), right{}(), smt-hook{}("not"), symbol'Kywd'{}(), terminals{}("10"), total{}()]
+  hooked-symbol LblordChar'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [format{}("%cordChar%r %c(%r %1 %c)%r"), function{}(), hook{}("STRING.ord"), klabel{}("ordChar"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1503,18,1503,70)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'ColnHash'tempFile'Coln'fd{}(SortIOFile{}) : SortInt{} [format{}("%cfd%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'ColnHash'tempFile'Coln'path{}(SortIOFile{}) : SortString{} [format{}("%cpath%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'ColnHash'unknownIOError'Coln'errno{}(SortIOError{}) : SortInt{} [format{}("%cerrno%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Bool{}(SortK{}) : SortBool{} [format{}("%cproject:Bool%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Exp{}(SortK{}) : SortExp{} [format{}("%cproject:Exp%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Float{}(SortK{}) : SortFloat{} [format{}("%cproject:Float%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedCounterCell{}(SortK{}) : SortGeneratedCounterCell{} [format{}("%cproject:GeneratedCounterCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedCounterCellOpt{}(SortK{}) : SortGeneratedCounterCellOpt{} [format{}("%cproject:GeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedTopCell{}(SortK{}) : SortGeneratedTopCell{} [format{}("%cproject:GeneratedTopCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedTopCellFragment{}(SortK{}) : SortGeneratedTopCellFragment{} [format{}("%cproject:GeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'IOError{}(SortK{}) : SortIOError{} [format{}("%cproject:IOError%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'IOFile{}(SortK{}) : SortIOFile{} [format{}("%cproject:IOFile%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'IOInt{}(SortK{}) : SortIOInt{} [format{}("%cproject:IOInt%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'IOString{}(SortK{}) : SortIOString{} [format{}("%cproject:IOString%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Id{}(SortK{}) : SortId{} [format{}("%cproject:Id%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Int{}(SortK{}) : SortInt{} [format{}("%cproject:Int%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'K{}(SortK{}) : SortK{} [format{}("%cproject:K%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'KCell{}(SortK{}) : SortKCell{} [format{}("%cproject:KCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'KCellOpt{}(SortK{}) : SortKCellOpt{} [format{}("%cproject:KCellOpt%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'KItem{}(SortK{}) : SortKItem{} [format{}("%cproject:KItem%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'List{}(SortK{}) : SortList{} [format{}("%cproject:List%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Map{}(SortK{}) : SortMap{} [format{}("%cproject:Map%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Set{}(SortK{}) : SortSet{} [format{}("%cproject:Set%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Stream{}(SortK{}) : SortStream{} [format{}("%cproject:Stream%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'String{}(SortK{}) : SortString{} [format{}("%cproject:String%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%crandInt%r %c(%r %1 %c)%r"), function{}(), hook{}("INT.rand"), impure{}(), klabel{}("randInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1110,18,1110,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [format{}("%cremoveAll%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("MAP.removeAll"), klabel{}("removeAll"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,18,333,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  hooked-symbol Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortString{}, SortInt{}) : SortString{} [format{}("%creplace%r %c(%r %1 %c,%r %2 %c,%r %3 %c,%r %4 %c)%r"), function{}(), hook{}("STRING.replace"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1613,21,1613,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101010101")]
+  hooked-symbol LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [format{}("%creplaceAll%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), functional{}(), hook{}("STRING.replaceAll"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1612,21,1612,149)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), total{}()]
+  hooked-symbol LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [format{}("%creplaceFirst%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), functional{}(), hook{}("STRING.replaceFirst"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1614,21,1614,151)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), total{}()]
+  hooked-symbol LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [format{}("%crfindChar%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("STRING.rfindChar"), klabel{}("rfindChar"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1540,18,1540,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [format{}("%crfindString%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("STRING.rfind"), klabel{}("rfindString"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1529,18,1529,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [format{}("%csignExtendBitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("INT.signExtendBitRange"), klabel{}("signExtendBitRangeInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1077,18,1077,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol Lblsize'LParUndsRParUnds'LIST'Unds'Int'Unds'List{}(SortList{}) : SortInt{} [format{}("%csize%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("LIST.size"), klabel{}("sizeList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(802,18,802,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_len"), terminals{}("1101"), total{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'MAP'Unds'Int'Unds'Map{}(SortMap{}) : SortInt{} [format{}("%csize%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("MAP.size"), klabel{}("sizeMap"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(373,18,373,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(SortSet{}) : SortInt{} [format{}("%csize%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("SET.size"), klabel{}("size"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(576,18,576,76)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT-COMMON'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [format{}("%csrandInt%r %c(%r %1 %c)%r"), function{}(), hook{}("INT.srand"), impure{}(), klabel{}("srandInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1111,16,1111,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(SortString{}, SortInt{}, SortInt{}) : SortString{} [format{}("%csubstrString%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), functional{}(), hook{}("STRING.substr"), klabel{}("substrString"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1518,21,1518,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), total{}()]
+  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [format{}("%cupdateList%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("LIST.updateAll"), klabel{}("updateList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(766,19,766,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [format{}("%cupdateMap%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("MAP.updateAll"), klabel{}("updateMap"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(324,18,324,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [format{}("%cvalues%r %c(%r %1 %c)%r"), function{}(), hook{}("MAP.values"), klabel{}("values"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(365,19,365,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbl'Tild'Int'Unds'{}(SortInt{}) : SortInt{} [format{}("%c~Int%r %1"), function{}(), functional{}(), hook{}("INT.not"), klabel{}("~Int_"), latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1010,18,1010,168)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsXor-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smtlib{}("notInt"), symbol'Kywd'{}(), terminals{}("10"), total{}()]
+
+// generated axioms
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOString{}, SortKItem{}} (From:SortIOString{}))) [subsort{SortIOString{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortString{}, SortKItem{}} (From:SortString{}))) [subsort{SortString{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCellOpt{}, SortKItem{}} (From:SortKCellOpt{}))) [subsort{SortKCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (From:SortGeneratedCounterCellOpt{}))) [subsort{SortGeneratedCounterCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCell{}, SortKItem{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOInt{}, \equals{SortIOInt{}, R} (Val:SortIOInt{}, inj{SortIOError{}, SortIOInt{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOInt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, inj{SortKCell{}, SortKCellOpt{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSet{}, SortKItem{}} (From:SortSet{}))) [subsort{SortSet{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOError{}, SortKItem{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOInt{}, \equals{SortIOInt{}, R} (Val:SortIOInt{}, inj{SortInt{}, SortIOInt{}} (From:SortInt{}))) [subsort{SortInt{}, SortIOInt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStream{}, SortKItem{}} (From:SortStream{}))) [subsort{SortStream{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOFile{}, SortKItem{}} (From:SortIOFile{}))) [subsort{SortIOFile{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCell{}, SortKItem{}} (From:SortGeneratedTopCell{}))) [subsort{SortGeneratedTopCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOInt{}, SortKItem{}} (From:SortIOInt{}))) [subsort{SortIOInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortList{}, SortKItem{}} (From:SortList{}))) [subsort{SortList{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKConfigVar{}, SortKItem{}} (From:SortKConfigVar{}))) [subsort{SortKConfigVar{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOString{}, \equals{SortIOString{}, R} (Val:SortIOString{}, inj{SortString{}, SortIOString{}} (From:SortString{}))) [subsort{SortString{}, SortIOString{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortId{}, SortKItem{}} (From:SortId{}))) [subsort{SortId{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortFloat{}, SortKItem{}} (From:SortFloat{}))) [subsort{SortFloat{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBool{}, SortKItem{}} (From:SortBool{}))) [subsort{SortBool{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (From:SortGeneratedTopCellFragment{}))) [subsort{SortGeneratedTopCellFragment{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortExp{}, SortKItem{}} (From:SortExp{}))) [subsort{SortExp{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMap{}, SortKItem{}} (From:SortMap{}))) [subsort{SortMap{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortInt{}, SortExp{}} (From:SortInt{}))) [subsort{SortInt{}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOString{}, \equals{SortIOString{}, R} (Val:SortIOString{}, inj{SortIOError{}, SortIOString{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOString{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOFile{}, \equals{SortIOFile{}, R} (Val:SortIOFile{}, inj{SortIOError{}, SortIOFile{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOFile{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'E2BIG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EACCES{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EADDRINUSE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EADDRNOTAVAIL{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EAFNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EAGAIN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EALREADY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EBADF{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EBUSY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECHILD{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNABORTED{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNREFUSED{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNRESET{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDEADLK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDESTADDRREQ{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDOM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EEXIST{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EFAULT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EFBIG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EHOSTDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EHOSTUNREACH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINPROGRESS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINTR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINVAL{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EIO{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EISCONN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EISDIR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ELOOP{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMFILE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMLINK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMSGSIZE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENAMETOOLONG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETRESET{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETUNREACH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENFILE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOBUFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENODEV{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOENT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOEXEC{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOLCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOMEM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOPROTOOPT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOSPC{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOSYS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTCONN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTDIR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTEMPTY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTSOCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTTY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENXIO{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOF{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOPNOTSUPP{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOVERFLOW{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPERM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPFNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPIPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPROTONOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPROTOTYPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ERANGE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EROFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESHUTDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESOCKTNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESPIPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESRCH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ETIMEDOUT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ETOOMANYREFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EWOULDBLOCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EXDEV{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(Y0:SortK{})), Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(X0:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(X0:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R, SortSort} \exists{R} (Val:SortSort, \equals{SortSort, R} (Val:SortSort, Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(K0:SortBool{}, K1:SortSort, K2:SortSort))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{})), Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'log{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'logToFile{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{})), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(X0:SortString{}, X1:SortString{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{})), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(\and{SortString{}} (X0:SortString{}, Y0:SortString{}), \and{SortString{}} (X1:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'remove'LParUndsRParUnds'K-IO'Unds'K'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'systemResult{}(K0:SortInt{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'systemResult{}(X0:SortInt{}, X1:SortString{}, X2:SortString{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{})), Lbl'Hash'systemResult{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}), \and{SortString{}} (X1:SortString{}, Y1:SortString{}), \and{SortString{}} (X2:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortIOFile{}, \equals{SortIOFile{}, R} (Val:SortIOFile{}, Lbl'Hash'tempFile{}(K0:SortString{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortIOFile{}} (\and{SortIOFile{}} (Lbl'Hash'tempFile{}(X0:SortString{}, X1:SortInt{}), Lbl'Hash'tempFile{}(Y0:SortString{}, Y1:SortInt{})), Lbl'Hash'tempFile{}(\and{SortString{}} (X0:SortString{}, Y0:SortString{}), \and{SortInt{}} (X1:SortInt{}, Y1:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'trace{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'traceK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'unknownIOError{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'unknownIOError{}(Y0:SortInt{})), Lbl'Hash'unknownIOError{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Stop'Set{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, Lbl'-LT-'generatedCounter'-GT-'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedCounterCell{}} (\and{SortGeneratedCounterCell{}} (Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{}), Lbl'-LT-'generatedCounter'-GT-'{}(Y0:SortInt{})), Lbl'-LT-'generatedCounter'-GT-'{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCell{}, \equals{SortGeneratedTopCell{}, R} (Val:SortGeneratedTopCell{}, Lbl'-LT-'generatedTop'-GT-'{}(K0:SortKCell{}, K1:SortGeneratedCounterCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCell{}} (\and{SortGeneratedTopCell{}} (Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}), Lbl'-LT-'generatedTop'-GT-'{}(Y0:SortKCell{}, Y1:SortGeneratedCounterCell{})), Lbl'-LT-'generatedTop'-GT-'{}(\and{SortKCell{}} (X0:SortKCell{}, Y0:SortKCell{}), \and{SortGeneratedCounterCell{}} (X1:SortGeneratedCounterCell{}, Y1:SortGeneratedCounterCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCellFragment{}, \equals{SortGeneratedTopCellFragment{}, R} (Val:SortGeneratedTopCellFragment{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(K0:SortKCellOpt{}, K1:SortGeneratedCounterCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCellFragment{}} (\and{SortGeneratedTopCellFragment{}} (Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}), Lbl'-LT-'generatedTop'-GT-'-fragment{}(Y0:SortKCellOpt{}, Y1:SortGeneratedCounterCellOpt{})), Lbl'-LT-'generatedTop'-GT-'-fragment{}(\and{SortKCellOpt{}} (X0:SortKCellOpt{}, Y0:SortKCellOpt{}), \and{SortGeneratedCounterCellOpt{}} (X1:SortGeneratedCounterCellOpt{}, Y1:SortGeneratedCounterCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, Lbl'-LT-'k'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblFloat2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float{}(K0:SortFloat{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblId2String'LParUndsRParUnds'ID-COMMON'Unds'String'Unds'Id{}(K0:SortId{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblMap'Coln'update{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortKItem{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(K0:SortExp{}, K1:SortExp{}))) [functional{}()] // functional
+  axiom{}\implies{SortExp{}} (\and{SortExp{}} (Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(X0:SortExp{}, X1:SortExp{}), Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(Y0:SortExp{}, Y1:SortExp{})), Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(\and{SortExp{}} (X0:SortExp{}, Y0:SortExp{}), \and{SortExp{}} (X1:SortExp{}, Y1:SortExp{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:SortList{},K2:SortList{}),K3:SortList{}),Lbl'Unds'List'Unds'{}(K1:SortList{},Lbl'Unds'List'Unds'{}(K2:SortList{},K3:SortList{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(K:SortList{},Lbl'Stop'List{}()),K:SortList{}) [unit{}()] // right unit
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Stop'List{}(),K:SortList{}),K:SortList{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K:SortMap{},Lbl'Stop'Map{}()),K:SortMap{}) [unit{}()] // right unit
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),K:SortMap{}),K:SortMap{}) [unit{}()] // left unit
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},Lbl'Stop'Set{}()),K:SortSet{}) [unit{}()] // right unit
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Stop'Set{}(),K:SortSet{}),K:SortSet{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'Unds'KItem'Unds'Map'Unds'KItem'Unds'KItem{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(K0:SortKItem{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortKItem{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBool{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisExp{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisFloat{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCellFragment{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOError{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOFile{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOString{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisId{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKConfigVar{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisList{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMap{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisSet{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisStream{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisString{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, LblnoGeneratedCounterCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, LblnoKCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'LIST'Unds'Int'Unds'List{}(K0:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'MAP'Unds'Int'Unds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(K0:SortString{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'Unds'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortInt{}, \exists{SortKItem{}} (X1:SortString{}, \exists{SortKItem{}} (X2:SortString{}, Lbl'Hash'systemResult{}(X0:SortInt{}, X1:SortString{}, X2:SortString{})))), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortString{}, inj{SortString{}, SortKItem{}} (Val:SortString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKConfigVar{}, inj{SortKConfigVar{}, SortKItem{}} (Val:SortKConfigVar{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOInt{}, inj{SortIOInt{}, SortKItem{}} (Val:SortIOInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortExp{}, inj{SortExp{}, SortKItem{}} (Val:SortExp{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (Val:SortGeneratedCounterCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (Val:SortGeneratedCounterCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortId{}, inj{SortId{}, SortKItem{}} (Val:SortId{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStream{}, inj{SortStream{}, SortKItem{}} (Val:SortStream{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOFile{}, inj{SortIOFile{}, SortKItem{}} (Val:SortIOFile{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortFloat{}, inj{SortFloat{}, SortKItem{}} (Val:SortFloat{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOString{}, inj{SortIOString{}, SortKItem{}} (Val:SortIOString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOError{}, inj{SortIOError{}, SortKItem{}} (Val:SortIOError{})), \bottom{SortKItem{}}())))))))))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \or{SortString{}} (\top{SortString{}}(), \bottom{SortString{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortIOInt{}} (\exists{SortIOInt{}} (Val:SortInt{}, inj{SortInt{}, SortIOInt{}} (Val:SortInt{})), \or{SortIOInt{}} (\exists{SortIOInt{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOInt{}} (Val:SortIOError{})), \bottom{SortIOInt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortExp{}} (\exists{SortExp{}} (X0:SortExp{}, \exists{SortExp{}} (X1:SortExp{}, Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(X0:SortExp{}, X1:SortExp{}))), \or{SortExp{}} (\exists{SortExp{}} (Val:SortInt{}, inj{SortInt{}, SortExp{}} (Val:SortInt{})), \bottom{SortExp{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCellOpt{}} (LblnoGeneratedCounterCell{}(), \or{SortGeneratedCounterCellOpt{}} (\exists{SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{})), \bottom{SortGeneratedCounterCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortId{}} (\top{SortId{}}(), \bottom{SortId{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortStream{}} (\exists{SortStream{}} (X0:SortK{}, Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{})), \or{SortStream{}} (\exists{SortStream{}} (X0:SortInt{}, Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{})), \or{SortStream{}} (\exists{SortStream{}} (X0:SortInt{}, Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{})), \or{SortStream{}} (\exists{SortStream{}} (X0:SortString{}, \exists{SortStream{}} (X1:SortString{}, Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(X0:SortString{}, X1:SortString{}))), \bottom{SortStream{}}())))) [constructor{}()] // no junk
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOFile{}} (\exists{SortIOFile{}} (X0:SortString{}, \exists{SortIOFile{}} (X1:SortInt{}, Lbl'Hash'tempFile{}(X0:SortString{}, X1:SortInt{}))), \or{SortIOFile{}} (\exists{SortIOFile{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOFile{}} (Val:SortIOError{})), \bottom{SortIOFile{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortKCellOpt{}} (LblnoKCell{}(), \or{SortKCellOpt{}} (\exists{SortKCellOpt{}} (Val:SortKCell{}, inj{SortKCell{}, SortKCellOpt{}} (Val:SortKCell{})), \bottom{SortKCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortFloat{}} (\top{SortFloat{}}(), \bottom{SortFloat{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortGeneratedTopCell{}} (\exists{SortGeneratedTopCell{}} (X0:SortKCell{}, \exists{SortGeneratedTopCell{}} (X1:SortGeneratedCounterCell{}, Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}))), \bottom{SortGeneratedTopCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOString{}} (\exists{SortIOString{}} (Val:SortString{}, inj{SortString{}, SortIOString{}} (Val:SortString{})), \or{SortIOString{}} (\exists{SortIOString{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOString{}} (Val:SortIOError{})), \bottom{SortIOString{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCellFragment{}} (\exists{SortGeneratedTopCellFragment{}} (X0:SortKCellOpt{}, \exists{SortGeneratedTopCellFragment{}} (X1:SortGeneratedCounterCellOpt{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}))), \bottom{SortGeneratedTopCellFragment{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOError{}} (Lbl'Hash'E2BIG{}(), \or{SortIOError{}} (Lbl'Hash'EACCES{}(), \or{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), \or{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), \or{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), \or{SortIOError{}} (Lbl'Hash'EAGAIN{}(), \or{SortIOError{}} (Lbl'Hash'EALREADY{}(), \or{SortIOError{}} (Lbl'Hash'EBADF{}(), \or{SortIOError{}} (Lbl'Hash'EBUSY{}(), \or{SortIOError{}} (Lbl'Hash'ECHILD{}(), \or{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), \or{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), \or{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), \or{SortIOError{}} (Lbl'Hash'EDEADLK{}(), \or{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), \or{SortIOError{}} (Lbl'Hash'EDOM{}(), \or{SortIOError{}} (Lbl'Hash'EEXIST{}(), \or{SortIOError{}} (Lbl'Hash'EFAULT{}(), \or{SortIOError{}} (Lbl'Hash'EFBIG{}(), \or{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), \or{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), \or{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), \or{SortIOError{}} (Lbl'Hash'EINTR{}(), \or{SortIOError{}} (Lbl'Hash'EINVAL{}(), \or{SortIOError{}} (Lbl'Hash'EIO{}(), \or{SortIOError{}} (Lbl'Hash'EISCONN{}(), \or{SortIOError{}} (Lbl'Hash'EISDIR{}(), \or{SortIOError{}} (Lbl'Hash'ELOOP{}(), \or{SortIOError{}} (Lbl'Hash'EMFILE{}(), \or{SortIOError{}} (Lbl'Hash'EMLINK{}(), \or{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), \or{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), \or{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), \or{SortIOError{}} (Lbl'Hash'ENETRESET{}(), \or{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), \or{SortIOError{}} (Lbl'Hash'ENFILE{}(), \or{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), \or{SortIOError{}} (Lbl'Hash'ENODEV{}(), \or{SortIOError{}} (Lbl'Hash'ENOENT{}(), \or{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), \or{SortIOError{}} (Lbl'Hash'ENOLCK{}(), \or{SortIOError{}} (Lbl'Hash'ENOMEM{}(), \or{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), \or{SortIOError{}} (Lbl'Hash'ENOSPC{}(), \or{SortIOError{}} (Lbl'Hash'ENOSYS{}(), \or{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), \or{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), \or{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), \or{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), \or{SortIOError{}} (Lbl'Hash'ENOTTY{}(), \or{SortIOError{}} (Lbl'Hash'ENXIO{}(), \or{SortIOError{}} (Lbl'Hash'EOF{}(), \or{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), \or{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), \or{SortIOError{}} (Lbl'Hash'EPERM{}(), \or{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), \or{SortIOError{}} (Lbl'Hash'EPIPE{}(), \or{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), \or{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), \or{SortIOError{}} (Lbl'Hash'ERANGE{}(), \or{SortIOError{}} (Lbl'Hash'EROFS{}(), \or{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), \or{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), \or{SortIOError{}} (Lbl'Hash'ESPIPE{}(), \or{SortIOError{}} (Lbl'Hash'ESRCH{}(), \or{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), \or{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), \or{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), \or{SortIOError{}} (Lbl'Hash'EXDEV{}(), \or{SortIOError{}} (\exists{SortIOError{}} (X0:SortInt{}, Lbl'Hash'unknownIOError{}(X0:SortInt{})), \bottom{SortIOError{}}())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) [constructor{}()] // no junk
+
+// rules
+// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,B1,_Gen0)=>B1 requires C ensures #token("true","Bool") [UNIQUE_ID(2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2), org.kframework.attributes.Location(Location(2073,8,2073,59)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        VarC:SortBool{},
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarB1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB1:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2073,8,2073,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,_Gen0,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [UNIQUE_ID(651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa), org.kframework.attributes.Location(Location(2074,8,2074,67)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        LblnotBool'Unds'{}(VarC:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            VarB2:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB2:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2074,8,2074,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `#open(_)_K-IO_IOInt_String`(S)=>`#open(_,_)_K-IO_IOInt_String_String`(S,#token("\"r+\"","String")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7ad2779cd54b9009119458217cae5138026cc4ff244e54c28e64db21100f63d9), org.kframework.attributes.Location(Location(2248,8,2248,48)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS:SortString{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOInt{},R} (
+      Lbl'Hash'open'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'String{}(X0:SortString{}),
+     \and{SortIOInt{}} (
+       Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'Unds'IOInt'Unds'String'Unds'String{}(VarS:SortString{},\dv{SortString{}}("r+")),
+        \top{SortIOInt{}}())))
+  [UNIQUE'Unds'ID{}("7ad2779cd54b9009119458217cae5138026cc4ff244e54c28e64db21100f63d9"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2248,8,2248,48)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `#stderr_K-IO_Int`(.KList)=>#token("2","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(75e0a8082acda4cf1e29caa6aaafb7f9a421e16421a41f2006943d6fab17a162), org.kframework.attributes.Location(Location(2345,8,2345,20)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortInt{},R} (
+      Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}(),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("2"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("75e0a8082acda4cf1e29caa6aaafb7f9a421e16421a41f2006943d6fab17a162"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2345,8,2345,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `#stdin_K-IO_Int`(.KList)=>#token("0","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c7ffdc9908c28a954521816d680f4e5ec44a679c7231a8dd09d4700f50b6d8c3), org.kframework.attributes.Location(Location(2343,8,2343,19)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortInt{},R} (
+      Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}(),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("0"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("c7ffdc9908c28a954521816d680f4e5ec44a679c7231a8dd09d4700f50b6d8c3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2343,8,2343,19)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `#stdout_K-IO_Int`(.KList)=>#token("1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4ad4f379ff9db687ff9dfd1b15052edbcd3342a2ed262ecdd38c769e177a592c), org.kframework.attributes.Location(Location(2344,8,2344,20)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortInt{},R} (
+      Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}(),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("1"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("4ad4f379ff9db687ff9dfd1b15052edbcd3342a2ed262ecdd38c769e177a592c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2344,8,2344,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp0_`(inj{Exp,KItem}(K1))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp`(HOLE,K1))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(HOLE)) ensures #token("true","Bool") [UNIQUE_ID(2e9a018f211f6dae4efd71c7d497612c1854e3b4e716a3b64c42742396bb68f2), cool, cool-like, left, org.kframework.attributes.Location(Location(5,18,5,44)), org.kframework.attributes.Source(Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)), strict]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK1:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(VarHOLE:SortExp{})),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(VarHOLE:SortExp{},VarK1:SortExp{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("2e9a018f211f6dae4efd71c7d497612c1854e3b4e716a3b64c42742396bb68f2"), cool{}(), cool-like{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,18,5,44)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)"), strict{}()]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp1_`(inj{Exp,KItem}(K0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp`(K0,HOLE))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(HOLE)) ensures #token("true","Bool") [UNIQUE_ID(75cae68863d7594ffd59a6b351cc294e0c0d27ecd155cd8fdb143ec822ffa373), cool, cool-like, left, org.kframework.attributes.Location(Location(5,18,5,44)), org.kframework.attributes.Source(Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)), strict]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(VarHOLE:SortExp{})),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(VarK0:SortExp{},VarHOLE:SortExp{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("75cae68863d7594ffd59a6b351cc294e0c0d27ecd155cd8fdb143ec822ffa373"), cool{}(), cool-like{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,18,5,44)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)"), strict{}()]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp`(HOLE,K1))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp0_`(inj{Exp,KItem}(K1))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(256b43ee5c1a63b36aeb7bc842c5115fd3ce501bdd7df89f992079de96ed0ebe), heat, left, org.kframework.attributes.Location(Location(5,18,5,44)), org.kframework.attributes.Source(Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)), strict]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(VarHOLE:SortExp{},VarK1:SortExp{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(VarHOLE:SortExp{}))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp0'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK1:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("256b43ee5c1a63b36aeb7bc842c5115fd3ce501bdd7df89f992079de96ed0ebe"), heat{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,18,5,44)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)"), strict{}()]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp`(K0,HOLE))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp1_`(inj{Exp,KItem}(K0))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(10f0aa53782d755b1057e9704033267f95c078122801f72f89a34a5687af749b), heat, left, org.kframework.attributes.Location(Location(5,18,5,44)), org.kframework.attributes.Source(Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)), strict]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(VarK0:SortExp{},VarHOLE:SortExp{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(VarHOLE:SortExp{}))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp1'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("10f0aa53782d755b1057e9704033267f95c078122801f72f89a34a5687af749b"), heat{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,18,5,44)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)"), strict{}()]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__ARITHMETIC-SYNTAX_Exp_Exp_Exp`(inj{Int,Exp}(A),inj{Int,Exp}(B)))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Int,KItem}(`_+Int_`(A,B))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(97f36d703686de5cd6bd8dd08a2f05cb258966bec3f144f0018ac28c1f5ab617), org.kframework.attributes.Location(Location(15,8,15,25)), org.kframework.attributes.Source(Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'ARITHMETIC-SYNTAX'Unds'Exp'Unds'Exp'Unds'Exp{}(inj{SortInt{}, SortExp{}}(VarA:SortInt{}),inj{SortInt{}, SortExp{}}(VarB:SortInt{}))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'UndsPlus'Int'Unds'{}(VarA:SortInt{},VarB:SortInt{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("97f36d703686de5cd6bd8dd08a2f05cb258966bec3f144f0018ac28c1f5ab617"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(15,8,15,25)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `Bool2String(_)_STRING-COMMON_String_Bool`(#token("false","Bool"))=>#token("\"false\"","String") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cca4780e4e7660055f781b9643f3125234a0f4f08ba76cacf8e5a18fe7fc999f), org.kframework.attributes.Location(Location(1548,8,1548,37)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(X0:SortBool{}),
+     \and{SortString{}} (
+       \dv{SortString{}}("false"),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("cca4780e4e7660055f781b9643f3125234a0f4f08ba76cacf8e5a18fe7fc999f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1548,8,1548,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `Bool2String(_)_STRING-COMMON_String_Bool`(#token("true","Bool"))=>#token("\"true\"","String") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(365df37345a5a44ac061f8741369c7bd74a49f0f6e7b716be0374806dd1add3d), org.kframework.attributes.Location(Location(1547,8,1547,36)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(X0:SortBool{}),
+     \and{SortString{}} (
+       \dv{SortString{}}("true"),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("365df37345a5a44ac061f8741369c7bd74a49f0f6e7b716be0374806dd1add3d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1547,8,1547,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `String2Bool(_)_STRING-COMMON_Bool_String`(#token("\"false\"","String"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b73b5c8e0ae45020f2b9b8170d366691fee01a63763b79653a2075703ec4e835), org.kframework.attributes.Location(Location(1554,8,1554,37)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            \dv{SortString{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(X0:SortString{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b73b5c8e0ae45020f2b9b8170d366691fee01a63763b79653a2075703ec4e835"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1554,8,1554,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `String2Bool(_)_STRING-COMMON_Bool_String`(#token("\"true\"","String"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(27a5d1d7872d61f82556a4e44bda13846dde7dc2d9c54304d7858de9a8b9d6b8), org.kframework.attributes.Location(Location(1553,8,1553,36)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            \dv{SortString{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(X0:SortString{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("27a5d1d7872d61f82556a4e44bda13846dde7dc2d9c54304d7858de9a8b9d6b8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1553,8,1553,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_<=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_<String__STRING-COMMON_Bool_String_String`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9e50fb4dcba1212ee863c170298cb8b555f39fb3b4bcb649f3d1d8e321accc80), org.kframework.attributes.Location(Location(1647,8,1647,63)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9e50fb4dcba1212ee863c170298cb8b555f39fb3b4bcb649f3d1d8e321accc80"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1647,8,1647,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_=/=Bool_`(B1,B2)=>`notBool_`(`_==Bool_`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f), org.kframework.attributes.Location(Location(932,8,932,57)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB1:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB2:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(VarB1:SortBool{},VarB2:SortBool{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(932,8,932,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_=/=Int_`(I1,I2)=>`notBool_`(`_==Int_`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3), org.kframework.attributes.Location(Location(1213,8,1213,53)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Int'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1213,8,1213,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c), org.kframework.attributes.Location(Location(2071,8,2071,45)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarK2:SortK{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2071,8,2071,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_=/=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_==String__STRING-COMMON_Bool_String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f390a9b650f3de0e3a93773a46e65aae3decdeb2a10906058f204f031681c9b7), org.kframework.attributes.Location(Location(1627,8,1627,65)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f390a9b650f3de0e3a93773a46e65aae3decdeb2a10906058f204f031681c9b7"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1627,8,1627,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_>=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_<String__STRING-COMMON_Bool_String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b376ffb0925555ed27696d73fc8fe43306e2005e4cf6ad819e860958992f9f17), org.kframework.attributes.Location(Location(1649,8,1649,63)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b376ffb0925555ed27696d73fc8fe43306e2005e4cf6ad819e860958992f9f17"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1649,8,1649,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_>String__STRING-COMMON_Bool_String_String`(S1,S2)=>`_<String__STRING-COMMON_Bool_String_String`(S2,S1) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8e5353c0a58491f8613ad7a35d0833206c342df0c91773e42485e52f4dad0cd0), org.kframework.attributes.Location(Location(1648,8,1648,52)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{}),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("8e5353c0a58491f8613ad7a35d0833206c342df0c91773e42485e52f4dad0cd0"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1648,8,1648,52)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497), org.kframework.attributes.Location(Location(905,8,905,37)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(905,8,905,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98), org.kframework.attributes.Location(Location(904,8,904,37)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(904,8,904,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andBool_`(_Gen0,#token("false","Bool") #as _Gen1)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca), org.kframework.attributes.Location(Location(906,8,906,37)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(906,8,906,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f), org.kframework.attributes.Location(Location(903,8,903,37)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(903,8,903,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andThenBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d), org.kframework.attributes.Location(Location(910,8,910,36)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(910,8,910,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andThenBool_`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c), org.kframework.attributes.Location(Location(909,8,909,37)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarK:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(909,8,909,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andThenBool_`(_Gen0,#token("false","Bool") #as _Gen1)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2), org.kframework.attributes.Location(Location(911,8,911,36)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(911,8,911,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andThenBool_`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689), org.kframework.attributes.Location(Location(908,8,908,37)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(908,8,908,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_divInt_`(I1,I2)=>`_/Int_`(`_-Int_`(I1,`_modInt_`(I1,I2)),I2) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4), org.kframework.attributes.Location(Location(1202,8,1203,23)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      Lbl'Unds'divInt'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsSlsh'Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1202,8,1203,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `_dividesInt__INT-COMMON_Bool_Int_Int`(I1,I2)=>`_==Int_`(`_%Int_`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5), org.kframework.attributes.Location(Location(1214,8,1214,58)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       Lbl'UndsEqlsEqls'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0")),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1214,8,1214,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_impliesBool_`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96), org.kframework.attributes.Location(Location(930,8,930,45)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(VarB:SortBool{}),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(930,8,930,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_impliesBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712), org.kframework.attributes.Location(Location(929,8,929,39)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(929,8,929,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_impliesBool_`(#token("false","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e), org.kframework.attributes.Location(Location(928,8,928,40)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(928,8,928,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_impliesBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d), org.kframework.attributes.Location(Location(927,8,927,36)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(927,8,927,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_modInt_`(I1,I2)=>`_%Int_`(`_+Int_`(`_%Int_`(I1,`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6), concrete, org.kframework.attributes.Location(Location(1205,5,1208,23)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \equals{SortInt{},R} (
+      Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsPerc'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1205,5,1208,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), simplification{}()]
+
+// rule `_orBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26), org.kframework.attributes.Location(Location(920,8,920,32)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(920,8,920,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3), org.kframework.attributes.Location(Location(918,8,918,34)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(918,8,918,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b), org.kframework.attributes.Location(Location(919,8,919,32)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(919,8,919,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2), org.kframework.attributes.Location(Location(917,8,917,34)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(917,8,917,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orElseBool_`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480), org.kframework.attributes.Location(Location(925,8,925,37)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarK:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(925,8,925,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orElseBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14), org.kframework.attributes.Location(Location(923,8,923,33)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(923,8,923,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orElseBool_`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf), org.kframework.attributes.Location(Location(924,8,924,37)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(924,8,924,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orElseBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6), org.kframework.attributes.Location(Location(922,8,922,33)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(922,8,922,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_xorBool_`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f), org.kframework.attributes.Location(Location(915,8,915,38)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(915,8,915,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_xorBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75), org.kframework.attributes.Location(Location(914,8,914,38)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(914,8,914,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_xorBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf), org.kframework.attributes.Location(Location(913,8,913,38)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(913,8,913,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_|Set__SET_Set_Set_Set`(S1,S2)=>`_Set_`(S1,`Set:difference`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62), concrete, org.kframework.attributes.Location(Location(531,8,531,45)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortSet{}, R} (
+            X0:SortSet{},
+            VarS1:SortSet{}
+          ),\and{R} (
+          \in{SortSet{}, R} (
+            X1:SortSet{},
+            VarS2:SortSet{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortSet{},R} (
+      Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(X0:SortSet{},X1:SortSet{}),
+     \and{SortSet{}} (
+       Lbl'Unds'Set'Unds'{}(VarS1:SortSet{},LblSet'Coln'difference{}(VarS2:SortSet{},VarS1:SortSet{})),
+        \top{SortSet{}}())))
+  [UNIQUE'Unds'ID{}("e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(531,8,531,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_modInt_`(`_>>Int_`(I,IDX),`_<<Int_`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119), org.kframework.attributes.Location(Location(1198,8,1198,85)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'modInt'Unds'{}(Lbl'Unds-GT--GT-'Int'Unds'{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1198,8,1198,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToCount)=>`_+Int_`(#token("1","Int"),`countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToCount)),`lengthString(_)_STRING-COMMON_Int_String`(Source)),ToCount)) requires `_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(628cff029a6d79e4c99999c0309f91ab8cb12f0ba549bb3faa850f96304c970e), org.kframework.attributes.Location(Location(1658,8,1659,60)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToCount:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortInt{}} (
+       Lbl'UndsPlus'Int'Unds'{}(\dv{SortInt{}}("1"),LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToCount:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})),VarToCount:SortString{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("628cff029a6d79e4c99999c0309f91ab8cb12f0ba549bb3faa850f96304c970e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1658,8,1659,60)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToCount)=>#token("0","Int") requires `_<Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(1c726cd81629c2e5f411539a7f9b4d297e8600e5d71a5d235d287e3001f3ec84), org.kframework.attributes.Location(Location(1656,8,1657,59)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToCount:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("0"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("1c726cd81629c2e5f411539a7f9b4d297e8600e5d71a5d235d287e3001f3ec84"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1656,8,1657,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,S2,I)=>`#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{Int}(`_==Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),#token("-1","Int")),`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I),`#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{Int}(`_==Int_`(`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I),#token("-1","Int")),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`minInt(_,_)_INT-COMMON_Int_Int_Int`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I)))) requires `_=/=String__STRING-COMMON_Bool_String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [UNIQUE_ID(9a3b7d1924363894c859ceb6bcec34fb944f01a5e0c90679d41b8430990b7295), org.kframework.attributes.Location(Location(1651,8,1651,431)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortInt{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}),Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortInt{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{})))),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("9a3b7d1924363894c859ceb6bcec34fb944f01a5e0c90679d41b8430990b7295"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1651,8,1651,431)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(_Gen0,#token("\"\"","String"),_Gen1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5a6cf981f0ec2494854cd3e517b0cf645a1c9762c92a14849adfca9a6a553117), org.kframework.attributes.Location(Location(1652,8,1652,32)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            \dv{SortString{}}("")
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            Var'Unds'Gen1:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("-1"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("5a6cf981f0ec2494854cd3e517b0cf645a1c9762c92a14849adfca9a6a553117"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1652,8,1652,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `freshId(_)_ID-COMMON_Id_Int`(I)=>`String2Id(_)_ID-COMMON_Id_String`(`_+String__STRING-COMMON_String_String_String`(#token("\"_\"","String"),`Int2String(_)_STRING-COMMON_String_Int`(I))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3965c8e65257ebae926d601fa8ac672d34e4c211d73ba594c571c6bc5960f3de), org.kframework.attributes.Location(Location(2015,8,2015,62)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortId{},R} (
+      LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(X0:SortInt{}),
+     \and{SortId{}} (
+       LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(\dv{SortString{}}("_"),LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(VarI:SortInt{}))),
+        \top{SortId{}}())))
+  [UNIQUE'Unds'ID{}("3965c8e65257ebae926d601fa8ac672d34e4c211d73ba594c571c6bc5960f3de"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2015,8,2015,62)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `freshInt(_)_INT_Int_Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b), org.kframework.attributes.Location(Location(1217,8,1217,28)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       VarI:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1217,8,1217,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule getGeneratedCounterCell(`<generatedTop>`(_DotVar0,Cell))=>Cell requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortGeneratedTopCell{}, R} (
+            X0:SortGeneratedTopCell{},
+            Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'DotVar0:SortKCell{},VarCell:SortGeneratedCounterCell{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblgetGeneratedCounterCell{}(X0:SortGeneratedTopCell{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarCell:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3")]
+
+// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblinitGeneratedCounterCell{}(),
+     \and{SortGeneratedCounterCell{}} (
+       Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")),
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553"), initializer{}()]
+
+// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initKCell(Init),initGeneratedCounterCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4cbc9d1da6e6bfe3605113d64379a38394b46b474e41d7bf884f8912546543b1), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      LblinitGeneratedTopCell{}(X0:SortMap{}),
+     \and{SortGeneratedTopCell{}} (
+       Lbl'-LT-'generatedTop'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}()),
+        \top{SortGeneratedTopCell{}}())))
+  [UNIQUE'Unds'ID{}("4cbc9d1da6e6bfe3605113d64379a38394b46b474e41d7bf884f8912546543b1"), initializer{}()]
+
+// rule initKCell(Init)=>`<k>`(inj{Exp,KItem}(`project:Exp`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar")))))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0708978885290eac9fd6647e7f8578594241e8c0c6ee97e8d8735f9732f4ab5c), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCell{},R} (
+      LblinitKCell{}(X0:SortMap{}),
+     \and{SortKCell{}} (
+       Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lblproject'Coln'Exp{}(kseq{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))),dotk{}()))),dotk{}())),
+        \top{SortKCell{}}())))
+  [UNIQUE'Unds'ID{}("0708978885290eac9fd6647e7f8578594241e8c0c6ee97e8d8735f9732f4ab5c"), initializer{}()]
+
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7f8273ebd616814dbf1acdd96b9534fbaa5b0491bfd05a61916e5015ad4a37ab), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortBool{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'Gen0:SortBool{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7f8273ebd616814dbf1acdd96b9534fbaa5b0491bfd05a61916e5015ad4a37ab"), owise{}()]
+
+// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarBool:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77")]
+
+// rule isExp(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3762fda3bb594dc94f3bc1b73e6be837dcb235b3eb61c39b1e9b4081559b2706), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortExp{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen1:SortExp{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisExp{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("3762fda3bb594dc94f3bc1b73e6be837dcb235b3eb61c39b1e9b4081559b2706"), owise{}()]
+
+// rule isExp(inj{Exp,KItem}(Exp))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5113a02f7660a72f8eec77fb75db8556ae809f64d13e8478319e14b277319d5c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp{}, SortKItem{}}(VarExp:SortExp{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisExp{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5113a02f7660a72f8eec77fb75db8556ae809f64d13e8478319e14b277319d5c")]
+
+// rule isFloat(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2a794de414a5b222c2b378d31aee70dd82d84237a3ab65881c92100c0bf5cb57), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortFloat{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortFloat{}, SortKItem{}}(Var'Unds'Gen1:SortFloat{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisFloat{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2a794de414a5b222c2b378d31aee70dd82d84237a3ab65881c92100c0bf5cb57"), owise{}()]
+
+// rule isFloat(inj{Float,KItem}(Float))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d74a36c34f45e0bf74d89fdd362f124478ab18934b5786ff4aabfe527643c5f0)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortFloat{}, SortKItem{}}(VarFloat:SortFloat{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisFloat{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d74a36c34f45e0bf74d89fdd362f124478ab18934b5786ff4aabfe527643c5f0")]
+
+// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7d501e1637f26769ad3b9439efef0285daa79523b0d071b3a792972ce92e4fe2), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedCounterCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedCounterCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7d501e1637f26769ad3b9439efef0285daa79523b0d071b3a792972ce92e4fe2"), owise{}()]
+
+// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarGeneratedCounterCell:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c")]
+
+// rule isGeneratedCounterCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55e7759c7640aa41fef8271d53c6dd8668aa497704539a65577604ada709c5df), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedCounterCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedCounterCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("55e7759c7640aa41fef8271d53c6dd8668aa497704539a65577604ada709c5df"), owise{}()]
+
+// rule isGeneratedCounterCellOpt(inj{GeneratedCounterCellOpt,KItem}(GeneratedCounterCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarGeneratedCounterCellOpt:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12")]
+
+// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ec16314688c4b2d204af490e243a3e83a2e82fbc74988c3574b997cc9ca56816), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortGeneratedTopCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(Var'Unds'Gen0:SortGeneratedTopCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ec16314688c4b2d204af490e243a3e83a2e82fbc74988c3574b997cc9ca56816"), owise{}()]
+
+// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarGeneratedTopCell:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2")]
+
+// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1f022b25cc5a2adbe99fbae6b50007c803258a5749eb01e05c86096f7b35c0df), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedTopCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedTopCellFragment{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("1f022b25cc5a2adbe99fbae6b50007c803258a5749eb01e05c86096f7b35c0df"), owise{}()]
+
+// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271")]
+
+// rule isIOError(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(20991c3332591ac971b290eb3a8cf0b0bcda5515745e9df3f1aef203db197006), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortIOError{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOError{}, SortKItem{}}(Var'Unds'Gen0:SortIOError{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOError{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("20991c3332591ac971b290eb3a8cf0b0bcda5515745e9df3f1aef203db197006"), owise{}()]
+
+// rule isIOError(inj{IOError,KItem}(IOError))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(af1461e241b050082a392e02da8a0d27eb78de77d591d7b2a949770399eea7d0)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOError{}, SortKItem{}}(VarIOError:SortIOError{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOError{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("af1461e241b050082a392e02da8a0d27eb78de77d591d7b2a949770399eea7d0")]
+
+// rule isIOFile(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0512dee3542dc027fbb3e8109dd7eda0d57c779d50e74dc69a69de93a12e6d63), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortIOFile{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOFile{}, SortKItem{}}(Var'Unds'Gen1:SortIOFile{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOFile{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0512dee3542dc027fbb3e8109dd7eda0d57c779d50e74dc69a69de93a12e6d63"), owise{}()]
+
+// rule isIOFile(inj{IOFile,KItem}(IOFile))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e265f4f40b46b033479ce783a161791d2f3390b848921b8d137e83f3f513fc0a)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOFile{}, SortKItem{}}(VarIOFile:SortIOFile{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOFile{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e265f4f40b46b033479ce783a161791d2f3390b848921b8d137e83f3f513fc0a")]
+
+// rule isIOInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a8647511396f0c9a09435045b00a5e7b4372d1d771597873d8bd8dc687456707), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortIOInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOInt{}, SortKItem{}}(Var'Unds'Gen1:SortIOInt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a8647511396f0c9a09435045b00a5e7b4372d1d771597873d8bd8dc687456707"), owise{}()]
+
+// rule isIOInt(inj{IOInt,KItem}(IOInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e744736c885f38e99587884080e17e1ddd231da39bcbdcb445d10f52b6675232)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOInt{}, SortKItem{}}(VarIOInt:SortIOInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e744736c885f38e99587884080e17e1ddd231da39bcbdcb445d10f52b6675232")]
+
+// rule isIOString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c2c1cfa5b8d1f4508bc208f23ab583f3e9b32659aec4f64e0228e3704bd22a07), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortIOString{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOString{}, SortKItem{}}(Var'Unds'Gen1:SortIOString{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("c2c1cfa5b8d1f4508bc208f23ab583f3e9b32659aec4f64e0228e3704bd22a07"), owise{}()]
+
+// rule isIOString(inj{IOString,KItem}(IOString))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(febfbad427936ffed4a4f974d1061ec9b65a4d6751c5a4e0e31661905c3f9e1e)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOString{}, SortKItem{}}(VarIOString:SortIOString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("febfbad427936ffed4a4f974d1061ec9b65a4d6751c5a4e0e31661905c3f9e1e")]
+
+// rule isId(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(79aa211b9cca8ff345580e936f59ebe000c9a0be28b59d063bd40ac3b72d72de), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortId{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortId{}, SortKItem{}}(Var'Unds'Gen1:SortId{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisId{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("79aa211b9cca8ff345580e936f59ebe000c9a0be28b59d063bd40ac3b72d72de"), owise{}()]
+
+// rule isId(inj{Id,KItem}(Id))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f024b5fa3f428dab8c832862d8a13219a64369be25641326400611b32ae8843d)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortId{}, SortKItem{}}(VarId:SortId{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisId{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f024b5fa3f428dab8c832862d8a13219a64369be25641326400611b32ae8843d")]
+
+// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5c9850befff40cc79151dbc5a8999b5ffaad767f244ed97f9f29b56b7170bf24), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortInt{}, SortKItem{}}(Var'Unds'Gen0:SortInt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5c9850befff40cc79151dbc5a8999b5ffaad767f244ed97f9f29b56b7170bf24"), owise{}()]
+
+// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarInt:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5")]
+
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisK{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847")]
+
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1668e9146ab7dd7867682198dd9dddc0c7c88d8f9fad9ed2366229fc4db18733), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKCell{}, SortKItem{}}(Var'Unds'Gen1:SortKCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("1668e9146ab7dd7867682198dd9dddc0c7c88d8f9fad9ed2366229fc4db18733"), owise{}()]
+
+// rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2695222b1238f711f8a356c0a1bc0ac418d7bd78fd3282e7c60882e2631a46df)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCell{}, SortKItem{}}(VarKCell:SortKCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2695222b1238f711f8a356c0a1bc0ac418d7bd78fd3282e7c60882e2631a46df")]
+
+// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fa44a9c94132ade195fc2cb566fa82471e4592c977a49183ac2142c5062701ca), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortKCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'Gen0:SortKCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fa44a9c94132ade195fc2cb566fa82471e4592c977a49183ac2142c5062701ca"), owise{}()]
+
+// rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1516473b1e153a368c273997543a4378ad451e5e828db8e289f4447f7e5228a5)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarKCellOpt:SortKCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("1516473b1e153a368c273997543a4378ad451e5e828db8e289f4447f7e5228a5")]
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f1c02853e001635e66a06d14d1cd322a996f4acbe38a7f9c88df6c97ea6a4677), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortKConfigVar{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKConfigVar{}, SortKItem{}}(Var'Unds'Gen0:SortKConfigVar{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f1c02853e001635e66a06d14d1cd322a996f4acbe38a7f9c88df6c97ea6a4677"), owise{}()]
+
+// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKConfigVar{}, SortKItem{}}(VarKConfigVar:SortKConfigVar{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd")]
+
+// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f766beabd3e632a98e221201d003f26f45f1feef2aff6da0ab07edde06a5d99d), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortKItem{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(Var'Unds'Gen0:SortKItem{},dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f766beabd3e632a98e221201d003f26f45f1feef2aff6da0ab07edde06a5d99d"), owise{}()]
+
+// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarKItem:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c")]
+
+// rule isKResult(_Gen0)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9ae4e8e91afda90defaf5ee862f05b8cd40f2b1cc709deee40824eb6bde35cb1), org.kframework.attributes.Location(Location(19,8,19,34)), org.kframework.attributes.Source(Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortExp{}, R} (
+                  X0:SortExp{},
+                  inj{SortInt{}, SortExp{}}(Var'Unds'Gen1:SortInt{})
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortExp{}, R} (
+            X0:SortExp{},
+            Var'Unds'Gen0:SortExp{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKResult{}(X0:SortExp{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9ae4e8e91afda90defaf5ee862f05b8cd40f2b1cc709deee40824eb6bde35cb1"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(19,8,19,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), owise{}()]
+
+// rule isKResult(inj{Int,Exp}(_Gen0))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d097a138e6f656d012ee2464d1fa156f4c66b21007de1d529f773c64143d965d), org.kframework.attributes.Location(Location(18,8,18,33)), org.kframework.attributes.Source(Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortExp{}, R} (
+            X0:SortExp{},
+            inj{SortInt{}, SortExp{}}(Var'Unds'Gen0:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKResult{}(X0:SortExp{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d097a138e6f656d012ee2464d1fa156f4c66b21007de1d529f773c64143d965d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(18,8,18,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0b6d1ffc254fbf57473abfe22e81bcfa646561c43d4e2cc175eab60cfb2b68aa), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortList{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortList{}, SortKItem{}}(Var'Unds'Gen0:SortList{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0b6d1ffc254fbf57473abfe22e81bcfa646561c43d4e2cc175eab60cfb2b68aa"), owise{}()]
+
+// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarList:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446")]
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5da72349a323db3019243ab26f08b728d336c1a52aecaa0bcb7de4adae14bd71), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortMap{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMap{}, SortKItem{}}(Var'Unds'Gen1:SortMap{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5da72349a323db3019243ab26f08b728d336c1a52aecaa0bcb7de4adae14bd71"), owise{}()]
+
+// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarMap:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795")]
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4bb33358689dc4ec69171f146dc69c169560a878b09ca872d2c4da9e2dbd0d5e), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortSet{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'Gen1:SortSet{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4bb33358689dc4ec69171f146dc69c169560a878b09ca872d2c4da9e2dbd0d5e"), owise{}()]
+
+// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarSet:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80")]
+
+// rule isStream(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b9fdcc98671795de0892a224238b1cf1bc7c23c4ae78e3a8e2c9c24b975ea29b), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortStream{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortStream{}, SortKItem{}}(Var'Unds'Gen0:SortStream{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisStream{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b9fdcc98671795de0892a224238b1cf1bc7c23c4ae78e3a8e2c9c24b975ea29b"), owise{}()]
+
+// rule isStream(inj{Stream,KItem}(Stream))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(27e703343d82a904ab8f74cc74fe8c6870a94fa1f4df39e1c0230ae06e4783cc)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortStream{}, SortKItem{}}(VarStream:SortStream{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisStream{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("27e703343d82a904ab8f74cc74fe8c6870a94fa1f4df39e1c0230ae06e4783cc")]
+
+// rule isString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(771c9ac303cbf7ec1228dd7a6f0b5db7e43db7edb5d4582845e18d9d602cb63f), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortString{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortString{}, SortKItem{}}(Var'Unds'Gen0:SortString{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("771c9ac303cbf7ec1228dd7a6f0b5db7e43db7edb5d4582845e18d9d602cb63f"), owise{}()]
+
+// rule isString(inj{String,KItem}(String))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(109ced650ead4a5092ddba090e1b8e181633ed0aa5c5f93bce9f88be215668ef)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortString{}, SortKItem{}}(VarString:SortString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("109ced650ead4a5092ddba090e1b8e181633ed0aa5c5f93bce9f88be215668ef")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I1 requires `_<=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6), org.kframework.attributes.Location(Location(1210,8,1210,57)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI1:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1210,8,1210,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I2 requires `_>=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3), org.kframework.attributes.Location(Location(1211,8,1211,57)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI2:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1211,8,1211,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415), org.kframework.attributes.Location(Location(901,8,901,29)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(901,8,901,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c), org.kframework.attributes.Location(Location(900,8,900,29)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(900,8,900,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `project:#tempFile:fd`(#tempFile(K0,K1))=>K1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(adb3a6d90d2e5267333e61f4e4be032bebb5f7a513450887a845c863a2adf95d)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortIOFile{}, R} (
+            X0:SortIOFile{},
+            Lbl'Hash'tempFile{}(VarK0:SortString{},VarK1:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'ColnHash'tempFile'Coln'fd{}(X0:SortIOFile{}),
+     \and{SortInt{}} (
+       VarK1:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("adb3a6d90d2e5267333e61f4e4be032bebb5f7a513450887a845c863a2adf95d")]
+
+// rule `project:#tempFile:path`(#tempFile(K0,K1))=>K0 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0020b2718cda89e9c9f4d05915593ca66761a24dffb111c697ccc162278da8ea)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortIOFile{}, R} (
+            X0:SortIOFile{},
+            Lbl'Hash'tempFile{}(VarK0:SortString{},VarK1:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      Lblproject'ColnHash'tempFile'Coln'path{}(X0:SortIOFile{}),
+     \and{SortString{}} (
+       VarK0:SortString{},
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("0020b2718cda89e9c9f4d05915593ca66761a24dffb111c697ccc162278da8ea")]
+
+// rule `project:#unknownIOError:errno`(#unknownIOError(K0))=>K0 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a36cde36a6581696f3d54614cc0d2d0864c2da35c6c8dc8d56daaf8b24199241)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortIOError{}, R} (
+            X0:SortIOError{},
+            Lbl'Hash'unknownIOError{}(VarK0:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'ColnHash'unknownIOError'Coln'errno{}(X0:SortIOError{}),
+     \and{SortInt{}} (
+       VarK0:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("a36cde36a6581696f3d54614cc0d2d0864c2da35c6c8dc8d56daaf8b24199241")]
+
+// rule `project:Bool`(inj{Bool,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarK:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblproject'Coln'Bool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54"), projection{}()]
+
+// rule `project:Exp`(inj{Exp,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9cd2bc2f2919e88b7c91858d910ebc06ec69505e24015e7346a27913f6b3d0c7), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp{}, SortKItem{}}(VarK:SortExp{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortExp{},R} (
+      Lblproject'Coln'Exp{}(X0:SortK{}),
+     \and{SortExp{}} (
+       VarK:SortExp{},
+        \top{SortExp{}}())))
+  [UNIQUE'Unds'ID{}("9cd2bc2f2919e88b7c91858d910ebc06ec69505e24015e7346a27913f6b3d0c7"), projection{}()]
+
+// rule `project:Float`(inj{Float,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ef206f477d884c0b6413273ff35b1206769cdb5a5ceba7b97d9e8e0a7b14e399), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortFloat{}, SortKItem{}}(VarK:SortFloat{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortFloat{},R} (
+      Lblproject'Coln'Float{}(X0:SortK{}),
+     \and{SortFloat{}} (
+       VarK:SortFloat{},
+        \top{SortFloat{}}())))
+  [UNIQUE'Unds'ID{}("ef206f477d884c0b6413273ff35b1206769cdb5a5ceba7b97d9e8e0a7b14e399"), projection{}()]
+
+// rule `project:GeneratedCounterCell`(inj{GeneratedCounterCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarK:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      Lblproject'Coln'GeneratedCounterCell{}(X0:SortK{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarK:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217"), projection{}()]
+
+// rule `project:GeneratedCounterCellOpt`(inj{GeneratedCounterCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarK:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCellOpt{},R} (
+      Lblproject'Coln'GeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortGeneratedCounterCellOpt{}} (
+       VarK:SortGeneratedCounterCellOpt{},
+        \top{SortGeneratedCounterCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca"), projection{}()]
+
+// rule `project:GeneratedTopCell`(inj{GeneratedTopCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarK:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      Lblproject'Coln'GeneratedTopCell{}(X0:SortK{}),
+     \and{SortGeneratedTopCell{}} (
+       VarK:SortGeneratedTopCell{},
+        \top{SortGeneratedTopCell{}}())))
+  [UNIQUE'Unds'ID{}("b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e"), projection{}()]
+
+// rule `project:GeneratedTopCellFragment`(inj{GeneratedTopCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarK:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCellFragment{},R} (
+      Lblproject'Coln'GeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortGeneratedTopCellFragment{}} (
+       VarK:SortGeneratedTopCellFragment{},
+        \top{SortGeneratedTopCellFragment{}}())))
+  [UNIQUE'Unds'ID{}("2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42"), projection{}()]
+
+// rule `project:IOError`(inj{IOError,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7ffe32516a0c3941ee4ba99c0f779b50c13a06e7eeb613f97334efb61b50c3aa), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOError{}, SortKItem{}}(VarK:SortIOError{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOError{},R} (
+      Lblproject'Coln'IOError{}(X0:SortK{}),
+     \and{SortIOError{}} (
+       VarK:SortIOError{},
+        \top{SortIOError{}}())))
+  [UNIQUE'Unds'ID{}("7ffe32516a0c3941ee4ba99c0f779b50c13a06e7eeb613f97334efb61b50c3aa"), projection{}()]
+
+// rule `project:IOFile`(inj{IOFile,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(09adbf7f680517f1f89e4e8c71d5bd247c4a2ea5d62e7c4aeb3153ab97239841), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOFile{}, SortKItem{}}(VarK:SortIOFile{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOFile{},R} (
+      Lblproject'Coln'IOFile{}(X0:SortK{}),
+     \and{SortIOFile{}} (
+       VarK:SortIOFile{},
+        \top{SortIOFile{}}())))
+  [UNIQUE'Unds'ID{}("09adbf7f680517f1f89e4e8c71d5bd247c4a2ea5d62e7c4aeb3153ab97239841"), projection{}()]
+
+// rule `project:IOInt`(inj{IOInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e39565377db8be1e421a86f0a0c31d0782a9af4aed7031245771fcb2a0152e06), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOInt{}, SortKItem{}}(VarK:SortIOInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOInt{},R} (
+      Lblproject'Coln'IOInt{}(X0:SortK{}),
+     \and{SortIOInt{}} (
+       VarK:SortIOInt{},
+        \top{SortIOInt{}}())))
+  [UNIQUE'Unds'ID{}("e39565377db8be1e421a86f0a0c31d0782a9af4aed7031245771fcb2a0152e06"), projection{}()]
+
+// rule `project:IOString`(inj{IOString,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(76a39386f0abf23155a1642ec64113306ae7c384a59c2e7f562d3c564efcc9a4), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOString{}, SortKItem{}}(VarK:SortIOString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOString{},R} (
+      Lblproject'Coln'IOString{}(X0:SortK{}),
+     \and{SortIOString{}} (
+       VarK:SortIOString{},
+        \top{SortIOString{}}())))
+  [UNIQUE'Unds'ID{}("76a39386f0abf23155a1642ec64113306ae7c384a59c2e7f562d3c564efcc9a4"), projection{}()]
+
+// rule `project:Id`(inj{Id,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(afcb3941b7c18d4b91d6ed8981582d58e0dc006425e9889e9891c2a7c2b93554), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortId{}, SortKItem{}}(VarK:SortId{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortId{},R} (
+      Lblproject'Coln'Id{}(X0:SortK{}),
+     \and{SortId{}} (
+       VarK:SortId{},
+        \top{SortId{}}())))
+  [UNIQUE'Unds'ID{}("afcb3941b7c18d4b91d6ed8981582d58e0dc006425e9889e9891c2a7c2b93554"), projection{}()]
+
+// rule `project:Int`(inj{Int,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarK:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'Coln'Int{}(X0:SortK{}),
+     \and{SortInt{}} (
+       VarK:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b"), projection{}()]
+
+// rule `project:K`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortK{},R} (
+      Lblproject'Coln'K{}(X0:SortK{}),
+     \and{SortK{}} (
+       VarK:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a"), projection{}()]
+
+// rule `project:KCell`(inj{KCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(894c13c4c410f11e35bc3781505aeddde4ff400ddda1daf8b35259dbf0de9a24), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCell{}, SortKItem{}}(VarK:SortKCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCell{},R} (
+      Lblproject'Coln'KCell{}(X0:SortK{}),
+     \and{SortKCell{}} (
+       VarK:SortKCell{},
+        \top{SortKCell{}}())))
+  [UNIQUE'Unds'ID{}("894c13c4c410f11e35bc3781505aeddde4ff400ddda1daf8b35259dbf0de9a24"), projection{}()]
+
+// rule `project:KCellOpt`(inj{KCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f684dd78d97feadf0cbcb3cbb8892e0842f137c7b29a904cb2f3fc9755b29b30), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarK:SortKCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCellOpt{},R} (
+      Lblproject'Coln'KCellOpt{}(X0:SortK{}),
+     \and{SortKCellOpt{}} (
+       VarK:SortKCellOpt{},
+        \top{SortKCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("f684dd78d97feadf0cbcb3cbb8892e0842f137c7b29a904cb2f3fc9755b29b30"), projection{}()]
+
+// rule `project:KItem`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarK:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKItem{},R} (
+      Lblproject'Coln'KItem{}(X0:SortK{}),
+     \and{SortKItem{}} (
+       VarK:SortKItem{},
+        \top{SortKItem{}}())))
+  [UNIQUE'Unds'ID{}("1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29"), projection{}()]
+
+// rule `project:List`(inj{List,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarK:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortList{},R} (
+      Lblproject'Coln'List{}(X0:SortK{}),
+     \and{SortList{}} (
+       VarK:SortList{},
+        \top{SortList{}}())))
+  [UNIQUE'Unds'ID{}("2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5"), projection{}()]
+
+// rule `project:Map`(inj{Map,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarK:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMap{},R} (
+      Lblproject'Coln'Map{}(X0:SortK{}),
+     \and{SortMap{}} (
+       VarK:SortMap{},
+        \top{SortMap{}}())))
+  [UNIQUE'Unds'ID{}("031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598"), projection{}()]
+
+// rule `project:Set`(inj{Set,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarK:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortSet{},R} (
+      Lblproject'Coln'Set{}(X0:SortK{}),
+     \and{SortSet{}} (
+       VarK:SortSet{},
+        \top{SortSet{}}())))
+  [UNIQUE'Unds'ID{}("0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0"), projection{}()]
+
+// rule `project:Stream`(inj{Stream,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bb30b432f6a3a9b73f42f0d3a54e07645be55c26bdee9d5c513f06e8009d0a77), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortStream{}, SortKItem{}}(VarK:SortStream{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortStream{},R} (
+      Lblproject'Coln'Stream{}(X0:SortK{}),
+     \and{SortStream{}} (
+       VarK:SortStream{},
+        \top{SortStream{}}())))
+  [UNIQUE'Unds'ID{}("bb30b432f6a3a9b73f42f0d3a54e07645be55c26bdee9d5c513f06e8009d0a77"), projection{}()]
+
+// rule `project:String`(inj{String,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e491dad8f644d2344f08cb72af01ade1e6ce9f564010a2de7909b3b6c7e2ae85), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortString{}, SortKItem{}}(VarK:SortString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      Lblproject'Coln'String{}(X0:SortK{}),
+     \and{SortString{}} (
+       VarK:SortString{},
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("e491dad8f644d2344f08cb72af01ade1e6ce9f564010a2de7909b3b6c7e2ae85"), projection{}()]
+
+// rule `replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,ToReplace,Replacement,Count)=>`_+String__STRING-COMMON_String_String_String`(`_+String__STRING-COMMON_String_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToReplace)),`lengthString(_)_STRING-COMMON_Int_String`(Source)),ToReplace,Replacement,`_-Int_`(Count,#token("1","Int")))) requires `_>Int_`(Count,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(311b80d2cb12d368f230eba968464e1fc926bd57e304059b282b82af4d9626d9), org.kframework.attributes.Location(Location(1668,8,1671,30)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-'Int'Unds'{}(VarCount:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            VarReplacement:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X3:SortInt{},
+            VarCount:SortInt{}
+          ),
+          \top{R} ()
+        ))))),
+    \equals{SortString{},R} (
+      Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortString{},X3:SortInt{}),
+     \and{SortString{}} (
+       Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})),VarToReplace:SortString{},VarReplacement:SortString{},Lbl'Unds'-Int'Unds'{}(VarCount:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("311b80d2cb12d368f230eba968464e1fc926bd57e304059b282b82af4d9626d9"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1668,8,1671,30)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,_Gen0,_Gen1,#token("0","Int"))=>Source requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4367434b0f61c404f7a2e926426bd23874dd547de689c5d15089967fbab2b3d5), org.kframework.attributes.Location(Location(1672,8,1672,49)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            Var'Unds'Gen1:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X3:SortInt{},
+            \dv{SortInt{}}("0")
+          ),
+          \top{R} ()
+        ))))),
+    \equals{SortString{},R} (
+      Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortString{},X3:SortInt{}),
+     \and{SortString{}} (
+       VarSource:SortString{},
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("4367434b0f61c404f7a2e926426bd23874dd547de689c5d15089967fbab2b3d5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1672,8,1672,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `replaceAll(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,Replacement)=>`replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,ToReplace,Replacement,`countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToReplace)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(262167183c3ec2e214d12bac6e639d7ac1a9f973582e16eca6c1af1da7ecc0a5), org.kframework.attributes.Location(Location(1673,8,1673,154)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            VarReplacement:SortString{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortString{},R} (
+      LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+     \and{SortString{}} (
+       Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{})),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("262167183c3ec2e214d12bac6e639d7ac1a9f973582e16eca6c1af1da7ecc0a5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1673,8,1673,154)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `replaceFirst(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,Replacement)=>`_+String__STRING-COMMON_String_String_String`(`_+String__STRING-COMMON_String_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToReplace)),`lengthString(_)_STRING-COMMON_Int_String`(Source))) requires `_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(e290042e5b5b2f620c0ca1871e708c3713c62b63b283e317bb7568e13968fe0c), org.kframework.attributes.Location(Location(1661,8,1663,66)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            VarReplacement:SortString{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortString{},R} (
+      LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+     \and{SortString{}} (
+       Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{}))),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("e290042e5b5b2f620c0ca1871e708c3713c62b63b283e317bb7568e13968fe0c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1661,8,1663,66)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `replaceFirst(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,_Gen0)=>Source requires `_<Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(8fbd1c8efb9988236eddc95fc2af4a3e74f6ec94d696ee47209543fd0826dd34), org.kframework.attributes.Location(Location(1664,8,1665,57)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortString{},R} (
+      LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+     \and{SortString{}} (
+       VarSource:SortString{},
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("8fbd1c8efb9988236eddc95fc2af4a3e74f6ec94d696ee47209543fd0826dd34"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1664,8,1665,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,S2,I)=>`maxInt(_,_)_INT-COMMON_Int_Int_Int`(`rfindString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I)) requires `_=/=String__STRING-COMMON_Bool_String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [UNIQUE_ID(b7f740050d72a847424b022a9c8217325aba8a154a42831aa3c7a3b0727f3205), org.kframework.attributes.Location(Location(1653,8,1653,182)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("b7f740050d72a847424b022a9c8217325aba8a154a42831aa3c7a3b0727f3205"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1653,8,1653,182)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(_Gen0,#token("\"\"","String"),_Gen1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(23b9fa88124c547d94aed32124d1ccd1069732b059f4c8b430ab4617979690f6), org.kframework.attributes.Location(Location(1654,8,1654,33)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            \dv{SortString{}}("")
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            Var'Unds'Gen1:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("-1"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("23b9fa88124c547d94aed32124d1ccd1069732b059f4c8b430ab4617979690f6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1654,8,1654,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_-Int_`(`_modInt_`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))),`_<<Int_`(#token("1","Int"),LEN)),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f), org.kframework.attributes.Location(Location(1200,8,1200,164)), org.kframework.attributes.Source(Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds'modInt'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1200,8,1200,164)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(8,1,20,10)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/bruce/code/llvm-backend/test/c/k-files/steps.k)")]


### PR DESCRIPTION
This is somewhat minimized example that should exhibit a memory leak.

in KLLVM when used via the C bindings.

## Getting the input

Please download [`llvm_calls_private.c`](https://drive.google.com/file/d/1jCn68dK10xULpJtY2jjQNDqIMgEse0GH/view?usp=drive_link) from RV Shared Google Drive, as it contains confidential bytecode and place it instead of the stub `llvm_calls.c` file. The stub file and the real file only differ in the bytecode token. 

## Running the test

The test should be compiled and ran as follows:

```
lit -av test/c/test_evm_leak.kore
```

Currently, this fails with

```
test/c/Output/test_evm_leak.kore.tmp.dir/libtest.so: undefined symbol: hook_KRYPTO_ecdsaPubKey/home/geo2a/Workspace/RV/llvm-backend/test/c/Output/test_evm_leak.kore.script: line 4: 2105633 Aborted                 (core dumped) 
```

because the call to `llvm-kompile-testing` needs to be changed to include hooks form `blockcahin-k-plugin`, and I don't have the expertise to do it in this test harness' setup.

## Context

Within `kore-rpc-booster`, we make hundreds of calls like this one while processing one execution request.