### PR TITLE
fix llvm-kompile-compute-loc and llvm-kompile-compute-ordinal

### DIFF
--- a/bin/llvm-kompile-compute-loc
+++ b/bin/llvm-kompile-compute-loc
@@ -1,7 +1,7 @@
 #!/bin/sh
 ordinal=$1
 definition=$2
-line=$(grep -on '^  axiom' "$definition/definition.kore" | awk '{print $1 " " i++}' | grep "$ordinal\$" | awk -F ':' '{print $1}')
+line=$(grep -on '^ *axiom' "$definition/definition.kore" | awk '{print $1 " " i++}' | grep "$ordinal\$" | awk -F ':' '{print $1}')
 echo "Line: $line"
 att=$(sed -n "$line,$((line+7))p;$((line+8))q" "$definition/definition.kore" | grep "'Stop'Source")
 echo "$att" | sed 's/.*Stop'\''Source{}("Source(//' | sed 's/)".*Stop'\''Location{}("Location(/:/' | sed 's/,\([0-9]\+\).*/:\1/'

--- a/bin/llvm-kompile-compute-ordinal
+++ b/bin/llvm-kompile-compute-ordinal
@@ -1,5 +1,5 @@
 #!/bin/sh
 line=$1
 definition=$2
-ordinal=$(grep -on '^  axiom' "$definition/definition.kore" | awk '{print $1 " " i++}' | grep "^$line" | awk '{print $2}')
+ordinal=$(grep -on '^ *axiom' "$definition/definition.kore" | awk '{print $1 " " i++}' | grep "^$line" | awk '{print $2}')
 echo "Ordinal: $ordinal"


### PR DESCRIPTION
We were previously incorrectly assuming that all axioms in a kore file were indented exactly two spaces, which is not correct. This led to the ordinals and locations being generated being incorrect. This ought to fix that.