### PR TITLE
Create Python bindings for definition parser

### DIFF
--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -111,17 +111,6 @@ std::shared_ptr<KOREPattern> read_pattern_from_file(py::object &file_like) {
   return kllvm::detail::read(pattern_begin, pattern_bytes.end(), version);
 }
 
-template <typename T>
-py::object
-vectorOfUniquePtrsToPyList(const std::vector<std::unique_ptr<T>> &vec) {
-  auto pylist = py::list();
-  for (auto &ptr : vec) {
-    pylist.append(
-        py::cast(*ptr, py::return_value_policy::reference_internal, pylist));
-  }
-  return pylist;
-}
-
 void bind_ast(py::module_ &m) {
   auto ast = m.def_submodule("ast", "K LLVM backend KORE AST");
 
@@ -203,17 +192,7 @@ void bind_ast(py::module_ &m) {
       .def(py::init(&KOREDefinition::Create))
       .def("__repr__", print_repr_adapter<KOREDefinition>())
       .def("add_module", &KOREDefinition::addModule)
-      .def_property_readonly(
-          "modules",
-          [](KOREDefinition &def) {
-            auto pylist = py::list();
-            for (auto &ptr : def.getModules()) {
-              auto pyobj = py::cast(
-                  *ptr, py::return_value_policy::reference_internal, pylist);
-              pylist.append(pyobj);
-            }
-            return pylist;
-          })
+      .def_property_readonly("modules", &KOREDefinition::getModules)
       .def("add_attribute", &KOREDefinition::addAttribute)
       .def_property_readonly("attributes", &KOREDefinition::getAttributes);
 

--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -136,6 +136,7 @@ void bind_ast(py::module_ &m) {
             .def_property_readonly(
                 "object_sort_variables",
                 &KOREDeclaration::getObjectSortVariables)
+            .def("add_attribute", &KOREDeclaration::addAttribute)
             .def_property_readonly(
                 "attributes", &KOREDeclaration::getAttributes);
 

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -649,7 +649,7 @@ private:
 // KOREDeclaration
 class KOREDeclaration {
 protected:
-  std::unordered_map<std::string, ptr<KORECompositePattern>> attributes;
+  std::unordered_map<std::string, sptr<KORECompositePattern>> attributes;
   std::vector<sptr<KORESortVariable>> objectSortVariables;
 
 public:
@@ -657,11 +657,11 @@ public:
   KOREDeclaration(const KOREDeclaration &) = delete;
   KOREDeclaration &operator=(const KOREDeclaration &) = delete;
 
-  void addAttribute(ptr<KORECompositePattern> Attribute);
+  void addAttribute(sptr<KORECompositePattern> Attribute);
   void addObjectSortVariable(sptr<KORESortVariable> SortVariable);
   virtual void print(std::ostream &Out, unsigned indent = 0) const = 0;
 
-  const std::unordered_map<std::string, ptr<KORECompositePattern>> &
+  const std::unordered_map<std::string, sptr<KORECompositePattern>> &
   getAttributes() const {
     return attributes;
   }
@@ -815,8 +815,8 @@ private:
 class KOREModule {
 private:
   std::string name;
-  std::vector<ptr<KOREDeclaration>> declarations;
-  std::unordered_map<std::string, ptr<KORECompositePattern>> attributes;
+  std::vector<sptr<KOREDeclaration>> declarations;
+  std::unordered_map<std::string, sptr<KORECompositePattern>> attributes;
 
 public:
   static ptr<KOREModule> Create(const std::string &Name) {
@@ -827,16 +827,16 @@ public:
   KOREModule(const KOREModule &) = delete;
   KOREModule &operator=(const KOREModule &) = delete;
 
-  void addAttribute(ptr<KORECompositePattern> Attribute);
-  void addDeclaration(ptr<KOREDeclaration> Declaration);
+  void addAttribute(sptr<KORECompositePattern> Attribute);
+  void addDeclaration(sptr<KOREDeclaration> Declaration);
   void print(std::ostream &Out, unsigned indent = 0) const;
 
   const std::string &getName() const { return name; }
-  const std::unordered_map<std::string, ptr<KORECompositePattern>> &
+  const std::unordered_map<std::string, sptr<KORECompositePattern>> &
   getAttributes() const {
     return attributes;
   }
-  const std::vector<ptr<KOREDeclaration>> &getDeclarations() const {
+  const std::vector<sptr<KOREDeclaration>> &getDeclarations() const {
     return declarations;
   }
 
@@ -887,8 +887,8 @@ private:
   KORESymbolStringMapType freshFunctions;
   KOREAxiomMapType ordinals;
 
-  std::vector<ptr<KOREModule>> modules;
-  std::unordered_map<std::string, ptr<KORECompositePattern>> attributes;
+  std::vector<sptr<KOREModule>> modules;
+  std::unordered_map<std::string, sptr<KORECompositePattern>> attributes;
   /* an automatically computed list of all the axioms in the definition */
   std::list<KOREAxiomDeclaration *> axioms;
 
@@ -909,11 +909,11 @@ public:
      user in the definition. */
   void preprocess();
 
-  void addModule(ptr<KOREModule> Module);
-  void addAttribute(ptr<KORECompositePattern> Attribute);
+  void addModule(sptr<KOREModule> Module);
+  void addAttribute(sptr<KORECompositePattern> Attribute);
   void print(std::ostream &Out, unsigned indent = 0) const;
 
-  const std::vector<ptr<KOREModule>> &getModules() const { return modules; }
+  const std::vector<sptr<KOREModule>> &getModules() const { return modules; }
   const KORECompositeSortDeclarationMapType &getSortDeclarations() const {
     return sortDeclarations;
   }
@@ -932,7 +932,7 @@ public:
   KOREAxiomDeclaration *getAxiomByOrdinal(size_t ordinal) const {
     return ordinals.at(ordinal);
   }
-  const std::unordered_map<std::string, ptr<KORECompositePattern>> &
+  const std::unordered_map<std::string, sptr<KORECompositePattern>> &
   getAttributes() const {
     return attributes;
   }

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -653,10 +653,6 @@ protected:
   std::vector<sptr<KORESortVariable>> objectSortVariables;
 
 public:
-  KOREDeclaration() = default;
-  KOREDeclaration(const KOREDeclaration &) = delete;
-  KOREDeclaration &operator=(const KOREDeclaration &) = delete;
-
   void addAttribute(sptr<KORECompositePattern> Attribute);
   void addObjectSortVariable(sptr<KORESortVariable> SortVariable);
   virtual void print(std::ostream &Out, unsigned indent = 0) const = 0;
@@ -822,10 +818,6 @@ public:
   static ptr<KOREModule> Create(const std::string &Name) {
     return ptr<KOREModule>(new KOREModule(Name));
   }
-
-  KOREModule() = default;
-  KOREModule(const KOREModule &) = delete;
-  KOREModule &operator=(const KOREModule &) = delete;
 
   void addAttribute(sptr<KORECompositePattern> Attribute);
   void addDeclaration(sptr<KOREDeclaration> Declaration);

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -653,9 +653,14 @@ protected:
   std::vector<sptr<KORESortVariable>> objectSortVariables;
 
 public:
+  KOREDeclaration() = default;
+  KOREDeclaration(const KOREDeclaration &) = delete;
+  KOREDeclaration &operator=(const KOREDeclaration &) = delete;
+
   void addAttribute(ptr<KORECompositePattern> Attribute);
   void addObjectSortVariable(sptr<KORESortVariable> SortVariable);
   virtual void print(std::ostream &Out, unsigned indent = 0) const = 0;
+
   const std::unordered_map<std::string, ptr<KORECompositePattern>> &
   getAttributes() const {
     return attributes;
@@ -694,9 +699,7 @@ private:
       , sortName(Name) { }
 };
 
-class KORESymbolOrAliasDeclaration : public KOREDeclaration { };
-
-class KORESymbolAliasDeclaration : public KORESymbolOrAliasDeclaration {
+class KORESymbolAliasDeclaration : public KOREDeclaration {
 protected:
   ptr<KORESymbol> symbol;
 
@@ -733,7 +736,7 @@ private:
 
 class KOREAliasDeclaration : public KORESymbolAliasDeclaration {
 private:
-  ptr<KORECompositePattern> boundVariables;
+  sptr<KORECompositePattern> boundVariables;
   sptr<KOREPattern> pattern;
 
 public:
@@ -742,9 +745,12 @@ public:
     return ptr<KOREAliasDeclaration>(new KOREAliasDeclaration(std::move(Sym)));
   }
 
-  void addVariables(ptr<KORECompositePattern> variables);
-  void addPattern(ptr<KOREPattern> Pattern);
+  void addVariables(sptr<KORECompositePattern> variables);
+  void addPattern(sptr<KOREPattern> Pattern);
   KOREPattern::substitution getSubstitution(KORECompositePattern *subject);
+  KORECompositePattern *getBoundVariables() const {
+    return boundVariables.get();
+  }
   sptr<KOREPattern> &getPattern() { return pattern; }
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
 
@@ -767,7 +773,7 @@ public:
     return ptr<KOREAxiomDeclaration>(new KOREAxiomDeclaration(isClaim));
   }
 
-  void addPattern(ptr<KOREPattern> Pattern);
+  void addPattern(sptr<KOREPattern> Pattern);
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
 
   /* returns true if the axiom is actually required to be translated to llvm
@@ -796,6 +802,8 @@ public:
         new KOREModuleImportDeclaration(Name));
   }
 
+  const std::string &getModuleName() const { return moduleName; }
+
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
 
 private:
@@ -815,10 +823,19 @@ public:
     return ptr<KOREModule>(new KOREModule(Name));
   }
 
+  KOREModule() = default;
+  KOREModule(const KOREModule &) = delete;
+  KOREModule &operator=(const KOREModule &) = delete;
+
   void addAttribute(ptr<KORECompositePattern> Attribute);
   void addDeclaration(ptr<KOREDeclaration> Declaration);
   void print(std::ostream &Out, unsigned indent = 0) const;
 
+  const std::string &getName() const { return name; }
+  const std::unordered_map<std::string, ptr<KORECompositePattern>> &
+  getAttributes() const {
+    return attributes;
+  }
   const std::vector<ptr<KOREDeclaration>> &getDeclarations() const {
     return declarations;
   }
@@ -896,6 +913,7 @@ public:
   void addAttribute(ptr<KORECompositePattern> Attribute);
   void print(std::ostream &Out, unsigned indent = 0) const;
 
+  const std::vector<ptr<KOREModule>> &getModules() const { return modules; }
   const KORECompositeSortDeclarationMapType &getSortDeclarations() const {
     return sortDeclarations;
   }

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -724,7 +724,7 @@ public:
 
   bool isHooked() const { return _isHooked; }
 
-  bool isAnywhere();
+  bool isAnywhere() const;
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
 
@@ -780,9 +780,9 @@ public:
      and false if it is an axiom pertaining to symbolic execution which is not
      required for concrete execution. Axioms that are not required are elided
      from the definition by KOREDefinition::preprocess. */
-  bool isRequired();
-  bool isTopAxiom();
-  bool isClaim() { return _isClaim; }
+  bool isRequired() const;
+  bool isTopAxiom() const;
+  bool isClaim() const { return _isClaim; }
   KOREPattern *getRightHandSide() const;
   std::vector<KOREPattern *> getLeftHandSide() const;
   KOREPattern *getRequires() const;

--- a/include/kllvm/codegen/Debug.h
+++ b/include/kllvm/codegen/Debug.h
@@ -30,7 +30,7 @@ void initDebugFunction(
     KOREDefinition *definition, llvm::Function *func);
 
 void initDebugAxiom(
-    std::unordered_map<std::string, ptr<KORECompositePattern>> const &att);
+    std::unordered_map<std::string, sptr<KORECompositePattern>> const &att);
 void initDebugParam(
     llvm::Function *func, unsigned argNo, std::string name, ValueType type,
     std::string typeName);

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1261,7 +1261,7 @@ std::string KOREDeclaration::getStringAttribute(std::string name) const {
   return strPattern->getContents();
 }
 
-void KOREAxiomDeclaration::addPattern(ptr<KOREPattern> Pattern) {
+void KOREAxiomDeclaration::addPattern(sptr<KOREPattern> Pattern) {
   pattern = std::move(Pattern);
 }
 
@@ -1620,11 +1620,11 @@ KOREPattern *KOREAxiomDeclaration::getRequires() const {
   abort();
 }
 
-void KOREAliasDeclaration::addVariables(ptr<KORECompositePattern> Variables) {
+void KOREAliasDeclaration::addVariables(sptr<KORECompositePattern> Variables) {
   boundVariables = std::move(Variables);
 }
 
-void KOREAliasDeclaration::addPattern(ptr<KOREPattern> Pattern) {
+void KOREAliasDeclaration::addPattern(sptr<KOREPattern> Pattern) {
   pattern = std::move(Pattern);
 }
 

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1277,7 +1277,7 @@ static const std::string CEIL = "ceil";
 static const std::string NON_EXECUTABLE = "non-executable";
 static const std::string SIMPLIFICATION = "simplification";
 
-bool KOREAxiomDeclaration::isRequired() {
+bool KOREAxiomDeclaration::isRequired() const {
   return !attributes.count(ASSOC) && !attributes.count(COMM)
          && !attributes.count(IDEM) && !attributes.count(UNIT)
          && !attributes.count(FUNCTIONAL) && !attributes.count(CONSTRUCTOR)
@@ -1286,7 +1286,7 @@ bool KOREAxiomDeclaration::isRequired() {
          && !attributes.count(SIMPLIFICATION);
 }
 
-bool KOREAxiomDeclaration::isTopAxiom() {
+bool KOREAxiomDeclaration::isTopAxiom() const {
   if (auto top = dynamic_cast<KORECompositePattern *>(pattern.get())) {
     if (top->getConstructor()->getName() == "\\implies"
         && top->getArguments().size() == 2) {
@@ -1642,7 +1642,7 @@ KOREAliasDeclaration::getSubstitution(KORECompositePattern *subject) {
   return result;
 }
 
-bool KORESymbolDeclaration::isAnywhere() {
+bool KORESymbolDeclaration::isAnywhere() const {
   return getAttributes().count("anywhere");
 }
 
@@ -1963,7 +1963,7 @@ void KOREAliasDeclaration::print(std::ostream &Out, unsigned indent) const {
 
 void KOREAxiomDeclaration::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
-  Out << Indent << "axiom ";
+  Out << Indent << (isClaim() ? "claim " : "axiom ");
   printSortVariables(Out);
   pattern->print(Out);
   Out << " ";

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1243,7 +1243,7 @@ bool KOREStringPattern::matches(
   return subj->contents == contents;
 }
 
-void KOREDeclaration::addAttribute(ptr<KORECompositePattern> Attribute) {
+void KOREDeclaration::addAttribute(sptr<KORECompositePattern> Attribute) {
   std::string name = Attribute->getConstructor()->getName();
   attributes.insert({name, std::move(Attribute)});
 }
@@ -1646,16 +1646,16 @@ bool KORESymbolDeclaration::isAnywhere() {
   return getAttributes().count("anywhere");
 }
 
-void KOREModule::addAttribute(ptr<KORECompositePattern> Attribute) {
+void KOREModule::addAttribute(sptr<KORECompositePattern> Attribute) {
   std::string name = Attribute->getConstructor()->getName();
   attributes.insert({name, std::move(Attribute)});
 }
 
-void KOREModule::addDeclaration(ptr<KOREDeclaration> Declaration) {
+void KOREModule::addDeclaration(sptr<KOREDeclaration> Declaration) {
   declarations.push_back(std::move(Declaration));
 }
 
-void KOREDefinition::addModule(ptr<KOREModule> Module) {
+void KOREDefinition::addModule(sptr<KOREModule> Module) {
   for (auto &decl : Module->getDeclarations()) {
     if (auto sortDecl
         = dynamic_cast<KORECompositeSortDeclaration *>(decl.get())) {
@@ -1675,7 +1675,7 @@ void KOREDefinition::addModule(ptr<KOREModule> Module) {
   modules.push_back(std::move(Module));
 }
 
-void KOREDefinition::addAttribute(ptr<KORECompositePattern> Attribute) {
+void KOREDefinition::addAttribute(sptr<KORECompositePattern> Attribute) {
   std::string name = Attribute->getConstructor()->getName();
   attributes.insert({name, std::move(Attribute)});
 }
@@ -1883,7 +1883,7 @@ void KOREStringPattern::print(std::ostream &Out, unsigned indent) const {
 
 static void printAttributeList(
     std::ostream &Out,
-    const std::unordered_map<std::string, ptr<KORECompositePattern>>
+    const std::unordered_map<std::string, sptr<KORECompositePattern>>
         &attributes,
     unsigned indent = 0) {
 

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -105,7 +105,7 @@ void initDebugGlobal(
 }
 
 void initDebugAxiom(
-    std::unordered_map<std::string, ptr<KORECompositePattern>> const &att) {
+    std::unordered_map<std::string, sptr<KORECompositePattern>> const &att) {
   if (!Dbg)
     return;
   if (!att.count(SOURCE_ATT)) {


### PR DESCRIPTION
Fixes #815

Create Python bindings for `KOREParser`, `KOREDefinition`, `KOREModule`, and all `KOREDeclaration` classes in order to expose the definition parser.

As part of this, 
- a few `unique_ptr`s were changed to `shared_ptr`s because pybind cannot handle anything which takes a `unique_ptr` as an argument
- fixed a bug in `KOREAxiomDeclaration` where `axiom` was always printed even when the instance was actually a `claim`
- improved `const` correctness in a few places

Tests are implemented on the Pyk side in runtimeverification/pyk#599