### PR TITLE
fix bugs with serializeConfiguration and garbage collection

### DIFF
--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -79,14 +79,14 @@ static void emitConstantSort(serializer &instance, char const *name) {
  * Emit a symbol of the form \dv{Sort}("string")
  */
 static void emitToken(
-    serializer &instance, char const *sort, char const *string, int len = 0) {
+    serializer &instance, char const *sort, char const *string, int len = -1) {
   instance.emit(header_byte<KOREStringPattern>);
 
   // Allow the length of the token to be passed in explicitly to handle the
   // Bytes sort, which can include null characters in the middle of a string.
   // Otherwise, assume that the string is null-terminated and that its length
   // can be worked out implicitly.
-  if (len == 0) {
+  if (len < 0) {
     instance.emit_string(string);
   } else {
     instance.emit_string(std::string(string, len));
@@ -224,8 +224,7 @@ void serializeStringBuffer(
     writer *file, stringbuffer *b, const char *sort, void *state) {
   auto &instance = static_cast<serialization_state *>(state)->instance;
 
-  std::string str(b->contents->data, b->strlen);
-  emitToken(instance, sort, str.c_str());
+  emitToken(instance, sort, b->contents->data, b->strlen);
 }
 
 void serializeMInt(


### PR DESCRIPTION
There was a bug in how we were serializing string buffers and strings/byte arrays of length 0. It was assuming that such strings are null terminated when they appear in a `string *` in the kore heap, but this is not necessarily true. Similarly, it was assuming that a string buffer was null terminated, which is also not true.

It's pretty difficult to write reliable tests for this bug since it relies on garbage collection to pollute the word that gets printed with a word that does not begin with the null byte. This is impossible in our existing test harness for serialization since  we don't ever garbage collect anything in those tests. However, we know that the fix works because it fixes the regression in the Booster's integration tests that arose from introducing garbage collection calls to their API usage.