### PR TITLE
Add llvm-backend-matching as an executable

### DIFF
--- a/nix/llvm-backend-matching.nix
+++ b/nix/llvm-backend-matching.nix
@@ -1,4 +1,4 @@
-{ buildMaven, src }:
+{ jdk11_headless, makeWrapper, buildMaven, src }:
 
 let
   self = buildMaven {
@@ -12,8 +12,13 @@ let
         "${self}/share/java/llvm-backend-matching-1.0-SNAPSHOT-jar-with-dependencies.jar";
     };
 
+    nativeBuildInputs = [ makeWrapper ];
+
     postInstall = ''
       test -f "$out/share/java/llvm-backend-matching-1.0-SNAPSHOT-jar-with-dependencies.jar"
+
+      makeWrapper ${jdk11_headless}/bin/java $out/bin/llvm-backend-matching \
+          --add-flags "-jar $out/share/java/llvm-backend-matching-1.0-SNAPSHOT-jar-with-dependencies.jar"
     '';
 
     # Add build dependencies

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,11 +1,13 @@
 final: prev:
 let
-  mkLlvmPackages = (packages: packages.override {
-    bootBintoolsNoLibc = null;
-    bootBintools = null;
-  });
+  mkLlvmPackages = (packages:
+    packages.override {
+      bootBintoolsNoLibc = null;
+      bootBintools = null;
+    });
 
-  llvmPackages = mkLlvmPackages prev."llvmPackages_${toString prev.llvm-version}";
+  llvmPackages =
+    mkLlvmPackages prev."llvmPackages_${toString prev.llvm-version}";
 
   clang = if !llvmPackages.stdenv.targetPlatform.isDarwin then
     llvmPackages.clangNoLibcxx.override (attrs: {
@@ -15,13 +17,15 @@ let
       '';
     })
   else
-    # In llvmPackages_15/16, libcxx is broken, so we use clang 14 as our compiler
-    # for C code etc, but still use LLVM 15 to build the backend properly. This
-    # is a workaround until the underlying package is more stable on macOS.
-    let clangPackages = if prev.llvm-version >= 15
-      then mkLlvmPackages prev.llvmPackages_14
-      else llvmPackages; in
-    clangPackages.libcxxClang.overrideAttrs (old: {
+  # In llvmPackages_15/16, libcxx is broken, so we use clang 14 as our compiler
+  # for C code etc, but still use LLVM 15 to build the backend properly. This
+  # is a workaround until the underlying package is more stable on macOS.
+    let
+      clangPackages = if prev.llvm-version >= 15 then
+        mkLlvmPackages prev.llvmPackages_14
+      else
+        llvmPackages;
+    in clangPackages.libcxxClang.overrideAttrs (old: {
       # Hack from https://github.com/NixOS/nixpkgs/issues/166205 for macOS
       postFixup = old.postFixup + ''
         echo "-lc++abi" >> $out/nix-support/libcxx-ldflags
@@ -47,7 +51,7 @@ let
   };
 
   llvm-backend-matching = import ./llvm-backend-matching.nix {
-    inherit (prev) buildMaven;
+    inherit (prev) buildMaven jdk11_headless makeWrapper;
     src = prev.llvm-backend-matching-src;
   };
 
@@ -58,9 +62,9 @@ let
   kllvm = prev.poetry2nix.mkPoetryApplication {
     python = prev.python39;
     projectDir = ../bindings/python/package;
-    postInstall = "
+    postInstall = ''
       cp ${llvm-backend}/lib/python/kllvm/* $out/lib/python3.9/site-packages/kllvm/
-    ";
+    '';
   };
 
   llvm-kompile-testing = let
@@ -111,7 +115,8 @@ let
   };
   devShell = prev.callPackage ./devShell.nix { };
 in {
-  inherit kllvm llvm-backend llvm-backend-matching llvm-kompile-testing integration-tests;
+  inherit kllvm llvm-backend llvm-backend-matching llvm-kompile-testing
+    integration-tests;
   inherit (prev) clang; # for compatibility
   inherit devShell; # for CI
 }


### PR DESCRIPTION
This is a minor change which wraps the llvm-backend-matching jar into an executable as a convenience.

The reason for this change is to enable the booster backend to re-generate decision trees for integration tests which need the llvm backend as a dynamic library. 