### PR TITLE
Update `k-rule-find` to handle multiple rule labels

### DIFF
--- a/test/k-rule-find/definition.kore
+++ b/test/k-rule-find/definition.kore
@@ -1,5 +1,9 @@
-// RUN: %find-rule %S k-rule-find-simple.k:6 | diff - %output-dir/`basename %S`/rule-label.out.diff
-[topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/tests/k-rule-find-examples/one-line-rule/k-rule-find-simple.k)")]
+// RUN: %find-rule %S k-rule-find-test.k:7 | diff - %output-dir/`basename %S`/fooRule-label.out.diff
+// RUN: %find-rule %S k-rule-find-test.k:11 | diff - %output-dir/`basename %S`/seqstrict-label.out.diff
+// RUN: %find-rule %S k-rule-find-test.k:13 | diff - %output-dir/`basename %S`/strict2-label.out.diff
+// RUN: %find-rule %S k-rule-find-test.k:15 | diff - %output-dir/`basename %S`/bar1-label.out.diff
+// RUN: %find-rule %S k-rule-find-test.k:16 | diff - %output-dir/`basename %S`/bar2-label.out.diff
+[topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)")]
 
 module BASIC-K
     sort SortK{} []
@@ -63,7 +67,7 @@ module K
 endmodule
 []
 
-module K-RULE-FIND-SIMPLE
+module K-RULE-FIND-TEST
 
 // imports
   import K []
@@ -72,150 +76,168 @@ module K-RULE-FIND-SIMPLE
   sort SortBar{} []
   sort SortKCellOpt{} []
   sort SortGeneratedTopCellFragment{} []
-  hooked-sort SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), element{}(LblListItem{}()), concat{}(Lbl'Unds'List'Unds'{}()), unit{}(Lbl'Stop'List{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(723,3,723,32)")]
+  hooked-sort SortList{} [concat{}(Lbl'Unds'List'Unds'{}()), element{}(LblListItem{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(913,3,913,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'List{}())]
   sort SortKCell{} []
   sort SortGeneratedTopCell{} []
   sort SortGeneratedCounterCell{} []
-  hooked-sort SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), concat{}(Lbl'Unds'Map'Unds'{}()), unit{}(Lbl'Stop'Map{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(218,3,218,29)")]
+  hooked-sort SortMap{} [concat{}(Lbl'Unds'Map'Unds'{}()), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(218,3,218,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Map{}())]
   sort SortGeneratedCounterCellOpt{} []
-  sort SortKConfigVar{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/kast.md)"), token{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(40,3,40,28)"), hasDomainValues{}()]
-  hooked-sort SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), hook{}("INT.Int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(999,3,999,29)"), hasDomainValues{}()]
-  hooked-sort SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), element{}(LblSetItem{}()), concat{}(Lbl'Unds'Set'Unds'{}()), unit{}(Lbl'Stop'Set{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(510,3,510,29)")]
+  sort SortKConfigVar{} [hasDomainValues{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(40,3,40,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/kast.md)"), token{}()]
+  hooked-sort SortInt{} [hasDomainValues{}(), hook{}("INT.Int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1189,3,1189,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-sort SortSet{} [concat{}(Lbl'Unds'Set'Unds'{}()), element{}(LblSetItem{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(700,3,700,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Set{}())]
   sort SortFoo{} []
-  hooked-sort SortBool{} [hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(878,3,878,32)"), hasDomainValues{}()]
+  sort SortKResult{} []
+  sort SortA{} []
+  hooked-sort SortBool{} [hasDomainValues{}(), hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1068,3,1068,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
 
 // symbols
-  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(SortBool{}, SortSort, SortSort) : SortSort [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), smt-hook{}("ite"), right{}(), terminals{}("1010101"), hook{}("KEQUAL.ite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2186,26,2186,121)"), left{}(), format{}("%c#if%r %1 %c#then%r %2 %c#else%r %3 %c#fi%r"), function{}()]
-  hooked-symbol Lbl'Stop'List{}() : SortList{} [latex{}("\\dotCt{List}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), smtlib{}("smt_seq_nil"), terminals{}("1"), klabel{}(".List"), hook{}("LIST.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(747,19,747,142)"), left{}(), format{}("%c.List%r"), function{}()]
-  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [latex{}("\\dotCt{Map}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}(".Map"), hook{}("MAP.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(248,18,248,124)"), left{}(), format{}("%c.Map%r"), function{}()]
-  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [latex{}("\\dotCt{Set}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}(".Set"), hook{}("SET.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(539,18,539,118)"), left{}(), format{}("%c.Set%r"), function{}()]
-  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [functional{}(), constructor{}(), cellName{}("generatedCounter"), priorities{}(), right{}(), terminals{}("101"), left{}(), format{}("%c<generatedCounter>%r%i%n%1%d%n%c</generatedCounter>%r"), injective{}(), cell{}()]
-  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortKCell{}, SortGeneratedCounterCell{}) : SortGeneratedTopCell{} [functional{}(), constructor{}(), cellName{}("generatedTop"), priorities{}(), right{}(), terminals{}("1001"), left{}(), format{}("%1"), injective{}(), cell{}(), topcell{}()]
-  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortKCellOpt{}, SortGeneratedCounterCellOpt{}) : SortGeneratedTopCellFragment{} [functional{}(), constructor{}(), cellFragment{}("GeneratedTopCell"), priorities{}(), right{}(), terminals{}("1001"), left{}(), format{}("%c<generatedTop>-fragment%r %1 %2 %c</generatedTop>-fragment%r"), injective{}()]
-  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/kast.md)"), cellName{}("k"), maincell{}(), priorities{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), right{}(), terminals{}("101"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(535,17,535,32)"), left{}(), format{}("%c<k>%r%i%n%1%d%n%c</k>%r"), injective{}(), cell{}(), topcell{}()]
-  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("0101"), klabel{}("List:get"), hook{}("LIST.get"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(766,20,766,99)"), left{}(), format{}("%1 %c[%r %2 %c]%r"), function{}()]
-  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("List:range"), hook{}("LIST.range"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(813,19,813,120)"), left{}(), format{}("%crange%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), smtlib{}("smt_seq_elem"), terminals{}("1101"), klabel{}("ListItem"), hook{}("LIST.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(755,19,755,132)"), left{}(), format{}("%cListItem%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("0101"), klabel{}("Map:lookup"), hook{}("MAP.lookup"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(271,20,271,113)"), left{}(), format{}("%1 %c[%r %2 %c]%r"), function{}()]
-  hooked-symbol LblMap'Coln'update{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), prefer{}(), right{}(), terminals{}("010101"), klabel{}("Map:update"), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,18,290,140)"), left{}(), format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}()]
-  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [latex{}("{#1}-_{\\it Set}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("010"), klabel{}("Set:difference"), hook{}("SET.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(579,18,579,142)"), left{}(), format{}("%1 %c-Set%r %2"), function{}()]
-  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("010"), klabel{}("Set:in"), hook{}("SET.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(587,19,587,102)"), left{}(), format{}("%1 %cin%r %2"), function{}()]
-  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("SetItem"), hook{}("SET.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(547,18,547,119)"), left{}(), format{}("%cSetItem%r %c(%r %1 %c)%r"), injective{}(), function{}()]
-  hooked-symbol Lbl'UndsPerc'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("mod"), right{}(), terminals{}("010"), klabel{}("_%Int_"), hook{}("INT.tmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1047,18,1047,171)"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), format{}("%1 %c%%Int%r %2"), function{}()]
-  hooked-symbol Lbl'UndsAnd-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), comm{}(), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("andInt"), terminals{}("010"), klabel{}("_&Int_"), hook{}("INT.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1058,18,1058,184)"), left{}(Lbl'UndsAnd-'Int'Unds'{}()), format{}("%1 %c&Int%r %2"), function{}()]
-  hooked-symbol Lbl'UndsStar'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), comm{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("*"), right{}(), terminals{}("010"), klabel{}("_*Int_"), hook{}("INT.mul"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1043,18,1043,183)"), left{}(Lbl'Unds'modInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), format{}("%1 %c*Int%r %2"), function{}()]
-  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), comm{}(), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), smt-hook{}("+"), right{}(), terminals{}("010"), klabel{}("_+Int_"), hook{}("INT.add"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1052,18,1052,180)"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), format{}("%1 %c+Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'-Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), smt-hook{}("-"), right{}(), terminals{}("010"), klabel{}("_-Int_"), hook{}("INT.sub"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1053,18,1053,174)"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), format{}("%1 %c-Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [latex{}("{#1}-_{\\it Map}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,18,311,116)"), left{}(), format{}("%1 %c-Map%r %2"), function{}()]
-  hooked-symbol Lbl'UndsSlsh'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("div"), right{}(), terminals{}("010"), klabel{}("_/Int_"), hook{}("INT.tdiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1046,18,1046,173)"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), format{}("%1 %c/Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-LT--LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shlInt"), terminals{}("010"), klabel{}("_<<Int_"), hook{}("INT.shl"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1056,18,1056,173)"), left{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}()), format{}("%1 %c<<Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-LT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}("<="), right{}(), terminals{}("010"), klabel{}("_<=Int_"), hook{}("INT.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1114,19,1114,172)"), left{}(Lbl'Unds-LT-Eqls'Int'Unds'{}()), format{}("%1 %c<=Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,19,383,87)"), left{}(), format{}("%1 %c<=Map%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(596,19,596,81)"), left{}(), format{}("%1 %c<=Set%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}("<"), right{}(), terminals{}("010"), klabel{}("_<Int_"), hook{}("INT.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1115,19,1115,167)"), left{}(Lbl'Unds-LT-'Int'Unds'{}()), format{}("%1 %c<Int%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}("distinct"), right{}(), terminals{}("010"), klabel{}("_=/=Bool_"), hook{}("BOOL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(919,19,919,128)"), left{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}()), format{}("%1 %c=/=Bool%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}("distinct"), right{}(), terminals{}("010"), klabel{}("_=/=Int_"), hook{}("INT.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1119,19,1119,184)"), left{}(Lbl'UndsEqlsSlshEqls'Int'Unds'{}()), format{}("%1 %c=/=Int%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [latex{}("{#1}\\mathrel{\\neq_K}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), notEqualEqualK{}(), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), smt-hook{}("distinct"), right{}(), terminals{}("010"), klabel{}("_=/=K_"), hook{}("KEQUAL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2182,19,2182,166)"), left{}(Lbl'UndsEqlsEqls'K'Unds'{}(),Lbl'UndsEqlsSlshEqls'K'Unds'{}()), format{}("%1 %c=/=K%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}("="), right{}(), terminals{}("010"), klabel{}("_==Bool_"), hook{}("BOOL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(918,19,918,120)"), left{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), format{}("%1 %c==Bool%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}("="), right{}(), terminals{}("010"), klabel{}("_==Int_"), hook{}("INT.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1118,19,1118,173)"), left{}(Lbl'UndsEqlsEqls'Int'Unds'{}()), format{}("%1 %c==Int%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [latex{}("{#1}\\mathrel{=_K}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), smt-hook{}("="), right{}(), terminals{}("010"), equalEqualK{}(), klabel{}("_==K_"), hook{}("KEQUAL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2181,19,2181,152)"), left{}(Lbl'UndsEqlsSlshEqls'K'Unds'{}(),Lbl'UndsEqlsEqls'K'Unds'{}()), format{}("%1 %c==K%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-GT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}(">="), right{}(), terminals{}("010"), klabel{}("_>=Int_"), hook{}("INT.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1116,19,1116,172)"), left{}(Lbl'Unds-GT-Eqls'Int'Unds'{}()), format{}("%1 %c>=Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-GT--GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shrInt"), terminals{}("010"), klabel{}("_>>Int_"), hook{}("INT.shr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1055,18,1055,173)"), left{}(Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}()), format{}("%1 %c>>Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), smt-hook{}(">"), right{}(), terminals{}("010"), klabel{}("_>Int_"), hook{}("INT.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1117,19,1117,167)"), left{}(Lbl'Unds-GT-'Int'Unds'{}()), format{}("%1 %c>Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [unit{}(Lbl'Stop'List{}()), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), element{}(LblListItem{}()), symbol'Kywd'{}(), priorities{}(), right{}(), assoc{}(), smtlib{}("smt_seq_concat"), terminals{}("00"), klabel{}("_List_"), hook{}("LIST.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(739,19,739,188)"), left{}(Lbl'Unds'List'Unds'{}()), format{}("%1%n%2"), function{}()]
-  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [unit{}(Lbl'Stop'Map{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), symbol'Kywd'{}(), comm{}(), priorities{}(), right{}(), assoc{}(), terminals{}("00"), index{}("0"), klabel{}("_Map_"), hook{}("MAP.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,18,240,173)"), left{}(Lbl'Unds'Map'Unds'{}()), format{}("%1%n%2"), function{}()]
-  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [unit{}(Lbl'Stop'Set{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), element{}(LblSetItem{}()), symbol'Kywd'{}(), idem{}(), comm{}(), priorities{}(), right{}(), assoc{}(), terminals{}("00"), klabel{}("_Set_"), hook{}("SET.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(531,18,531,165)"), left{}(Lbl'Unds'Set'Unds'{}()), format{}("%1%n%2"), function{}()]
-  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010101"), klabel{}("List:set"), hook{}("LIST.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(775,19,775,108)"), left{}(), format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}()]
-  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("010111"), klabel{}("_[_<-undef]"), hook{}("MAP.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(299,18,299,117)"), left{}(), format{}("%1 %c[%r %2 %c<-%r %cundef%r %c]%r"), function{}()]
-  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'Unds'KItem'Unds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010110"), klabel{}("Map:lookupOrDefault"), hook{}("MAP.lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(281,20,281,134)"), left{}(), format{}("%1 %c[%r %2 %c]%r %corDefault%r %3"), function{}()]
-  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUnds'{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("(mod (^ #1 #2) #3)"), right{}(), terminals{}("0100"), klabel{}("_^%Int__"), hook{}("INT.powmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1041,18,1041,139)"), left{}(Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'UndsXor-'Int'Unds'{}()), format{}("%1 %c^%%Int%r %2 %3"), function{}()]
-  hooked-symbol Lbl'UndsXor-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("^"), right{}(), terminals{}("010"), klabel{}("_^Int_"), hook{}("INT.pow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1040,18,1040,178)"), left{}(Lbl'UndsXor-'Int'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}()), format{}("%1 %c^Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("and"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_andBool_"), hook{}("BOOL.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(911,19,911,185)"), left{}(Lbl'Unds'andBool'Unds'{}()), format{}("%1 %candBool%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'andThenBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("and"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_andThenBool_"), hook{}("BOOL.andThen"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(912,19,912,147)"), left{}(Lbl'Unds'andThenBool'Unds'{}()), format{}("%1 %candThenBool%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'divInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("div"), right{}(), terminals{}("010"), klabel{}("_divInt_"), hook{}("INT.ediv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1049,18,1049,122)"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}()), format{}("%1 %cdivInt%r %2"), function{}()]
-  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1128,19,1128,53)"), left{}(), format{}("%1 %cdividesInt%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'impliesBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("=>"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_impliesBool_"), hook{}("BOOL.implies"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(916,19,916,146)"), left{}(Lbl'Unds'impliesBool'Unds'{}()), format{}("%1 %cimpliesBool%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(SortKItem{}, SortList{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("010"), klabel{}("_inList_"), hook{}("LIST.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(822,19,822,97)"), left{}(), format{}("%1 %cin%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("01101"), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(357,19,357,89)"), left{}(), format{}("%1 %cin_keys%r %c(%r %2 %c)%r"), function{}()]
-  hooked-symbol Lbl'Unds'modInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("mod"), right{}(), terminals{}("010"), klabel{}("_modInt_"), hook{}("INT.emod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1050,18,1050,122)"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), format{}("%1 %cmodInt%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'orBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("or"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_orBool_"), hook{}("BOOL.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(914,19,914,180)"), left{}(Lbl'Unds'orBool'Unds'{}()), format{}("%1 %corBool%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'orElseBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("or"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_orElseBool_"), hook{}("BOOL.orElse"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(915,19,915,144)"), left{}(Lbl'Unds'orElseBool'Unds'{}()), format{}("%1 %corElseBool%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'xorBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("xor"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_xorBool_"), hook{}("BOOL.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(913,19,913,139)"), left{}(Lbl'Unds'xorBool'Unds'{}()), format{}("%1 %cxorBool%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'xorInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), comm{}(), priorities{}(Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("xorInt"), terminals{}("010"), klabel{}("_xorInt_"), hook{}("INT.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1060,18,1060,190)"), left{}(Lbl'Unds'xorInt'Unds'{}()), format{}("%1 %cxorInt%r %2"), function{}()]
-  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [latex{}("{#1}\\mapsto{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'Stop'Map{}(),Lbl'Unds'Map'Unds'{}()), right{}(Lbl'UndsPipe'-'-GT-Unds'{}()), terminals{}("010"), klabel{}("_|->_"), hook{}("MAP.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(257,18,257,151)"), left{}(Lbl'UndsPipe'-'-GT-Unds'{}()), format{}("%1 %c|->%r %2"), injective{}(), function{}()]
-  hooked-symbol Lbl'UndsPipe'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), comm{}(), priorities{}(), right{}(), smtlib{}("orInt"), terminals{}("010"), klabel{}("_|Int_"), hook{}("INT.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1062,18,1062,181)"), left{}(Lbl'UndsPipe'Int'Unds'{}()), format{}("%1 %c|Int%r %2"), function{}()]
-  hooked-symbol Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), comm{}(), priorities{}(), right{}(), terminals{}("010"), hook{}("SET.union"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(558,18,558,92)"), left{}(Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}()), format{}("%1 %c|Set%r %2"), function{}()]
-  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), smt-hook{}("(ite (< #1 0) (- 0 #1) #1)"), right{}(), terminals{}("1101"), klabel{}("absInt"), hook{}("INT.abs"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1079,18,1079,119)"), left{}(), format{}("%cabsInt%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblbar'LParRParUnds'K-RULE-FIND-SIMPLE'Unds'Bar{}() : SortBar{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/tests/k-rule-find-examples/one-line-rule/k-rule-find-simple.k)"), priorities{}(), right{}(), terminals{}("111"), klabel{}("bar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(4,20,4,25)"), left{}(), format{}("%cbar%r %c(%r %c)%r"), injective{}()]
-  symbol Lblbar2'LParRParUnds'K-RULE-FIND-SIMPLE'Unds'Bar{}() : SortBar{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/tests/k-rule-find-examples/one-line-rule/k-rule-find-simple.k)"), priorities{}(), right{}(), terminals{}("111"), klabel{}("bar2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(4,28,4,34)"), left{}(), format{}("%cbar2%r %c(%r %c)%r"), injective{}()]
-  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("bitRangeInt"), hook{}("INT.bitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1104,18,1104,103)"), left{}(), format{}("%cbitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'Unds'KItem'Unds'Map{}(SortMap{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Map:choice"), hook{}("MAP.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,20,393,101)"), left{}(), format{}("%cchoice%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lblchoice'LParUndsRParUnds'SET'Unds'KItem'Unds'Set{}(SortSet{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Set:choice"), hook{}("SET.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(614,20,614,95)"), left{}(), format{}("%cchoice%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101010101"), klabel{}("fillList"), hook{}("LIST.fill"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(803,19,803,100)"), left{}(), format{}("%cfillList%r %c(%r %1 %c,%r %2 %c,%r %3 %c,%r %4 %c)%r"), function{}()]
-  symbol Lblfoo'LParUndsRParUnds'K-RULE-FIND-SIMPLE'Unds'Foo'Unds'Bar{}(SortBar{}) : SortFoo{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/tests/k-rule-find-examples/one-line-rule/k-rule-find-simple.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("foo"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3,20,3,28)"), left{}(), format{}("%cfoo%r %c(%r %1 %c)%r"), injective{}()]
-  symbol LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), freshGenerator{}(), klabel{}("freshInt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1253,18,1253,77)"), left{}(), format{}("%cfreshInt%r %c(%r %1 %c)%r"), private{}(), function{}()]
-  symbol LblgetGeneratedCounterCell{}(SortGeneratedTopCell{}) : SortGeneratedCounterCell{} [priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cgetGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [noThread{}(), priorities{}(), right{}(), terminals{}("1"), left{}(), initializer{}(), format{}("%cinitGeneratedCounterCell%r"), function{}()]
-  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [noThread{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), initializer{}(), format{}("%cinitGeneratedTopCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [noThread{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), initializer{}(), format{}("%cinitKCell%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), comm{}(), priorities{}(), right{}(), terminals{}("110101"), klabel{}("intersectSet"), hook{}("SET.intersection"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(569,18,569,90)"), left{}(), format{}("%cintersectSet%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  symbol LblisBar{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Bar"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisBar%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisBool{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Bool"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisBool%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisFoo{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Foo"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisFoo%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("GeneratedCounterCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("GeneratedCounterCellOpt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("GeneratedTopCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedTopCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("GeneratedTopCellFragment"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisInt{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Int"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisInt%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisK{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("K"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisK%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisKCell{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("KCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("KCellOpt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKCellOpt%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("KConfigVar"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKConfigVar%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisKItem{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("KItem"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKItem%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisList{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("List"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisList%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisMap{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Map"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisMap%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisSet{}(SortK{}) : SortBool{} [functional{}(), total{}(), predicate{}("Set"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisSet%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(SortMap{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("keys"), hook{}("MAP.keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,18,341,82)"), left{}(), format{}("%ckeys%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,19,349,80)"), left{}(), format{}("%ckeys_list%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("log2Int"), hook{}("INT.log2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1090,18,1090,75)"), left{}(), format{}("%clog2Int%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'Unds'List'Unds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("makeList"), hook{}("LIST.make"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(784,19,784,82)"), left{}(), format{}("%cmakeList%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), smt-hook{}("(ite (< #1 #2) #2 #1)"), right{}(), terminals{}("110101"), hook{}("INT.max"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1071,18,1071,114)"), left{}(), format{}("%cmaxInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), smt-hook{}("(ite (< #1 #2) #1 #2)"), right{}(), terminals{}("110101"), hook{}("INT.min"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1070,18,1070,114)"), left{}(), format{}("%cminInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  symbol LblnoGeneratedCounterCell{}() : SortGeneratedCounterCellOpt{} [functional{}(), constructor{}(), cellOptAbsent{}("GeneratedCounterCell"), priorities{}(), right{}(), terminals{}("1"), left{}(), format{}("%cnoGeneratedCounterCell%r"), injective{}()]
-  symbol LblnoKCell{}() : SortKCellOpt{} [functional{}(), constructor{}(), cellOptAbsent{}("KCell"), priorities{}(), right{}(), terminals{}("1"), left{}(), format{}("%cnoKCell%r"), injective{}()]
-  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), smt-hook{}("not"), boolOperation{}(), right{}(), terminals{}("10"), klabel{}("notBool_"), hook{}("BOOL.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(910,19,910,172)"), left{}(), format{}("%cnotBool%r %1"), function{}()]
-  symbol Lblproject'Coln'Bar{}(SortK{}) : SortBar{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Bar%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'Bool{}(SortK{}) : SortBool{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Bool%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'Foo{}(SortK{}) : SortFoo{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Foo%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'GeneratedCounterCell{}(SortK{}) : SortGeneratedCounterCell{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:GeneratedCounterCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'GeneratedCounterCellOpt{}(SortK{}) : SortGeneratedCounterCellOpt{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:GeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'GeneratedTopCell{}(SortK{}) : SortGeneratedTopCell{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:GeneratedTopCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'GeneratedTopCellFragment{}(SortK{}) : SortGeneratedTopCellFragment{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:GeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'Int{}(SortK{}) : SortInt{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Int%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'K{}(SortK{}) : SortK{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:K%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'KCell{}(SortK{}) : SortKCell{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:KCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'KCellOpt{}(SortK{}) : SortKCellOpt{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:KCellOpt%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'KItem{}(SortK{}) : SortKItem{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:KItem%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'List{}(SortK{}) : SortList{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:List%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'Map{}(SortK{}) : SortMap{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Map%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'Set{}(SortK{}) : SortSet{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Set%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblrandInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("randInt"), hook{}("INT.rand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1138,18,1138,65)"), left{}(), format{}("%crandInt%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("110101"), klabel{}("removeAll"), hook{}("MAP.removeAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,18,333,87)"), left{}(), format{}("%cremoveAll%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("signExtendBitRangeInt"), hook{}("INT.signExtendBitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1105,18,1105,113)"), left{}(), format{}("%csignExtendBitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol Lblsize'LParUndsRParUnds'LIST'Unds'Int'Unds'List{}(SortList{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), smtlib{}("smt_seq_len"), terminals{}("1101"), klabel{}("sizeList"), hook{}("LIST.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(830,18,830,117)"), left{}(), format{}("%csize%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lblsize'LParUndsRParUnds'MAP'Unds'Int'Unds'Map{}(SortMap{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("sizeMap"), hook{}("MAP.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(373,18,373,99)"), left{}(), format{}("%csize%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(SortSet{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("size"), hook{}("SET.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(604,18,604,76)"), left{}(), format{}("%csize%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblsrandInt'LParUndsRParUnds'INT-COMMON'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("srandInt"), hook{}("INT.srand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1139,16,1139,65)"), left{}(), format{}("%csrandInt%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("updateList"), hook{}("LIST.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(794,19,794,97)"), left{}(), format{}("%cupdateList%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), priorities{}(), right{}(), terminals{}("110101"), klabel{}("updateMap"), hook{}("MAP.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(324,18,324,87)"), left{}(), format{}("%cupdateMap%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("values"), hook{}("MAP.values"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(365,19,365,77)"), left{}(), format{}("%cvalues%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lbl'Tild'Int'Unds'{}(SortInt{}) : SortInt{} [latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}(), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsXor-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smtlib{}("notInt"), terminals{}("10"), klabel{}("~Int_"), hook{}("INT.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1038,18,1038,168)"), left{}(), format{}("%c~Int%r %1"), function{}()]
+  symbol Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(SortK{}) : SortKItem{} [constructor{}(), format{}("%c#freezerbar(_,_)_K-RULE-FIND-TEST_A_A_A0_%r %c(%r %1 %c)%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(SortK{}) : SortKItem{} [constructor{}(), format{}("%c#freezerbar(_,_)_K-RULE-FIND-TEST_A_A_A1_%r %c(%r %1 %c)%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lbl'Hash'freezerbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(SortK{}) : SortKItem{} [constructor{}(), format{}("%c#freezerbaz(_,_)_K-RULE-FIND-TEST_A_A_A1_%r %c(%r %1 %c)%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(SortK{}) : SortKItem{} [constructor{}(), format{}("%c#freezerfoo(_,_)_K-RULE-FIND-TEST_A_A_A0_%r %c(%r %1 %c)%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(SortK{}) : SortKItem{} [constructor{}(), format{}("%c#freezerfoo(_,_)_K-RULE-FIND-TEST_A_A_A1_%r %c(%r %1 %c)%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(SortBool{}, SortSort, SortSort) : SortSort [format{}("%c#if%r %1 %c#then%r %2 %c#else%r %3 %c#fi%r"), function{}(), functional{}(), hook{}("KEQUAL.ite"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2262,26,2262,121)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("ite"), terminals{}("1010101"), total{}()]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [format{}("%c.List%r"), function{}(), functional{}(), hook{}("LIST.unit"), klabel{}(".List"), latex{}("\\dotCt{List}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(937,19,937,142)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_nil"), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [format{}("%c.Map%r"), function{}(), functional{}(), hook{}("MAP.unit"), klabel{}(".Map"), latex{}("\\dotCt{Map}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(248,18,248,124)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [format{}("%c.Set%r"), function{}(), functional{}(), hook{}("SET.unit"), klabel{}(".Set"), latex{}("\\dotCt{Set}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(729,18,729,118)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [cell{}(), cellName{}("generatedCounter"), constructor{}(), format{}("%c<generatedCounter>%r%i%n%1%d%n%c</generatedCounter>%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("101")]
+  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortKCell{}, SortGeneratedCounterCell{}) : SortGeneratedTopCell{} [cell{}(), cellName{}("generatedTop"), constructor{}(), format{}("%1"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1001")]
+  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortKCellOpt{}, SortGeneratedCounterCellOpt{}) : SortGeneratedTopCellFragment{} [cellFragment{}("GeneratedTopCell"), constructor{}(), format{}("%c<generatedTop>-fragment%r %1 %2 %c</generatedTop>-fragment%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1001")]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [cell{}(), cellName{}("k"), constructor{}(), format{}("%c<k>%r%i%n%1%d%n%c</k>%r"), functional{}(), injective{}(), left{}(), maincell{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(535,17,535,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/kast.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), priorities{}(), right{}(), terminals{}("101")]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [format{}("%1 %c[%r %2 %c]%r"), function{}(), hook{}("LIST.get"), klabel{}("List:get"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(956,20,956,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("0101")]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [format{}("%crange%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("LIST.range"), klabel{}("List:range"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1003,19,1003,120)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("11010101")]
+  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [format{}("%cListItem%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("LIST.element"), klabel{}("ListItem"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(945,19,945,132)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_elem"), symbol'Kywd'{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [format{}("%1 %c[%r %2 %c]%r"), function{}(), hook{}("MAP.lookup"), klabel{}("Map:lookup"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(271,20,271,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("0101")]
+  hooked-symbol LblMap'Coln'update{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}(), functional{}(), hook{}("MAP.update"), klabel{}("Map:update"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,18,290,140)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), prefer{}(), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010101"), total{}()]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [format{}("%1 %c-Set%r %2"), function{}(), functional{}(), hook{}("SET.difference"), klabel{}("Set:difference"), latex{}("{#1}-_{\\it Set}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(769,18,769,142)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [format{}("%1 %cin%r %2"), function{}(), functional{}(), hook{}("SET.in"), klabel{}("Set:in"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(777,19,777,102)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [format{}("%cSetItem%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("SET.element"), injective{}(), klabel{}("SetItem"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(737,18,737,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lbl'UndsPerc'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c%%Int%r %2"), function{}(), hook{}("INT.tmod"), klabel{}("_%Int_"), latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1237,18,1237,171)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("mod"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'UndsAnd-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c&Int%r %2"), function{}(), functional{}(), hook{}("INT.and"), klabel{}("_&Int_"), latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsAnd-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1248,18,1248,184)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("andInt"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsStar'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c*Int%r %2"), function{}(), functional{}(), hook{}("INT.mul"), klabel{}("_*Int_"), latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds'modInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1233,18,1233,183)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("*"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c+Int%r %2"), function{}(), functional{}(), hook{}("INT.add"), klabel{}("_+Int_"), latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1242,18,1242,180)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smt-hook{}("+"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'-Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c-Int%r %2"), function{}(), functional{}(), hook{}("INT.sub"), klabel{}("_-Int_"), latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1243,18,1243,174)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smt-hook{}("-"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [format{}("%1 %c-Map%r %2"), function{}(), functional{}(), hook{}("MAP.difference"), latex{}("{#1}-_{\\it Map}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,18,311,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsSlsh'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c/Int%r %2"), function{}(), hook{}("INT.tdiv"), klabel{}("_/Int_"), latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1236,18,1236,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("div"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c<<Int%r %2"), function{}(), hook{}("INT.shl"), klabel{}("_<<Int_"), latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1246,18,1246,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shlInt"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c<=Int%r %2"), function{}(), functional{}(), hook{}("INT.le"), klabel{}("_<=Int_"), latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1304,19,1304,166)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("<="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [format{}("%1 %c<=Map%r %2"), function{}(), functional{}(), hook{}("MAP.inclusion"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,19,383,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [format{}("%1 %c<=Set%r %2"), function{}(), functional{}(), hook{}("SET.inclusion"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(786,19,786,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c<Int%r %2"), function{}(), functional{}(), hook{}("INT.lt"), klabel{}("_<Int_"), latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1305,19,1305,161)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("<"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [comm{}(), format{}("%1 %c=/=Bool%r %2"), function{}(), functional{}(), hook{}("BOOL.ne"), klabel{}("_=/=Bool_"), left{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1109,19,1109,134)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("distinct"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [comm{}(), format{}("%1 %c=/=Int%r %2"), function{}(), functional{}(), hook{}("INT.ne"), klabel{}("_=/=Int_"), latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1309,19,1309,184)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("distinct"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [comm{}(), format{}("%1 %c=/=K%r %2"), function{}(), functional{}(), group{}("notEqualEqualK"), hook{}("KEQUAL.ne"), klabel{}("_=/=K_"), latex{}("{#1}\\mathrel{\\neq_K}{#2}"), left{}(Lbl'UndsEqlsEqls'K'Unds'{}(),Lbl'UndsEqlsSlshEqls'K'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2258,19,2258,179)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), right{}(), smt-hook{}("distinct"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [comm{}(), format{}("%1 %c==Bool%r %2"), function{}(), functional{}(), hook{}("BOOL.eq"), klabel{}("_==Bool_"), left{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1108,19,1108,126)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [comm{}(), format{}("%1 %c==Int%r %2"), function{}(), functional{}(), hook{}("INT.eq"), klabel{}("_==Int_"), latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1308,19,1308,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [comm{}(), format{}("%1 %c==K%r %2"), function{}(), functional{}(), group{}("equalEqualK"), hook{}("KEQUAL.eq"), klabel{}("_==K_"), latex{}("{#1}\\mathrel{=_K}{#2}"), left{}(Lbl'UndsEqlsSlshEqls'K'Unds'{}(),Lbl'UndsEqlsEqls'K'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2257,19,2257,165)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), right{}(), smt-hook{}("="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c>=Int%r %2"), function{}(), functional{}(), hook{}("INT.ge"), klabel{}("_>=Int_"), latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1306,19,1306,166)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}(">="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c>>Int%r %2"), function{}(), hook{}("INT.shr"), klabel{}("_>>Int_"), latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1245,18,1245,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shrInt"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds-GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c>Int%r %2"), function{}(), functional{}(), hook{}("INT.gt"), klabel{}("_>Int_"), latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1307,19,1307,161)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}(">"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [assoc{}(), element{}(LblListItem{}()), format{}("%1%n%2"), function{}(), functional{}(), hook{}("LIST.concat"), klabel{}("_List_"), left{}(Lbl'Unds'List'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(929,19,929,188)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_concat"), symbol'Kywd'{}(), terminals{}("00"), total{}(), unit{}(Lbl'Stop'List{}())]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [assoc{}(), comm{}(), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), format{}("%1%n%2"), function{}(), hook{}("MAP.concat"), index{}("0"), klabel{}("_Map_"), left{}(Lbl'Unds'Map'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,18,240,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("00"), unit{}(Lbl'Stop'Map{}())]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [assoc{}(), comm{}(), element{}(LblSetItem{}()), format{}("%1%n%2"), function{}(), hook{}("SET.concat"), idem{}(), klabel{}("_Set_"), left{}(Lbl'Unds'Set'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(721,18,721,165)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("00"), unit{}(Lbl'Stop'Set{}())]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}(), hook{}("LIST.update"), klabel{}("List:set"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(965,19,965,108)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010101")]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [format{}("%1 %c[%r %2 %c<-%r %cundef%r %c]%r"), function{}(), functional{}(), hook{}("MAP.remove"), klabel{}("_[_<-undef]"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(299,18,299,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010111"), total{}()]
+  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'Unds'KItem'Unds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [format{}("%1 %c[%r %2 %c]%r %corDefault%r %3"), function{}(), functional{}(), hook{}("MAP.lookupOrDefault"), klabel{}("Map:lookupOrDefault"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(281,20,281,134)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010110"), total{}()]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUnds'{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c^%%Int%r %2 %3"), function{}(), hook{}("INT.powmod"), klabel{}("_^%Int__"), left{}(Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'UndsXor-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1231,18,1231,139)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("(mod (^ #1 #2) #3)"), symbol'Kywd'{}(), terminals{}("0100")]
+  hooked-symbol Lbl'UndsXor-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c^Int%r %2"), function{}(), hook{}("INT.pow"), klabel{}("_^Int_"), latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsXor-'Int'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1230,18,1230,178)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("^"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [format{}("%1 %candBool%r %2"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.and"), klabel{}("_andBool_"), latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), left{}(Lbl'Unds'andBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1101,19,1101,192)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("and"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'andThenBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [format{}("%1 %candThenBool%r %2"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.andThen"), klabel{}("_andThenBool_"), left{}(Lbl'Unds'andThenBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1102,19,1102,154)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("and"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'divInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %cdivInt%r %2"), function{}(), hook{}("INT.ediv"), klabel{}("_divInt_"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1239,18,1239,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("div"), symbol'Kywd'{}(), terminals{}("010")]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %cdividesInt%r %2"), function{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1318,19,1318,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'impliesBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [format{}("%1 %cimpliesBool%r %2"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.implies"), klabel{}("_impliesBool_"), left{}(Lbl'Unds'impliesBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1106,19,1106,153)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("=>"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(SortKItem{}, SortList{}) : SortBool{} [format{}("%1 %cin%r %2"), function{}(), functional{}(), hook{}("LIST.in"), klabel{}("_inList_"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1012,19,1012,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [format{}("%1 %cin_keys%r %c(%r %2 %c)%r"), function{}(), functional{}(), hook{}("MAP.in_keys"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(357,19,357,89)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("01101"), total{}()]
+  hooked-symbol Lbl'Unds'modInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %cmodInt%r %2"), function{}(), hook{}("INT.emod"), klabel{}("_modInt_"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1240,18,1240,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("mod"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'orBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [format{}("%1 %corBool%r %2"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.or"), klabel{}("_orBool_"), latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), left{}(Lbl'Unds'orBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1104,19,1104,187)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("or"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'orElseBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [format{}("%1 %corElseBool%r %2"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.orElse"), klabel{}("_orElseBool_"), left{}(Lbl'Unds'orElseBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1105,19,1105,151)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("or"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'xorBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [format{}("%1 %cxorBool%r %2"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.xor"), klabel{}("_xorBool_"), left{}(Lbl'Unds'xorBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1103,19,1103,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("xor"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'xorInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %cxorInt%r %2"), function{}(), functional{}(), hook{}("INT.xor"), klabel{}("_xorInt_"), latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds'xorInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1250,18,1250,190)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("xorInt"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [format{}("%1 %c|->%r %2"), function{}(), functional{}(), hook{}("MAP.element"), injective{}(), klabel{}("_|->_"), latex{}("{#1}\\mapsto{#2}"), left{}(Lbl'UndsPipe'-'-GT-Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(257,18,257,151)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Stop'Map{}(),Lbl'Unds'Map'Unds'{}()), right{}(Lbl'UndsPipe'-'-GT-Unds'{}()), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c|Int%r %2"), function{}(), functional{}(), hook{}("INT.or"), klabel{}("_|Int_"), latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsPipe'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1252,18,1252,181)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("orInt"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [comm{}(), format{}("%1 %c|Set%r %2"), function{}(), functional{}(), hook{}("SET.union"), left{}(Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(748,18,748,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  symbol Lbla'Unds'K-RULE-FIND-TEST'Unds'A{}() : SortA{} [constructor{}(), format{}("%ca%r"), functional{}(), injective{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(10,18,10,21)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), priorities{}(), right{}(), terminals{}("1")]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%cabsInt%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("INT.abs"), klabel{}("absInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1269,18,1269,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("(ite (< #1 0) (- 0 #1) #1)"), terminals{}("1101"), total{}()]
+  symbol Lblbar'LParRParUnds'K-RULE-FIND-TEST'Unds'Bar{}() : SortBar{} [constructor{}(), format{}("%cbar%r %c(%r %c)%r"), functional{}(), injective{}(), klabel{}("bar"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,20,5,25)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), priorities{}(), right{}(), terminals{}("111")]
+  symbol Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(SortA{}, SortA{}) : SortA{} [constructor{}(), format{}("%cbar%r %c(%r %1 %c,%r %2 %c)%r"), functional{}(), injective{}(), klabel{}("bar"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,19,12,30)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), priorities{}(), right{}(), terminals{}("110101")]
+  symbol Lblbar2'LParRParUnds'K-RULE-FIND-TEST'Unds'Bar{}() : SortBar{} [constructor{}(), format{}("%cbar2%r %c(%r %c)%r"), functional{}(), injective{}(), klabel{}("bar2"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,28,5,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), priorities{}(), right{}(), terminals{}("111")]
+  symbol Lblbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(SortA{}, SortA{}) : SortA{} [constructor{}(), format{}("%cbaz%r %c(%r %1 %c,%r %2 %c)%r"), functional{}(), injective{}(), klabel{}("baz"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(13,19,13,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), priorities{}(), right{}(), strict{}("2"), terminals{}("110101")]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [format{}("%cbitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("INT.bitRange"), klabel{}("bitRangeInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1294,18,1294,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'Unds'KItem'Unds'Map{}(SortMap{}) : SortKItem{} [format{}("%cchoice%r %c(%r %1 %c)%r"), function{}(), hook{}("MAP.choice"), klabel{}("Map:choice"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,20,393,101)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'SET'Unds'KItem'Unds'Set{}(SortSet{}) : SortKItem{} [format{}("%cchoice%r %c(%r %1 %c)%r"), function{}(), hook{}("SET.choice"), klabel{}("Set:choice"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(804,20,804,95)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [format{}("%cfillList%r %c(%r %1 %c,%r %2 %c,%r %3 %c,%r %4 %c)%r"), function{}(), hook{}("LIST.fill"), klabel{}("fillList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(993,19,993,100)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101010101")]
+  symbol Lblfoo'LParUndsRParUnds'K-RULE-FIND-TEST'Unds'Foo'Unds'Bar{}(SortBar{}) : SortFoo{} [constructor{}(), format{}("%cfoo%r %c(%r %1 %c)%r"), functional{}(), injective{}(), klabel{}("foo"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(4,20,4,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(SortA{}, SortA{}) : SortA{} [constructor{}(), format{}("%cfoo%r %c(%r %1 %c,%r %2 %c)%r"), functional{}(), injective{}(), klabel{}("foo"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(11,19,11,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), priorities{}(), right{}(), seqstrict{}(), terminals{}("110101")]
+  symbol LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%cfreshInt%r %c(%r %1 %c)%r"), freshGenerator{}(), function{}(), functional{}(), klabel{}("freshInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1432,18,1432,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), private{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblgetGeneratedCounterCell{}(SortGeneratedTopCell{}) : SortGeneratedCounterCell{} [format{}("%cgetGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [format{}("%cinitGeneratedCounterCell%r"), function{}(), initializer{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [format{}("%cinitGeneratedTopCell%r %c(%r %1 %c)%r"), function{}(), initializer{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [format{}("%cinitKCell%r %c(%r %1 %c)%r"), function{}(), initializer{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [comm{}(), format{}("%cintersectSet%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("SET.intersection"), klabel{}("intersectSet"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(759,18,759,90)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  symbol LblisA{}(SortK{}) : SortBool{} [format{}("%cisA%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("A"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisBar{}(SortK{}) : SortBool{} [format{}("%cisBar%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Bar"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisBool{}(SortK{}) : SortBool{} [format{}("%cisBool%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Bool"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisFoo{}(SortK{}) : SortBool{} [format{}("%cisFoo%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Foo"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [format{}("%cisGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedCounterCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [format{}("%cisGeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedCounterCellOpt"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [format{}("%cisGeneratedTopCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedTopCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [format{}("%cisGeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedTopCellFragment"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisInt{}(SortK{}) : SortBool{} [format{}("%cisInt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Int"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisK{}(SortK{}) : SortBool{} [format{}("%cisK%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("K"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [format{}("%cisKCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [format{}("%cisKCellOpt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KCellOpt"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [format{}("%cisKConfigVar%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KConfigVar"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [format{}("%cisKItem%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KItem"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKResult{}(SortK{}) : SortBool{} [format{}("%cisKResult%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KResult"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisList{}(SortK{}) : SortBool{} [format{}("%cisList%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("List"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisMap{}(SortK{}) : SortBool{} [format{}("%cisMap%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Map"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [format{}("%cisSet%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Set"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(SortMap{}) : SortSet{} [format{}("%ckeys%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("MAP.keys"), klabel{}("keys"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,18,341,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [format{}("%ckeys_list%r %c(%r %1 %c)%r"), function{}(), hook{}("MAP.keys_list"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,19,349,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%clog2Int%r %c(%r %1 %c)%r"), function{}(), hook{}("INT.log2"), klabel{}("log2Int"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1280,18,1280,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'Unds'List'Unds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [format{}("%cmakeList%r %c(... %r length: %1 %c,%r value: %2 %c)%r"), function{}(), hook{}("LIST.make"), klabel{}("makeList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(974,19,974,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%cmaxInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("INT.max"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1261,18,1261,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("(ite (< #1 #2) #2 #1)"), terminals{}("110101"), total{}()]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%cminInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("INT.min"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1260,18,1260,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("(ite (< #1 #2) #1 #2)"), terminals{}("110101"), total{}()]
+  symbol LblnoGeneratedCounterCell{}() : SortGeneratedCounterCellOpt{} [cellOptAbsent{}("GeneratedCounterCell"), constructor{}(), format{}("%cnoGeneratedCounterCell%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  symbol LblnoKCell{}() : SortKCellOpt{} [cellOptAbsent{}("KCell"), constructor{}(), format{}("%cnoKCell%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [format{}("%cnotBool%r %1"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.not"), klabel{}("notBool_"), latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1100,19,1100,179)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), right{}(), smt-hook{}("not"), symbol'Kywd'{}(), terminals{}("10"), total{}()]
+  symbol Lblproject'Coln'A{}(SortK{}) : SortA{} [format{}("%cproject:A%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Bar{}(SortK{}) : SortBar{} [format{}("%cproject:Bar%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Bool{}(SortK{}) : SortBool{} [format{}("%cproject:Bool%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Foo{}(SortK{}) : SortFoo{} [format{}("%cproject:Foo%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedCounterCell{}(SortK{}) : SortGeneratedCounterCell{} [format{}("%cproject:GeneratedCounterCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedCounterCellOpt{}(SortK{}) : SortGeneratedCounterCellOpt{} [format{}("%cproject:GeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedTopCell{}(SortK{}) : SortGeneratedTopCell{} [format{}("%cproject:GeneratedTopCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedTopCellFragment{}(SortK{}) : SortGeneratedTopCellFragment{} [format{}("%cproject:GeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Int{}(SortK{}) : SortInt{} [format{}("%cproject:Int%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'K{}(SortK{}) : SortK{} [format{}("%cproject:K%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'KCell{}(SortK{}) : SortKCell{} [format{}("%cproject:KCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'KCellOpt{}(SortK{}) : SortKCellOpt{} [format{}("%cproject:KCellOpt%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'KItem{}(SortK{}) : SortKItem{} [format{}("%cproject:KItem%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'KResult{}(SortK{}) : SortKResult{} [format{}("%cproject:KResult%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'List{}(SortK{}) : SortList{} [format{}("%cproject:List%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Map{}(SortK{}) : SortMap{} [format{}("%cproject:Map%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Set{}(SortK{}) : SortSet{} [format{}("%cproject:Set%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%crandInt%r %c(%r %1 %c)%r"), function{}(), hook{}("INT.rand"), impure{}(), klabel{}("randInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1328,18,1328,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [format{}("%cremoveAll%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("MAP.removeAll"), klabel{}("removeAll"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,18,333,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [format{}("%csignExtendBitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("INT.signExtendBitRange"), klabel{}("signExtendBitRangeInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1295,18,1295,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol Lblsize'LParUndsRParUnds'LIST'Unds'Int'Unds'List{}(SortList{}) : SortInt{} [format{}("%csize%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("LIST.size"), klabel{}("sizeList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1020,18,1020,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_len"), terminals{}("1101"), total{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'MAP'Unds'Int'Unds'Map{}(SortMap{}) : SortInt{} [format{}("%csize%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("MAP.size"), klabel{}("sizeMap"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(373,18,373,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(SortSet{}) : SortInt{} [format{}("%csize%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("SET.size"), klabel{}("size"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(794,18,794,76)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT-COMMON'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [format{}("%csrandInt%r %c(%r %1 %c)%r"), function{}(), hook{}("INT.srand"), impure{}(), klabel{}("srandInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1329,16,1329,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [format{}("%cupdateList%r %c(... %r dest: %1 %c,%r index: %2 %c,%r src: %3 %c)%r"), function{}(), hook{}("LIST.updateAll"), klabel{}("updateList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(984,19,984,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [format{}("%cupdateMap%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("MAP.updateAll"), klabel{}("updateMap"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(324,18,324,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [format{}("%cvalues%r %c(%r %1 %c)%r"), function{}(), hook{}("MAP.values"), klabel{}("values"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(365,19,365,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbl'Tild'Int'Unds'{}(SortInt{}) : SortInt{} [format{}("%c~Int%r %1"), function{}(), functional{}(), hook{}("INT.not"), klabel{}("~Int_"), latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1228,18,1228,168)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsXor-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smtlib{}("notInt"), symbol'Kywd'{}(), terminals{}("10"), total{}()]
 
 // generated axioms
+  axiom{R} \exists{R} (Val:SortKResult{}, \equals{SortKResult{}, R} (Val:SortKResult{}, inj{SortInt{}, SortKResult{}} (From:SortInt{}))) [subsort{SortInt{}, SortKResult{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCellOpt{}, SortKItem{}} (From:SortKCellOpt{}))) [subsort{SortKCellOpt{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (From:SortGeneratedCounterCellOpt{}))) [subsort{SortGeneratedCounterCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKResult{}, SortKItem{}} (From:SortKResult{}))) [subsort{SortKResult{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCell{}, SortKItem{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortA{}, \equals{SortA{}, R} (Val:SortA{}, inj{SortInt{}, SortA{}} (From:SortInt{}))) [subsort{SortInt{}, SortA{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, inj{SortKCell{}, SortKCellOpt{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKCellOpt{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSet{}, SortKItem{}} (From:SortSet{}))) [subsort{SortSet{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortKItem{}}()] // subsort
@@ -228,6 +250,27 @@ module K-RULE-FIND-SIMPLE
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (From:SortGeneratedTopCellFragment{}))) [subsort{SortGeneratedTopCellFragment{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMap{}, SortKItem{}} (From:SortMap{}))) [subsort{SortMap{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortA{}, SortKItem{}} (From:SortA{}))) [subsort{SortA{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(X0:SortK{}), Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(Y0:SortK{})), Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(X0:SortK{}), Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(X0:SortK{}), Lbl'Hash'freezerbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(X0:SortK{}), Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(X0:SortK{}), Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(X0:SortK{}), Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(Y0:SortK{})), Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(X0:SortK{}), Lbl'Hash'freezerbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(X0:SortK{}), Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(X0:SortK{}), Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezerbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(X0:SortK{}), Lbl'Hash'freezerbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(Y0:SortK{})), Lbl'Hash'freezerbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(X0:SortK{}), Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(X0:SortK{}), Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(X0:SortK{}), Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(Y0:SortK{})), Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(X0:SortK{}), Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(X0:SortK{}), Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(Y0:SortK{})), Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
   axiom{R, SortSort} \exists{R} (Val:SortSort, \equals{SortSort, R} (Val:SortSort, Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(K0:SortBool{}, K1:SortSort, K2:SortSort))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
@@ -245,11 +288,8 @@ module K-RULE-FIND-SIMPLE
   axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortKItem{}, K1:SortSet{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortKItem{}))) [functional{}()] // functional
-  axiom{R} \equals{SortInt{}, R} (Lbl'UndsAnd-'Int'Unds'{}(K1:SortInt{},K2:SortInt{}),Lbl'UndsAnd-'Int'Unds'{}(K2:SortInt{},K1:SortInt{})) [comm{}()] // commutativity
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
-  axiom{R} \equals{SortInt{}, R} (Lbl'UndsStar'Int'Unds'{}(K1:SortInt{},K2:SortInt{}),Lbl'UndsStar'Int'Unds'{}(K2:SortInt{},K1:SortInt{})) [comm{}()] // commutativity
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
-  axiom{R} \equals{SortInt{}, R} (Lbl'UndsPlus'Int'Unds'{}(K1:SortInt{},K2:SortInt{}),Lbl'UndsPlus'Int'Unds'{}(K2:SortInt{},K1:SortInt{})) [comm{}()] // commutativity
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
@@ -270,11 +310,9 @@ module K-RULE-FIND-SIMPLE
   axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Stop'List{}(),K:SortList{}),K:SortList{}) [unit{}()] // left unit
   axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
   axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
-  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),Lbl'Unds'Map'Unds'{}(K2:SortMap{},K1:SortMap{})) [comm{}()] // commutativity
   axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K:SortMap{},Lbl'Stop'Map{}()),K:SortMap{}) [unit{}()] // right unit
   axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),K:SortMap{}),K:SortMap{}) [unit{}()] // left unit
   axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
-  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),Lbl'Unds'Set'Unds'{}(K2:SortSet{},K1:SortSet{})) [comm{}()] // commutativity
   axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
   axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},Lbl'Stop'Set{}()),K:SortSet{}) [unit{}()] // right unit
   axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Stop'Set{}(),K:SortSet{}),K:SortSet{}) [unit{}()] // left unit
@@ -288,22 +326,32 @@ module K-RULE-FIND-SIMPLE
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
-  axiom{R} \equals{SortInt{}, R} (Lbl'Unds'xorInt'Unds'{}(K1:SortInt{},K2:SortInt{}),Lbl'Unds'xorInt'Unds'{}(K2:SortInt{},K1:SortInt{})) [comm{}()] // commutativity
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortKItem{}, K1:SortKItem{}))) [functional{}()] // functional
-  axiom{R} \equals{SortInt{}, R} (Lbl'UndsPipe'Int'Unds'{}(K1:SortInt{},K2:SortInt{}),Lbl'UndsPipe'Int'Unds'{}(K2:SortInt{},K1:SortInt{})) [comm{}()] // commutativity
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
-  axiom{R} \equals{SortSet{}, R} (Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K1:SortSet{},K2:SortSet{}),Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K2:SortSet{},K1:SortSet{})) [comm{}()] // commutativity
   axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortA{}, \equals{SortA{}, R} (Val:SortA{}, Lbla'Unds'K-RULE-FIND-TEST'Unds'A{}())) [functional{}()] // functional
+  axiom{}\not{SortA{}} (\and{SortA{}} (Lbla'Unds'K-RULE-FIND-TEST'Unds'A{}(), Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(Y0:SortA{}, Y1:SortA{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortA{}} (\and{SortA{}} (Lbla'Unds'K-RULE-FIND-TEST'Unds'A{}(), Lblbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(Y0:SortA{}, Y1:SortA{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortA{}} (\and{SortA{}} (Lbla'Unds'K-RULE-FIND-TEST'Unds'A{}(), Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(Y0:SortA{}, Y1:SortA{}))) [constructor{}()] // no confusion different constructors
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
-  axiom{R} \exists{R} (Val:SortBar{}, \equals{SortBar{}, R} (Val:SortBar{}, Lblbar'LParRParUnds'K-RULE-FIND-SIMPLE'Unds'Bar{}())) [functional{}()] // functional
-  axiom{}\not{SortBar{}} (\and{SortBar{}} (Lblbar'LParRParUnds'K-RULE-FIND-SIMPLE'Unds'Bar{}(), Lblbar2'LParRParUnds'K-RULE-FIND-SIMPLE'Unds'Bar{}())) [constructor{}()] // no confusion different constructors
-  axiom{R} \exists{R} (Val:SortBar{}, \equals{SortBar{}, R} (Val:SortBar{}, Lblbar2'LParRParUnds'K-RULE-FIND-SIMPLE'Unds'Bar{}())) [functional{}()] // functional
-  axiom{R} \exists{R} (Val:SortFoo{}, \equals{SortFoo{}, R} (Val:SortFoo{}, Lblfoo'LParUndsRParUnds'K-RULE-FIND-SIMPLE'Unds'Foo'Unds'Bar{}(K0:SortBar{}))) [functional{}()] // functional
-  axiom{}\implies{SortFoo{}} (\and{SortFoo{}} (Lblfoo'LParUndsRParUnds'K-RULE-FIND-SIMPLE'Unds'Foo'Unds'Bar{}(X0:SortBar{}), Lblfoo'LParUndsRParUnds'K-RULE-FIND-SIMPLE'Unds'Foo'Unds'Bar{}(Y0:SortBar{})), Lblfoo'LParUndsRParUnds'K-RULE-FIND-SIMPLE'Unds'Foo'Unds'Bar{}(\and{SortBar{}} (X0:SortBar{}, Y0:SortBar{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBar{}, \equals{SortBar{}, R} (Val:SortBar{}, Lblbar'LParRParUnds'K-RULE-FIND-TEST'Unds'Bar{}())) [functional{}()] // functional
+  axiom{}\not{SortBar{}} (\and{SortBar{}} (Lblbar'LParRParUnds'K-RULE-FIND-TEST'Unds'Bar{}(), Lblbar2'LParRParUnds'K-RULE-FIND-TEST'Unds'Bar{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortA{}, \equals{SortA{}, R} (Val:SortA{}, Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(K0:SortA{}, K1:SortA{}))) [functional{}()] // functional
+  axiom{}\implies{SortA{}} (\and{SortA{}} (Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(X0:SortA{}, X1:SortA{}), Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(Y0:SortA{}, Y1:SortA{})), Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(\and{SortA{}} (X0:SortA{}, Y0:SortA{}), \and{SortA{}} (X1:SortA{}, Y1:SortA{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortA{}} (\and{SortA{}} (Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(X0:SortA{}, X1:SortA{}), Lblbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(Y0:SortA{}, Y1:SortA{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortA{}} (\and{SortA{}} (Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(X0:SortA{}, X1:SortA{}), Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(Y0:SortA{}, Y1:SortA{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBar{}, \equals{SortBar{}, R} (Val:SortBar{}, Lblbar2'LParRParUnds'K-RULE-FIND-TEST'Unds'Bar{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortA{}, \equals{SortA{}, R} (Val:SortA{}, Lblbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(K0:SortA{}, K1:SortA{}))) [functional{}()] // functional
+  axiom{}\implies{SortA{}} (\and{SortA{}} (Lblbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(X0:SortA{}, X1:SortA{}), Lblbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(Y0:SortA{}, Y1:SortA{})), Lblbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(\and{SortA{}} (X0:SortA{}, Y0:SortA{}), \and{SortA{}} (X1:SortA{}, Y1:SortA{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortA{}} (\and{SortA{}} (Lblbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(X0:SortA{}, X1:SortA{}), Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(Y0:SortA{}, Y1:SortA{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortFoo{}, \equals{SortFoo{}, R} (Val:SortFoo{}, Lblfoo'LParUndsRParUnds'K-RULE-FIND-TEST'Unds'Foo'Unds'Bar{}(K0:SortBar{}))) [functional{}()] // functional
+  axiom{}\implies{SortFoo{}} (\and{SortFoo{}} (Lblfoo'LParUndsRParUnds'K-RULE-FIND-TEST'Unds'Foo'Unds'Bar{}(X0:SortBar{}), Lblfoo'LParUndsRParUnds'K-RULE-FIND-TEST'Unds'Foo'Unds'Bar{}(Y0:SortBar{})), Lblfoo'LParUndsRParUnds'K-RULE-FIND-TEST'Unds'Foo'Unds'Bar{}(\and{SortBar{}} (X0:SortBar{}, Y0:SortBar{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortA{}, \equals{SortA{}, R} (Val:SortA{}, Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(K0:SortA{}, K1:SortA{}))) [functional{}()] // functional
+  axiom{}\implies{SortA{}} (\and{SortA{}} (Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(X0:SortA{}, X1:SortA{}), Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(Y0:SortA{}, Y1:SortA{})), Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(\and{SortA{}} (X0:SortA{}, Y0:SortA{}), \and{SortA{}} (X1:SortA{}, Y1:SortA{}))) [constructor{}()] // no confusion same constructor
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
-  axiom{R} \equals{SortSet{}, R} (LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K1:SortSet{},K2:SortSet{}),LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K2:SortSet{},K1:SortSet{})) [comm{}()] // commutativity
   axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisA{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBar{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBool{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisFoo{}(K0:SortK{}))) [functional{}()] // functional
@@ -317,6 +365,7 @@ module K-RULE-FIND-SIMPLE
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCellOpt{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKConfigVar{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKResult{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisList{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMap{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisSet{}(K0:SortK{}))) [functional{}()] // functional
@@ -332,25 +381,23 @@ module K-RULE-FIND-SIMPLE
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(K0:SortSet{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'Unds'{}(K0:SortInt{}))) [functional{}()] // functional
-  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKConfigVar{}, inj{SortKConfigVar{}, SortKItem{}} (Val:SortKConfigVar{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (Val:SortGeneratedCounterCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (Val:SortGeneratedCounterCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortFoo{}, inj{SortFoo{}, SortKItem{}} (Val:SortFoo{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBar{}, inj{SortBar{}, SortKItem{}} (Val:SortBar{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \bottom{SortKItem{}}())))))))))))))) [constructor{}()] // no junk
-  axiom{} \bottom{SortList{}}() [constructor{}()] // no junk
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezerbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortA{}, inj{SortA{}, SortKItem{}} (Val:SortA{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKConfigVar{}, inj{SortKConfigVar{}, SortKItem{}} (Val:SortKConfigVar{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (Val:SortGeneratedCounterCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (Val:SortGeneratedCounterCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKResult{}, inj{SortKResult{}, SortKItem{}} (Val:SortKResult{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortFoo{}, inj{SortFoo{}, SortKItem{}} (Val:SortFoo{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBar{}, inj{SortBar{}, SortKItem{}} (Val:SortBar{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \bottom{SortKItem{}}()))))))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \or{SortA{}} (Lbla'Unds'K-RULE-FIND-TEST'Unds'A{}(), \or{SortA{}} (\exists{SortA{}} (X0:SortA{}, \exists{SortA{}} (X1:SortA{}, Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(X0:SortA{}, X1:SortA{}))), \or{SortA{}} (\exists{SortA{}} (X0:SortA{}, \exists{SortA{}} (X1:SortA{}, Lblbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(X0:SortA{}, X1:SortA{}))), \or{SortA{}} (\exists{SortA{}} (X0:SortA{}, \exists{SortA{}} (X1:SortA{}, Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(X0:SortA{}, X1:SortA{}))), \or{SortA{}} (\exists{SortA{}} (Val:SortInt{}, inj{SortInt{}, SortA{}} (Val:SortInt{})), \bottom{SortA{}}()))))) [constructor{}()] // no junk
   axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
   axiom{} \or{SortGeneratedCounterCellOpt{}} (LblnoGeneratedCounterCell{}(), \or{SortGeneratedCounterCellOpt{}} (\exists{SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{})), \bottom{SortGeneratedCounterCellOpt{}}())) [constructor{}()] // no junk
   axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
   axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
   axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
-  axiom{} \bottom{SortK{}}() [constructor{}()] // no junk
-  axiom{} \bottom{SortMap{}}() [constructor{}()] // no junk
+  axiom{} \or{SortKResult{}} (\exists{SortKResult{}} (Val:SortInt{}, inj{SortInt{}, SortKResult{}} (Val:SortInt{})), \bottom{SortKResult{}}()) [constructor{}()] // no junk
   axiom{} \or{SortKCellOpt{}} (LblnoKCell{}(), \or{SortKCellOpt{}} (\exists{SortKCellOpt{}} (Val:SortKCell{}, inj{SortKCell{}, SortKCellOpt{}} (Val:SortKCell{})), \bottom{SortKCellOpt{}}())) [constructor{}()] // no junk
   axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
   axiom{} \or{SortGeneratedTopCell{}} (\exists{SortGeneratedTopCell{}} (X0:SortKCell{}, \exists{SortGeneratedTopCell{}} (X1:SortGeneratedCounterCell{}, Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}))), \bottom{SortGeneratedTopCell{}}()) [constructor{}()] // no junk
-  axiom{} \or{SortFoo{}} (\exists{SortFoo{}} (X0:SortBar{}, Lblfoo'LParUndsRParUnds'K-RULE-FIND-SIMPLE'Unds'Foo'Unds'Bar{}(X0:SortBar{})), \bottom{SortFoo{}}()) [constructor{}()] // no junk
-  axiom{} \or{SortBar{}} (Lblbar'LParRParUnds'K-RULE-FIND-SIMPLE'Unds'Bar{}(), \or{SortBar{}} (Lblbar2'LParRParUnds'K-RULE-FIND-SIMPLE'Unds'Bar{}(), \bottom{SortBar{}}())) [constructor{}()] // no junk
-  axiom{} \bottom{SortSet{}}() [constructor{}()] // no junk
+  axiom{} \or{SortFoo{}} (\exists{SortFoo{}} (X0:SortBar{}, Lblfoo'LParUndsRParUnds'K-RULE-FIND-TEST'Unds'Foo'Unds'Bar{}(X0:SortBar{})), \bottom{SortFoo{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortBar{}} (Lblbar'LParRParUnds'K-RULE-FIND-TEST'Unds'Bar{}(), \or{SortBar{}} (Lblbar2'LParRParUnds'K-RULE-FIND-TEST'Unds'Bar{}(), \bottom{SortBar{}}())) [constructor{}()] // no junk
   axiom{} \or{SortGeneratedTopCellFragment{}} (\exists{SortGeneratedTopCellFragment{}} (X0:SortKCellOpt{}, \exists{SortGeneratedTopCellFragment{}} (X1:SortGeneratedCounterCellOpt{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}))), \bottom{SortGeneratedTopCellFragment{}}()) [constructor{}()] // no junk
 
 // rules
-// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,B1,_Gen0)=>B1 requires C ensures #token("true","Bool") [UNIQUE_ID(2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2), org.kframework.attributes.Location(Location(2222,8,2222,59)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,B1,_Gen0)=>B1 requires C ensures #token("true","Bool") [UNIQUE_ID(2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2), org.kframework.attributes.Location(Location(2289,8,2289,59)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -376,9 +423,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortK{}} (
        VarB1:SortK{},
         \top{SortK{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2222,8,2222,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2")]
+  [UNIQUE'Unds'ID{}("2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2289,8,2289,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
 
-// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,_Gen0,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [UNIQUE_ID(651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa), org.kframework.attributes.Location(Location(2223,8,2223,67)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,_Gen0,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [UNIQUE_ID(651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa), org.kframework.attributes.Location(Location(2290,8,2290,67)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -404,21 +451,137 @@ module K-RULE-FIND-SIMPLE
      \and{SortK{}} (
        VarB2:SortK{},
         \top{SortK{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2223,8,2223,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa")]
+  [UNIQUE'Unds'ID{}("651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2290,8,2290,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
 
-// rule `<generatedTop>`(`<k>`(inj{Foo,KItem}(`foo(_)_K-RULE-FIND-SIMPLE_Foo_Bar`(`bar()_K-RULE-FIND-SIMPLE_Bar`(.KList) #as _Gen4))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Bar,KItem}(_Gen4)~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f3566e32d76ecf90c9086b5aabea106f2e223c3faf054a48509b93c489929e70), label(K-RULE-FIND-SIMPLE.fooRule), org.kframework.attributes.Location(Location(6,21,6,40)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/tests/k-rule-find-examples/one-line-rule/k-rule-find-simple.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  alias rule2LHS{}(SortGeneratedCounterCell{},SortK{},SortBar{}) : SortGeneratedTopCell{}
-  where rule2LHS{}(Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortK{},Var'Unds'Gen4:SortBar{}) :=
-    \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblfoo'LParUndsRParUnds'K-RULE-FIND-SIMPLE'Unds'Foo'Unds'Bar{}(\and{SortBar{}}(Lblbar'LParRParUnds'K-RULE-FIND-SIMPLE'Unds'Bar{}(),Var'Unds'Gen4:SortBar{}))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
-
+// rule `<generatedTop>`(`<k>`(``inj{A,KItem}(HOLE) #as _Gen2``~>`#freezerbaz(_,_)_K-RULE-FIND-TEST_A_A_A1_`(inj{A,KItem}(K0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{A,KItem}(`baz(_,_)_K-RULE-FIND-TEST_A_A_A`(K0,HOLE))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_Gen2)) ensures #token("true","Bool") [UNIQUE_ID(425ec6284ebb74b931418d43521a6c8d736c95530a0f0ad277171fef56b96bb1), cool, cool-like, klabel(baz), label(K-RULE-FIND-TEST.baz2-cool), org.kframework.attributes.Location(Location(13,19,13,55)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)), strict(2)]
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule2LHS{}(Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortK{},Var'Unds'Gen4:SortBar{}),
-    \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBar{}, SortKItem{}}(Var'Unds'Gen4:SortBar{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
-  [label{}("K-RULE-FIND-SIMPLE.fooRule"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/tests/k-rule-find-examples/one-line-rule/k-rule-find-simple.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,21,6,40)"), UNIQUE'Unds'ID{}("f3566e32d76ecf90c9086b5aabea106f2e223c3faf054a48509b93c489929e70")]
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),Var'Unds'Gen2:SortKItem{}),kseq{}(Lbl'Hash'freezerbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(kseq{}(inj{SortA{}, SortKItem{}}(VarK0:SortA{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'Gen2:SortKItem{},dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(Lblbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(VarK0:SortA{},VarHOLE:SortA{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("425ec6284ebb74b931418d43521a6c8d736c95530a0f0ad277171fef56b96bb1"), cool{}(), cool-like{}(), klabel{}("baz"), label{}("K-RULE-FIND-TEST.baz2-cool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(13,19,13,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), strict{}("2")]
 
-// rule `_=/=Bool_`(B1,B2)=>`notBool_`(`_==Bool_`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f), org.kframework.attributes.Location(Location(960,8,960,57)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `<generatedTop>`(`<k>`(``inj{A,KItem}(HOLE) #as _Gen2``~>`#freezerfoo(_,_)_K-RULE-FIND-TEST_A_A_A0_`(inj{A,KItem}(K1))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{A,KItem}(`foo(_,_)_K-RULE-FIND-TEST_A_A_A`(HOLE,K1))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_Gen2)) ensures #token("true","Bool") [UNIQUE_ID(7a46ade81b139c647f55128dc645fcd6ffb8e6dcf456317493057dc2331274e1), cool, cool-like, klabel(foo), label(K-RULE-FIND-TEST.foo1-cool), org.kframework.attributes.Location(Location(11,19,11,55)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)), seqstrict]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),Var'Unds'Gen2:SortKItem{}),kseq{}(Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(kseq{}(inj{SortA{}, SortKItem{}}(VarK1:SortA{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'Gen2:SortKItem{},dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(VarHOLE:SortA{},VarK1:SortA{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("7a46ade81b139c647f55128dc645fcd6ffb8e6dcf456317493057dc2331274e1"), cool{}(), cool-like{}(), klabel{}("foo"), label{}("K-RULE-FIND-TEST.foo1-cool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(11,19,11,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), seqstrict{}()]
+
+// rule `<generatedTop>`(`<k>`(``inj{A,KItem}(HOLE) #as _Gen2``~>`#freezerfoo(_,_)_K-RULE-FIND-TEST_A_A_A1_`(inj{A,KItem}(K0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{A,KItem}(`foo(_,_)_K-RULE-FIND-TEST_A_A_A`(K0,HOLE))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_Gen2)) ensures #token("true","Bool") [UNIQUE_ID(4d4d56069d22fdf691bc0dce46497d0bd3df1743f5e61c0cbd77db42f07bd0c0), cool, cool-like, klabel(foo), label(K-RULE-FIND-TEST.foo2-cool), org.kframework.attributes.Location(Location(11,19,11,55)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)), seqstrict]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),Var'Unds'Gen2:SortKItem{}),kseq{}(Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(kseq{}(inj{SortA{}, SortKItem{}}(VarK0:SortA{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'Gen2:SortKItem{},dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(VarK0:SortA{},VarHOLE:SortA{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("4d4d56069d22fdf691bc0dce46497d0bd3df1743f5e61c0cbd77db42f07bd0c0"), cool{}(), cool-like{}(), klabel{}("foo"), label{}("K-RULE-FIND-TEST.foo2-cool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(11,19,11,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), seqstrict{}()]
+
+// rule `<generatedTop>`(`<k>`(``inj{A,KItem}(HOLE) #as _Gen3``~>`#freezerbar(_,_)_K-RULE-FIND-TEST_A_A_A0_`(inj{A,KItem}(_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{A,KItem}(`bar(_,_)_K-RULE-FIND-TEST_A_A_A`(HOLE,_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_Gen3)) ensures #token("true","Bool") [UNIQUE_ID(0d3f19917785378b1ea46f5827dbe0761677a2673cefe143587955dc40b5b5e7), cool, cool-like, label(K-RULE-FIND-TEST.bar1-cool), org.kframework.attributes.Location(Location(15,21,15,38)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),Var'Unds'Gen3:SortKItem{}),kseq{}(Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(kseq{}(inj{SortA{}, SortKItem{}}(Var'Unds'Gen0:SortA{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'Gen3:SortKItem{},dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(VarHOLE:SortA{},Var'Unds'Gen0:SortA{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("0d3f19917785378b1ea46f5827dbe0761677a2673cefe143587955dc40b5b5e7"), cool{}(), cool-like{}(), label{}("K-RULE-FIND-TEST.bar1-cool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(15,21,15,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `<generatedTop>`(`<k>`(``inj{A,KItem}(HOLE) #as _Gen3``~>`#freezerbar(_,_)_K-RULE-FIND-TEST_A_A_A1_`(inj{A,KItem}(_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{A,KItem}(`bar(_,_)_K-RULE-FIND-TEST_A_A_A`(_Gen0,HOLE))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_Gen3)) ensures #token("true","Bool") [UNIQUE_ID(124d585df71e063125ebf1bcee7b8526f2e7712273bde223594b698d77689ad7), cool, cool-like, label(K-RULE-FIND-TEST.bar2-cool), org.kframework.attributes.Location(Location(16,21,16,38)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),Var'Unds'Gen3:SortKItem{}),kseq{}(Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(kseq{}(inj{SortA{}, SortKItem{}}(Var'Unds'Gen0:SortA{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'Gen3:SortKItem{},dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(Var'Unds'Gen0:SortA{},VarHOLE:SortA{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("124d585df71e063125ebf1bcee7b8526f2e7712273bde223594b698d77689ad7"), cool{}(), cool-like{}(), label{}("K-RULE-FIND-TEST.bar2-cool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(16,21,16,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `<generatedTop>`(`<k>`(inj{A,KItem}(`a_K-RULE-FIND-TEST_A`(.KList))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Int,KItem}(#token("0","Int"))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b36877f6a57fb734904f3174b2f63ea127dda963d8663908957d6e98d85d7a2), org.kframework.attributes.Location(Location(18,10,18,16)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(Lbla'Unds'K-RULE-FIND-TEST'Unds'A{}()),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("3b36877f6a57fb734904f3174b2f63ea127dda963d8663908957d6e98d85d7a2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(18,10,18,16)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `<generatedTop>`(`<k>`(inj{A,KItem}(`bar(_,_)_K-RULE-FIND-TEST_A_A_A`(HOLE,_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{A,KItem}(HOLE)~>`#freezerbar(_,_)_K-RULE-FIND-TEST_A_A_A0_`(inj{A,KItem}(_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{A,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(def7fdef9eebbe97ad53a8e200143a5e52e1d3d3bb69ed63e833059375e94852), heat, label(K-RULE-FIND-TEST.bar1-heat), org.kframework.attributes.Location(Location(15,21,15,38)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(VarHOLE:SortA{},Var'Unds'Gen0:SortA{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),kseq{}(Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(kseq{}(inj{SortA{}, SortKItem{}}(Var'Unds'Gen0:SortA{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("def7fdef9eebbe97ad53a8e200143a5e52e1d3d3bb69ed63e833059375e94852"), heat{}(), label{}("K-RULE-FIND-TEST.bar1-heat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(15,21,15,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `<generatedTop>`(`<k>`(inj{A,KItem}(`bar(_,_)_K-RULE-FIND-TEST_A_A_A`(_Gen0,HOLE))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{A,KItem}(HOLE)~>`#freezerbar(_,_)_K-RULE-FIND-TEST_A_A_A1_`(inj{A,KItem}(_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{A,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(a57f6be10aa02517c6524987026d6340949a0f43e1c2148d861baad958497f6a), heat, label(K-RULE-FIND-TEST.bar2-heat), org.kframework.attributes.Location(Location(16,21,16,38)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(Lblbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(Var'Unds'Gen0:SortA{},VarHOLE:SortA{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),kseq{}(Lbl'Hash'freezerbar'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(kseq{}(inj{SortA{}, SortKItem{}}(Var'Unds'Gen0:SortA{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("a57f6be10aa02517c6524987026d6340949a0f43e1c2148d861baad958497f6a"), heat{}(), label{}("K-RULE-FIND-TEST.bar2-heat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(16,21,16,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `<generatedTop>`(`<k>`(inj{A,KItem}(`baz(_,_)_K-RULE-FIND-TEST_A_A_A`(K0,HOLE))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{A,KItem}(HOLE)~>`#freezerbaz(_,_)_K-RULE-FIND-TEST_A_A_A1_`(inj{A,KItem}(K0))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{A,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(70b292260caeb7303b194c772eed353a213b45d8c451341d7f8d8499d12da1be), heat, klabel(baz), label(K-RULE-FIND-TEST.baz2-heat), org.kframework.attributes.Location(Location(13,19,13,55)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)), strict(2)]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(Lblbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(VarK0:SortA{},VarHOLE:SortA{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),kseq{}(Lbl'Hash'freezerbaz'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(kseq{}(inj{SortA{}, SortKItem{}}(VarK0:SortA{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("70b292260caeb7303b194c772eed353a213b45d8c451341d7f8d8499d12da1be"), heat{}(), klabel{}("baz"), label{}("K-RULE-FIND-TEST.baz2-heat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(13,19,13,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), strict{}("2")]
+
+// rule `<generatedTop>`(`<k>`(inj{Foo,KItem}(`foo(_)_K-RULE-FIND-TEST_Foo_Bar`(`bar()_K-RULE-FIND-TEST_Bar`(.KList) #as _Gen4))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Bar,KItem}(_Gen4)~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2a201e8476fab2b94d766a4f15a1448ddb74cacb6ed53f17b316cda120b7eb01), label(K-RULE-FIND-TEST.fooRule), org.kframework.attributes.Location(Location(7,21,7,40)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblfoo'LParUndsRParUnds'K-RULE-FIND-TEST'Unds'Foo'Unds'Bar{}(\and{SortBar{}}(Lblbar'LParRParUnds'K-RULE-FIND-TEST'Unds'Bar{}(),Var'Unds'Gen4:SortBar{}))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBar{}, SortKItem{}}(Var'Unds'Gen4:SortBar{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("2a201e8476fab2b94d766a4f15a1448ddb74cacb6ed53f17b316cda120b7eb01"), label{}("K-RULE-FIND-TEST.fooRule"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(7,21,7,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `<generatedTop>`(`<k>`(inj{A,KItem}(`foo(_,_)_K-RULE-FIND-TEST_A_A_A`(HOLE,K1))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{A,KItem}(HOLE)~>`#freezerfoo(_,_)_K-RULE-FIND-TEST_A_A_A0_`(inj{A,KItem}(K1))~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{A,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(ecb7c1b01baf8e1c9b982b94803bef898e9cf6ebcad873f8883711086fa2ae97), heat, klabel(foo), label(K-RULE-FIND-TEST.foo1-heat), org.kframework.attributes.Location(Location(11,19,11,55)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)), seqstrict]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(VarHOLE:SortA{},VarK1:SortA{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),kseq{}(Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A0'Unds'{}(kseq{}(inj{SortA{}, SortKItem{}}(VarK1:SortA{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("ecb7c1b01baf8e1c9b982b94803bef898e9cf6ebcad873f8883711086fa2ae97"), heat{}(), klabel{}("foo"), label{}("K-RULE-FIND-TEST.foo1-heat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(11,19,11,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), seqstrict{}()]
+
+// rule `<generatedTop>`(`<k>`(inj{A,KItem}(`foo(_,_)_K-RULE-FIND-TEST_A_A_A`(K0,HOLE))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{A,KItem}(HOLE)~>`#freezerfoo(_,_)_K-RULE-FIND-TEST_A_A_A1_`(inj{A,KItem}(K0))~>_DotVar1),_DotVar0) requires `_andBool_`(`_andBool_`(isKResult(inj{A,KItem}(K0)),#token("true","Bool")),`notBool_`(isKResult(inj{A,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(8e7fdce188f27d7b23e898538be5d9a4ebb5f3770c556c0e5f1fac0f5f4dbd17), heat, klabel(foo), label(K-RULE-FIND-TEST.foo2-heat), org.kframework.attributes.Location(Location(11,19,11,55)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)), seqstrict]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(Lblfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A{}(VarK0:SortA{},VarHOLE:SortA{})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'Unds'andBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortA{}, SortKItem{}}(VarK0:SortA{}),dotk{}())),\dv{SortBool{}}("true")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortA{}, SortKItem{}}(VarHOLE:SortA{}),kseq{}(Lbl'Hash'freezerfoo'LParUndsCommUndsRParUnds'K-RULE-FIND-TEST'Unds'A'Unds'A'Unds'A1'Unds'{}(kseq{}(inj{SortA{}, SortKItem{}}(VarK0:SortA{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("8e7fdce188f27d7b23e898538be5d9a4ebb5f3770c556c0e5f1fac0f5f4dbd17"), heat{}(), klabel{}("foo"), label{}("K-RULE-FIND-TEST.foo2-heat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(11,19,11,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)"), seqstrict{}()]
+
+// rule `_=/=Bool_`(B1,B2)=>`notBool_`(`_==Bool_`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f), org.kframework.attributes.Location(Location(1150,8,1150,57)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -438,9 +601,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(VarB1:SortBool{},VarB2:SortBool{})),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(960,8,960,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f")]
+  [UNIQUE'Unds'ID{}("31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1150,8,1150,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_=/=Int_`(I1,I2)=>`notBool_`(`_==Int_`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3), org.kframework.attributes.Location(Location(1250,8,1250,53)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_=/=Int_`(I1,I2)=>`notBool_`(`_==Int_`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3), org.kframework.attributes.Location(Location(1429,8,1429,53)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -460,9 +623,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1250,8,1250,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3")]
+  [UNIQUE'Unds'ID{}("4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1429,8,1429,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c), org.kframework.attributes.Location(Location(2220,8,2220,45)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c), org.kframework.attributes.Location(Location(2287,8,2287,45)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -482,9 +645,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2220,8,2220,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c")]
+  [UNIQUE'Unds'ID{}("bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2287,8,2287,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_andBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497), org.kframework.attributes.Location(Location(933,8,933,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497), org.kframework.attributes.Location(Location(1123,8,1123,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -504,9 +667,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        Var'Unds'Gen1:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(933,8,933,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497")]
+  [UNIQUE'Unds'ID{}("61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1123,8,1123,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98), org.kframework.attributes.Location(Location(932,8,932,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98), org.kframework.attributes.Location(Location(1122,8,1122,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -526,9 +689,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        VarB:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(932,8,932,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98")]
+  [UNIQUE'Unds'ID{}("e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1122,8,1122,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_andBool_`(_Gen0,#token("false","Bool") #as _Gen1)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca), org.kframework.attributes.Location(Location(934,8,934,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andBool_`(_Gen0,#token("false","Bool") #as _Gen1)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca), org.kframework.attributes.Location(Location(1124,8,1124,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -548,9 +711,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        Var'Unds'Gen1:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(934,8,934,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca")]
+  [UNIQUE'Unds'ID{}("9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1124,8,1124,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f), org.kframework.attributes.Location(Location(931,8,931,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f), org.kframework.attributes.Location(Location(1121,8,1121,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -570,9 +733,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        VarB:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(931,8,931,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f")]
+  [UNIQUE'Unds'ID{}("5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1121,8,1121,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_andThenBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d), org.kframework.attributes.Location(Location(938,8,938,36)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andThenBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d), org.kframework.attributes.Location(Location(1128,8,1128,36)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -592,9 +755,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        Var'Unds'Gen1:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(938,8,938,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d")]
+  [UNIQUE'Unds'ID{}("5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1128,8,1128,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_andThenBool_`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c), org.kframework.attributes.Location(Location(937,8,937,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andThenBool_`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c), org.kframework.attributes.Location(Location(1127,8,1127,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -614,9 +777,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        VarK:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(937,8,937,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c")]
+  [UNIQUE'Unds'ID{}("82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1127,8,1127,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_andThenBool_`(_Gen0,#token("false","Bool") #as _Gen1)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2), org.kframework.attributes.Location(Location(939,8,939,36)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andThenBool_`(_Gen0,#token("false","Bool") #as _Gen1)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2), org.kframework.attributes.Location(Location(1129,8,1129,36)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -636,9 +799,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        Var'Unds'Gen1:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(939,8,939,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2")]
+  [UNIQUE'Unds'ID{}("0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1129,8,1129,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_andThenBool_`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689), org.kframework.attributes.Location(Location(936,8,936,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andThenBool_`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689), org.kframework.attributes.Location(Location(1126,8,1126,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -658,9 +821,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        VarK:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(936,8,936,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689")]
+  [UNIQUE'Unds'ID{}("78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1126,8,1126,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_divInt_`(I1,I2)=>`_/Int_`(`_-Int_`(I1,`_modInt_`(I1,I2)),I2) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4), org.kframework.attributes.Location(Location(1239,8,1240,23)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+// rule `_divInt_`(I1,I2)=>`_/Int_`(`_-Int_`(I1,`_modInt_`(I1,I2)),I2) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4), org.kframework.attributes.Location(Location(1418,8,1419,23)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -682,9 +845,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortInt{}} (
        Lbl'UndsSlsh'Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{}),
         \top{SortInt{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1239,8,1240,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4")]
+  [UNIQUE'Unds'ID{}("83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1418,8,1419,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
 
-// rule `_dividesInt__INT-COMMON_Bool_Int_Int`(I1,I2)=>`_==Int_`(`_%Int_`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5), org.kframework.attributes.Location(Location(1251,8,1251,58)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_dividesInt__INT-COMMON_Bool_Int_Int`(I1,I2)=>`_==Int_`(`_%Int_`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5), org.kframework.attributes.Location(Location(1430,8,1430,58)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -704,9 +867,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        Lbl'UndsEqlsEqls'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0")),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1251,8,1251,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5")]
+  [UNIQUE'Unds'ID{}("fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1430,8,1430,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_impliesBool_`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96), org.kframework.attributes.Location(Location(958,8,958,45)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_impliesBool_`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96), org.kframework.attributes.Location(Location(1148,8,1148,45)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -726,9 +889,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        LblnotBool'Unds'{}(VarB:SortBool{}),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(958,8,958,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96")]
+  [UNIQUE'Unds'ID{}("022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1148,8,1148,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_impliesBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712), org.kframework.attributes.Location(Location(957,8,957,39)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_impliesBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712), org.kframework.attributes.Location(Location(1147,8,1147,39)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -748,9 +911,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(957,8,957,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712")]
+  [UNIQUE'Unds'ID{}("99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1147,8,1147,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_impliesBool_`(#token("false","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e), org.kframework.attributes.Location(Location(956,8,956,40)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_impliesBool_`(#token("false","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e), org.kframework.attributes.Location(Location(1146,8,1146,40)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -770,9 +933,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(956,8,956,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e")]
+  [UNIQUE'Unds'ID{}("55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1146,8,1146,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_impliesBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d), org.kframework.attributes.Location(Location(955,8,955,36)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_impliesBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d), org.kframework.attributes.Location(Location(1145,8,1145,36)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -792,9 +955,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        VarB:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(955,8,955,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d")]
+  [UNIQUE'Unds'ID{}("da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1145,8,1145,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_modInt_`(I1,I2)=>`_%Int_`(`_+Int_`(`_%Int_`(I1,`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6), concrete, org.kframework.attributes.Location(Location(1242,5,1245,23)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol]), simplification]
+// rule `_modInt_`(I1,I2)=>`_%Int_`(`_+Int_`(`_%Int_`(I1,`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6), concrete, org.kframework.attributes.Location(Location(1421,5,1424,23)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol]), simplification]
   axiom{R} \implies{R} (
     \equals{SortBool{},R}(
         Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
@@ -804,9 +967,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortInt{}} (
        Lbl'UndsPerc'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),
         \top{SortInt{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1242,5,1245,23)"), simplification{}(), UNIQUE'Unds'ID{}("adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6")]
+  [UNIQUE'Unds'ID{}("adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1421,5,1424,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), simplification{}()]
 
-// rule `_orBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26), org.kframework.attributes.Location(Location(948,8,948,32)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26), org.kframework.attributes.Location(Location(1138,8,1138,32)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -826,9 +989,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        VarB:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(948,8,948,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26")]
+  [UNIQUE'Unds'ID{}("d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1138,8,1138,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_orBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3), org.kframework.attributes.Location(Location(946,8,946,34)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3), org.kframework.attributes.Location(Location(1136,8,1136,34)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -848,9 +1011,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(946,8,946,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3")]
+  [UNIQUE'Unds'ID{}("47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1136,8,1136,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_orBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b), org.kframework.attributes.Location(Location(947,8,947,32)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b), org.kframework.attributes.Location(Location(1137,8,1137,32)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -870,9 +1033,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        VarB:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(947,8,947,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b")]
+  [UNIQUE'Unds'ID{}("991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1137,8,1137,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_orBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2), org.kframework.attributes.Location(Location(945,8,945,34)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2), org.kframework.attributes.Location(Location(1135,8,1135,34)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -892,9 +1055,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(945,8,945,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2")]
+  [UNIQUE'Unds'ID{}("71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1135,8,1135,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_orElseBool_`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480), org.kframework.attributes.Location(Location(953,8,953,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orElseBool_`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480), org.kframework.attributes.Location(Location(1143,8,1143,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -914,9 +1077,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        VarK:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(953,8,953,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480")]
+  [UNIQUE'Unds'ID{}("684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1143,8,1143,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_orElseBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14), org.kframework.attributes.Location(Location(951,8,951,33)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orElseBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14), org.kframework.attributes.Location(Location(1141,8,1141,33)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -936,9 +1099,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(951,8,951,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14")]
+  [UNIQUE'Unds'ID{}("c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1141,8,1141,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_orElseBool_`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf), org.kframework.attributes.Location(Location(952,8,952,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orElseBool_`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf), org.kframework.attributes.Location(Location(1142,8,1142,37)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -958,9 +1121,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        VarK:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(952,8,952,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf")]
+  [UNIQUE'Unds'ID{}("eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1142,8,1142,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_orElseBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6), org.kframework.attributes.Location(Location(950,8,950,33)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orElseBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6), org.kframework.attributes.Location(Location(1140,8,1140,33)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -980,9 +1143,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(950,8,950,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6")]
+  [UNIQUE'Unds'ID{}("354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1140,8,1140,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_xorBool_`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f), org.kframework.attributes.Location(Location(943,8,943,38)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_xorBool_`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f), org.kframework.attributes.Location(Location(1133,8,1133,38)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1002,9 +1165,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(943,8,943,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f")]
+  [UNIQUE'Unds'ID{}("9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1133,8,1133,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_xorBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75), org.kframework.attributes.Location(Location(942,8,942,38)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_xorBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75), org.kframework.attributes.Location(Location(1132,8,1132,38)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1024,9 +1187,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        VarB:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(942,8,942,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75")]
+  [UNIQUE'Unds'ID{}("7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1132,8,1132,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_xorBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf), org.kframework.attributes.Location(Location(941,8,941,38)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_xorBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf), org.kframework.attributes.Location(Location(1131,8,1131,38)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1046,9 +1209,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        VarB:SortBool{},
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(941,8,941,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf")]
+  [UNIQUE'Unds'ID{}("73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1131,8,1131,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `_|Set__SET_Set_Set_Set`(S1,S2)=>`_Set_`(S1,`Set:difference`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62), concrete, org.kframework.attributes.Location(Location(559,8,559,45)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_|Set__SET_Set_Set_Set`(S1,S2)=>`_Set_`(S1,`Set:difference`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62), concrete, org.kframework.attributes.Location(Location(749,8,749,45)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1068,9 +1231,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortSet{}} (
        Lbl'Unds'Set'Unds'{}(VarS1:SortSet{},LblSet'Coln'difference{}(VarS2:SortSet{},VarS1:SortSet{})),
         \top{SortSet{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(559,8,559,45)"), UNIQUE'Unds'ID{}("e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62")]
+  [UNIQUE'Unds'ID{}("e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(749,8,749,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_modInt_`(`_>>Int_`(I,IDX),`_<<Int_`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119), org.kframework.attributes.Location(Location(1235,8,1235,85)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_modInt_`(`_>>Int_`(I,IDX),`_<<Int_`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119), org.kframework.attributes.Location(Location(1414,8,1414,85)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1094,9 +1257,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortInt{}} (
        Lbl'Unds'modInt'Unds'{}(Lbl'Unds-GT--GT-'Int'Unds'{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),
         \top{SortInt{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1235,8,1235,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119")]
+  [UNIQUE'Unds'ID{}("147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1414,8,1414,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `freshInt(_)_INT_Int_Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b), org.kframework.attributes.Location(Location(1254,8,1254,28)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `freshInt(_)_INT_Int_Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b), org.kframework.attributes.Location(Location(1433,8,1433,28)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1112,9 +1275,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortInt{}} (
        VarI:SortInt{},
         \top{SortInt{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1254,8,1254,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b")]
+  [UNIQUE'Unds'ID{}("cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1433,8,1433,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule getGeneratedCounterCell(`<generatedTop>`(_DotVar0,Cell))=>Cell requires #token("true","Bool") ensures #token("true","Bool") 
+// rule getGeneratedCounterCell(`<generatedTop>`(_DotVar0,Cell))=>Cell requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1130,9 +1293,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortGeneratedCounterCell{}} (
        VarCell:SortGeneratedCounterCell{},
         \top{SortGeneratedCounterCell{}}())))
-  []
+  [UNIQUE'Unds'ID{}("9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3")]
 
-// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [initializer]
+// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553), initializer]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1144,9 +1307,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortGeneratedCounterCell{}} (
        Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")),
         \top{SortGeneratedCounterCell{}}())))
-  [initializer{}()]
+  [UNIQUE'Unds'ID{}("5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553"), initializer{}()]
 
-// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initKCell(Init),initGeneratedCounterCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer]
+// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initKCell(Init),initGeneratedCounterCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4cbc9d1da6e6bfe3605113d64379a38394b46b474e41d7bf884f8912546543b1), initializer]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1162,7 +1325,7 @@ module K-RULE-FIND-SIMPLE
      \and{SortGeneratedTopCell{}} (
        Lbl'-LT-'generatedTop'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}()),
         \top{SortGeneratedTopCell{}}())))
-  [initializer{}()]
+  [UNIQUE'Unds'ID{}("4cbc9d1da6e6bfe3605113d64379a38394b46b474e41d7bf884f8912546543b1"), initializer{}()]
 
 // rule initKCell(Init)=>`<k>`(`project:KItem`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar"))))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(888ac40929773fd17d5b9fd1e9d0be94791665a663f07907d894c31dccc871a5), initializer]
   axiom{R} \implies{R} (
@@ -1180,20 +1343,74 @@ module K-RULE-FIND-SIMPLE
      \and{SortKCell{}} (
        Lbl'-LT-'k'-GT-'{}(kseq{}(Lblproject'Coln'KItem{}(kseq{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))),dotk{}())),dotk{}())),
         \top{SortKCell{}}())))
-  [initializer{}(), UNIQUE'Unds'ID{}("888ac40929773fd17d5b9fd1e9d0be94791665a663f07907d894c31dccc871a5")]
+  [UNIQUE'Unds'ID{}("888ac40929773fd17d5b9fd1e9d0be94791665a663f07907d894c31dccc871a5"), initializer{}()]
 
-// rule isBar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isA(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(23db30e6da755bca69d91c5172a79d7e90c32c50aa548dba08b6d0a183ac8f66), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'Gen1:SortBar{},
+          \exists{R} (Var'Unds'Gen1:SortA{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortBar{}, SortKItem{}}(Var'Unds'Gen1:SortBar{}),dotk{}())
+                  kseq{}(inj{SortA{}, SortKItem{}}(Var'Unds'Gen1:SortA{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisA{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("23db30e6da755bca69d91c5172a79d7e90c32c50aa548dba08b6d0a183ac8f66"), owise{}()]
+
+// rule isA(inj{A,KItem}(A))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e397d6c6851c28eb2bb4fe160401eda3f7d9496cc0fc9354b4640b223e5270ea)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortA{}, SortKItem{}}(VarA:SortA{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisA{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e397d6c6851c28eb2bb4fe160401eda3f7d9496cc0fc9354b4640b223e5270ea")]
+
+// rule isBar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a6a9f4d161e29129ef4f42faea50812465c8a20c3aabc1b39b7075445ecfece), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortBar{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortBar{}, SortKItem{}}(Var'Unds'Gen0:SortBar{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -1216,9 +1433,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("9a6a9f4d161e29129ef4f42faea50812465c8a20c3aabc1b39b7075445ecfece"), owise{}()]
 
-// rule isBar(inj{Bar,KItem}(Bar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isBar(inj{Bar,KItem}(Bar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cc276c543fadaa80fb96bdc62ad61169108839e9da5ba20953c2eb76a29e676f)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1234,20 +1451,20 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("cc276c543fadaa80fb96bdc62ad61169108839e9da5ba20953c2eb76a29e676f")]
 
-// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7f8273ebd616814dbf1acdd96b9534fbaa5b0491bfd05a61916e5015ad4a37ab), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'Gen0:SortBool{},
+          \exists{R} (Var'Unds'Gen1:SortBool{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'Gen0:SortBool{}),dotk{}())
+                  kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'Gen1:SortBool{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -1270,9 +1487,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("7f8273ebd616814dbf1acdd96b9534fbaa5b0491bfd05a61916e5015ad4a37ab"), owise{}()]
 
-// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1288,9 +1505,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77")]
 
-// rule isFoo(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isFoo(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(eb606675580211d82fd88f0cbd88315a0ebfe4e84946c7cd01d4bde4d55800a4), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
@@ -1324,9 +1541,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("eb606675580211d82fd88f0cbd88315a0ebfe4e84946c7cd01d4bde4d55800a4"), owise{}()]
 
-// rule isFoo(inj{Foo,KItem}(Foo))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isFoo(inj{Foo,KItem}(Foo))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1730b15b3df8c1ba505d757a95d3378b37691d6307ab5e39247f96643b5e212c)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1342,9 +1559,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("1730b15b3df8c1ba505d757a95d3378b37691d6307ab5e39247f96643b5e212c")]
 
-// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7d501e1637f26769ad3b9439efef0285daa79523b0d071b3a792972ce92e4fe2), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
@@ -1378,9 +1595,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("7d501e1637f26769ad3b9439efef0285daa79523b0d071b3a792972ce92e4fe2"), owise{}()]
 
-// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1396,20 +1613,20 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c")]
 
-// rule isGeneratedCounterCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isGeneratedCounterCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55e7759c7640aa41fef8271d53c6dd8668aa497704539a65577604ada709c5df), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'Gen1:SortGeneratedCounterCellOpt{},
+          \exists{R} (Var'Unds'Gen0:SortGeneratedCounterCellOpt{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedCounterCellOpt{}),dotk{}())
+                  kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'Gen0:SortGeneratedCounterCellOpt{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -1432,9 +1649,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("55e7759c7640aa41fef8271d53c6dd8668aa497704539a65577604ada709c5df"), owise{}()]
 
-// rule isGeneratedCounterCellOpt(inj{GeneratedCounterCellOpt,KItem}(GeneratedCounterCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isGeneratedCounterCellOpt(inj{GeneratedCounterCellOpt,KItem}(GeneratedCounterCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1450,9 +1667,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12")]
 
-// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ec16314688c4b2d204af490e243a3e83a2e82fbc74988c3574b997cc9ca56816), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
@@ -1486,9 +1703,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("ec16314688c4b2d204af490e243a3e83a2e82fbc74988c3574b997cc9ca56816"), owise{}()]
 
-// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1504,9 +1721,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2")]
 
-// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1f022b25cc5a2adbe99fbae6b50007c803258a5749eb01e05c86096f7b35c0df), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
@@ -1540,9 +1757,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("1f022b25cc5a2adbe99fbae6b50007c803258a5749eb01e05c86096f7b35c0df"), owise{}()]
 
-// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1558,9 +1775,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271")]
 
-// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5c9850befff40cc79151dbc5a8999b5ffaad767f244ed97f9f29b56b7170bf24), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
@@ -1594,9 +1811,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("5c9850befff40cc79151dbc5a8999b5ffaad767f244ed97f9f29b56b7170bf24"), owise{}()]
 
-// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1612,9 +1829,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5")]
 
-// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1630,20 +1847,20 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847")]
 
-// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1668e9146ab7dd7867682198dd9dddc0c7c88d8f9fad9ed2366229fc4db18733), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'Gen1:SortKCell{},
+          \exists{R} (Var'Unds'Gen0:SortKCell{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortKCell{}, SortKItem{}}(Var'Unds'Gen1:SortKCell{}),dotk{}())
+                  kseq{}(inj{SortKCell{}, SortKItem{}}(Var'Unds'Gen0:SortKCell{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -1666,9 +1883,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("1668e9146ab7dd7867682198dd9dddc0c7c88d8f9fad9ed2366229fc4db18733"), owise{}()]
 
-// rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2695222b1238f711f8a356c0a1bc0ac418d7bd78fd3282e7c60882e2631a46df)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1684,20 +1901,20 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("2695222b1238f711f8a356c0a1bc0ac418d7bd78fd3282e7c60882e2631a46df")]
 
-// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fa44a9c94132ade195fc2cb566fa82471e4592c977a49183ac2142c5062701ca), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'Gen0:SortKCellOpt{},
+          \exists{R} (Var'Unds'Gen1:SortKCellOpt{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'Gen0:SortKCellOpt{}),dotk{}())
+                  kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'Gen1:SortKCellOpt{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -1720,9 +1937,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("fa44a9c94132ade195fc2cb566fa82471e4592c977a49183ac2142c5062701ca"), owise{}()]
 
-// rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1516473b1e153a368c273997543a4378ad451e5e828db8e289f4447f7e5228a5)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1738,20 +1955,20 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("1516473b1e153a368c273997543a4378ad451e5e828db8e289f4447f7e5228a5")]
 
-// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f1c02853e001635e66a06d14d1cd322a996f4acbe38a7f9c88df6c97ea6a4677), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'Gen1:SortKConfigVar{},
+          \exists{R} (Var'Unds'Gen0:SortKConfigVar{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortKConfigVar{}, SortKItem{}}(Var'Unds'Gen1:SortKConfigVar{}),dotk{}())
+                  kseq{}(inj{SortKConfigVar{}, SortKItem{}}(Var'Unds'Gen0:SortKConfigVar{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -1774,9 +1991,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("f1c02853e001635e66a06d14d1cd322a996f4acbe38a7f9c88df6c97ea6a4677"), owise{}()]
 
-// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1792,20 +2009,20 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd")]
 
-// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f766beabd3e632a98e221201d003f26f45f1feef2aff6da0ab07edde06a5d99d), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'Gen1:SortKItem{},
+          \exists{R} (Var'Unds'Gen0:SortKItem{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(Var'Unds'Gen1:SortKItem{},dotk{}())
+                  kseq{}(Var'Unds'Gen0:SortKItem{},dotk{}())
                 ),
                 \top{R} ()
               )
@@ -1828,9 +2045,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("f766beabd3e632a98e221201d003f26f45f1feef2aff6da0ab07edde06a5d99d"), owise{}()]
 
-// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1846,20 +2063,74 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c")]
 
-// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isKResult(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b74c72133f88a5a621a948f57a9e1abd3144eb8d539c42ea330b3898a93cef77), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'Gen0:SortList{},
+          \exists{R} (Var'Unds'Gen0:SortKResult{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortList{}, SortKItem{}}(Var'Unds'Gen0:SortList{}),dotk{}())
+                  kseq{}(inj{SortKResult{}, SortKItem{}}(Var'Unds'Gen0:SortKResult{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKResult{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b74c72133f88a5a621a948f57a9e1abd3144eb8d539c42ea330b3898a93cef77"), owise{}()]
+
+// rule isKResult(inj{KResult,KItem}(KResult))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f4c2469bcff9527515b6d36f16040307917bda61067d10b85fb531e142483bee)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKResult{}, SortKItem{}}(VarKResult:SortKResult{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKResult{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f4c2469bcff9527515b6d36f16040307917bda61067d10b85fb531e142483bee")]
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0b6d1ffc254fbf57473abfe22e81bcfa646561c43d4e2cc175eab60cfb2b68aa), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortList{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortList{}, SortKItem{}}(Var'Unds'Gen1:SortList{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -1882,9 +2153,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("0b6d1ffc254fbf57473abfe22e81bcfa646561c43d4e2cc175eab60cfb2b68aa"), owise{}()]
 
-// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1900,9 +2171,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446")]
 
-// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5da72349a323db3019243ab26f08b728d336c1a52aecaa0bcb7de4adae14bd71), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
@@ -1936,9 +2207,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("5da72349a323db3019243ab26f08b728d336c1a52aecaa0bcb7de4adae14bd71"), owise{}()]
 
-// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -1954,20 +2225,20 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795")]
 
-// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4bb33358689dc4ec69171f146dc69c169560a878b09ca872d2c4da9e2dbd0d5e), owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'Gen0:SortSet{},
+          \exists{R} (Var'Unds'Gen1:SortSet{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'Gen0:SortSet{}),dotk{}())
+                  kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'Gen1:SortSet{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -1990,9 +2261,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [owise{}()]
+  [UNIQUE'Unds'ID{}("4bb33358689dc4ec69171f146dc69c169560a878b09ca872d2c4da9e2dbd0d5e"), owise{}()]
 
-// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
+// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80)]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2008,9 +2279,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  []
+  [UNIQUE'Unds'ID{}("f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80")]
 
-// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I1 requires `_<=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6), org.kframework.attributes.Location(Location(1247,8,1247,57)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I1 requires `_<=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6), org.kframework.attributes.Location(Location(1426,8,1426,57)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -2032,9 +2303,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortInt{}} (
        VarI1:SortInt{},
         \top{SortInt{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1247,8,1247,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6")]
+  [UNIQUE'Unds'ID{}("fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1426,8,1426,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
 
-// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I2 requires `_>=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3), org.kframework.attributes.Location(Location(1248,8,1248,57)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I2 requires `_>=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3), org.kframework.attributes.Location(Location(1427,8,1427,57)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -2056,9 +2327,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortInt{}} (
        VarI2:SortInt{},
         \top{SortInt{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1248,8,1248,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3")]
+  [UNIQUE'Unds'ID{}("e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1427,8,1427,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
 
-// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415), org.kframework.attributes.Location(Location(929,8,929,29)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415), org.kframework.attributes.Location(Location(1119,8,1119,29)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2074,9 +2345,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("true"),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(929,8,929,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415")]
+  [UNIQUE'Unds'ID{}("17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1119,8,1119,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c), org.kframework.attributes.Location(Location(928,8,928,29)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c), org.kframework.attributes.Location(Location(1118,8,1118,29)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2092,9 +2363,27 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        \dv{SortBool{}}("false"),
         \top{SortBool{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(928,8,928,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c")]
+  [UNIQUE'Unds'ID{}("53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1118,8,1118,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-// rule `project:Bar`(inj{Bar,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:A`(inj{A,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(044795a77ba44034f732f491fc26cc62dcbda7cbc240ec48be1cc3b7aafa39a3), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortA{}, SortKItem{}}(VarK:SortA{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortA{},R} (
+      Lblproject'Coln'A{}(X0:SortK{}),
+     \and{SortA{}} (
+       VarK:SortA{},
+        \top{SortA{}}())))
+  [UNIQUE'Unds'ID{}("044795a77ba44034f732f491fc26cc62dcbda7cbc240ec48be1cc3b7aafa39a3"), projection{}()]
+
+// rule `project:Bar`(inj{Bar,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55c3fea05d35963b91c15eebbbd91013d0a7ed16d084d115e1065d11bb66d37a), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2110,9 +2399,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBar{}} (
        VarK:SortBar{},
         \top{SortBar{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("55c3fea05d35963b91c15eebbbd91013d0a7ed16d084d115e1065d11bb66d37a"), projection{}()]
 
-// rule `project:Bool`(inj{Bool,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:Bool`(inj{Bool,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2128,9 +2417,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortBool{}} (
        VarK:SortBool{},
         \top{SortBool{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54"), projection{}()]
 
-// rule `project:Foo`(inj{Foo,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:Foo`(inj{Foo,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8351d968bf0243dab1cca650752271f3cfcf781a0fb4eb51eff242554c7fe59e), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2146,9 +2435,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortFoo{}} (
        VarK:SortFoo{},
         \top{SortFoo{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("8351d968bf0243dab1cca650752271f3cfcf781a0fb4eb51eff242554c7fe59e"), projection{}()]
 
-// rule `project:GeneratedCounterCell`(inj{GeneratedCounterCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:GeneratedCounterCell`(inj{GeneratedCounterCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2164,9 +2453,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortGeneratedCounterCell{}} (
        VarK:SortGeneratedCounterCell{},
         \top{SortGeneratedCounterCell{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217"), projection{}()]
 
-// rule `project:GeneratedCounterCellOpt`(inj{GeneratedCounterCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:GeneratedCounterCellOpt`(inj{GeneratedCounterCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2182,9 +2471,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortGeneratedCounterCellOpt{}} (
        VarK:SortGeneratedCounterCellOpt{},
         \top{SortGeneratedCounterCellOpt{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca"), projection{}()]
 
-// rule `project:GeneratedTopCell`(inj{GeneratedTopCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:GeneratedTopCell`(inj{GeneratedTopCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2200,9 +2489,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortGeneratedTopCell{}} (
        VarK:SortGeneratedTopCell{},
         \top{SortGeneratedTopCell{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e"), projection{}()]
 
-// rule `project:GeneratedTopCellFragment`(inj{GeneratedTopCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:GeneratedTopCellFragment`(inj{GeneratedTopCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2218,9 +2507,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortGeneratedTopCellFragment{}} (
        VarK:SortGeneratedTopCellFragment{},
         \top{SortGeneratedTopCellFragment{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42"), projection{}()]
 
-// rule `project:Int`(inj{Int,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:Int`(inj{Int,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2236,9 +2525,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortInt{}} (
        VarK:SortInt{},
         \top{SortInt{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b"), projection{}()]
 
-// rule `project:K`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:K`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2254,9 +2543,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortK{}} (
        VarK:SortK{},
         \top{SortK{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a"), projection{}()]
 
-// rule `project:KCell`(inj{KCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:KCell`(inj{KCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(894c13c4c410f11e35bc3781505aeddde4ff400ddda1daf8b35259dbf0de9a24), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2272,9 +2561,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortKCell{}} (
        VarK:SortKCell{},
         \top{SortKCell{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("894c13c4c410f11e35bc3781505aeddde4ff400ddda1daf8b35259dbf0de9a24"), projection{}()]
 
-// rule `project:KCellOpt`(inj{KCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:KCellOpt`(inj{KCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f684dd78d97feadf0cbcb3cbb8892e0842f137c7b29a904cb2f3fc9755b29b30), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2290,9 +2579,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortKCellOpt{}} (
        VarK:SortKCellOpt{},
         \top{SortKCellOpt{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("f684dd78d97feadf0cbcb3cbb8892e0842f137c7b29a904cb2f3fc9755b29b30"), projection{}()]
 
-// rule `project:KItem`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:KItem`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2308,9 +2597,27 @@ module K-RULE-FIND-SIMPLE
      \and{SortKItem{}} (
        VarK:SortKItem{},
         \top{SortKItem{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29"), projection{}()]
 
-// rule `project:List`(inj{List,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:KResult`(inj{KResult,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(07a916f84d6294528a6d07f273fb778b316d52b4ef8204a1817b105750b2b734), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKResult{}, SortKItem{}}(VarK:SortKResult{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKResult{},R} (
+      Lblproject'Coln'KResult{}(X0:SortK{}),
+     \and{SortKResult{}} (
+       VarK:SortKResult{},
+        \top{SortKResult{}}())))
+  [UNIQUE'Unds'ID{}("07a916f84d6294528a6d07f273fb778b316d52b4ef8204a1817b105750b2b734"), projection{}()]
+
+// rule `project:List`(inj{List,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2326,9 +2633,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortList{}} (
        VarK:SortList{},
         \top{SortList{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5"), projection{}()]
 
-// rule `project:Map`(inj{Map,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:Map`(inj{Map,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2344,9 +2651,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortMap{}} (
        VarK:SortMap{},
         \top{SortMap{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598"), projection{}()]
 
-// rule `project:Set`(inj{Set,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
+// rule `project:Set`(inj{Set,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0), projection]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2362,9 +2669,9 @@ module K-RULE-FIND-SIMPLE
      \and{SortSet{}} (
        VarK:SortSet{},
         \top{SortSet{}}())))
-  [projection{}()]
+  [UNIQUE'Unds'ID{}("0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0"), projection{}()]
 
-// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_-Int_`(`_modInt_`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))),`_<<Int_`(#token("1","Int"),LEN)),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f), org.kframework.attributes.Location(Location(1237,8,1237,164)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_-Int_`(`_modInt_`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))),`_<<Int_`(#token("1","Int"),LEN)),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f), org.kframework.attributes.Location(Location(1416,8,1416,164)), org.kframework.attributes.Source(Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -2388,8 +2695,6 @@ module K-RULE-FIND-SIMPLE
      \and{SortInt{}} (
        Lbl'Unds'-Int'Unds'{}(Lbl'Unds'modInt'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),
         \top{SortInt{}}())))
-  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1237,8,1237,164)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f")]
+  [UNIQUE'Unds'ID{}("3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1416,8,1416,164)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
 
-
-// priority groups
-endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1,1,7,10)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/tests/k-rule-find-examples/one-line-rule/k-rule-find-simple.k)")]
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2,1,19,10)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/llvm-backend/test/k-rule-find/k-files/k-rule-find-test.k)")]

--- a/test/k-rule-find/k-files/k-rule-find-test.k
+++ b/test/k-rule-find/k-files/k-rule-find-test.k
@@ -1,0 +1,19 @@
+// Copyright (c) K Team. All Rights Reserved.
+module K-RULE-FIND-TEST
+    imports INT
+    syntax Foo ::= foo(Bar)
+    syntax Bar ::= bar() | bar2()
+
+    rule [fooRule]: foo(bar()) => bar()
+
+    syntax KResult ::= Int
+    syntax A ::= "a" | Int
+                | foo( A, A ) [seqstrict, klabel(foo)]
+                | bar( A, A )
+                | baz( A, A ) [strict(2), klabel(baz)]
+
+    context [bar1]: bar( HOLE,    _ )
+    context [bar2]: bar(    _, HOLE )
+
+    rule a => 0
+endmodule

--- a/test/output/k-rule-find/bar1-label.out.diff
+++ b/test/output/k-rule-find/bar1-label.out.diff
@@ -1,0 +1,2 @@
+K-RULE-FIND-TEST.bar1-cool
+K-RULE-FIND-TEST.bar1-heat

--- a/test/output/k-rule-find/bar2-label.out.diff
+++ b/test/output/k-rule-find/bar2-label.out.diff
@@ -1,0 +1,2 @@
+K-RULE-FIND-TEST.bar2-cool
+K-RULE-FIND-TEST.bar2-heat

--- a/test/output/k-rule-find/fooRule-label.out.diff
+++ b/test/output/k-rule-find/fooRule-label.out.diff
@@ -1,0 +1,1 @@
+K-RULE-FIND-TEST.fooRule

--- a/test/output/k-rule-find/rule-label.out.diff
+++ b/test/output/k-rule-find/rule-label.out.diff
@@ -1,1 +1,0 @@
-K-RULE-FIND-SIMPLE.fooRule

--- a/test/output/k-rule-find/seqstrict-label.out.diff
+++ b/test/output/k-rule-find/seqstrict-label.out.diff
@@ -1,0 +1,4 @@
+K-RULE-FIND-TEST.foo1-cool
+K-RULE-FIND-TEST.foo2-cool
+K-RULE-FIND-TEST.foo1-heat
+K-RULE-FIND-TEST.foo2-heat

--- a/test/output/k-rule-find/strict2-label.out.diff
+++ b/test/output/k-rule-find/strict2-label.out.diff
@@ -1,0 +1,2 @@
+K-RULE-FIND-TEST.baz2-cool
+K-RULE-FIND-TEST.baz2-heat

--- a/tools/k-rule-find/main.cpp
+++ b/tools/k-rule-find/main.cpp
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
 
   auto loc = parseLocation(RuleLocation);
   auto definition = KompiledDir + "/definition.kore";
-  std::string rule_label = "";
+  std::vector<std::string> rule_labels;
 
   // Parse the definition.kore to get the AST.
   kllvm::parser::KOREParser parser(definition);
@@ -114,17 +114,18 @@ int main(int argc, char **argv) {
       if (source.find(loc.filename) != std::string::npos) {
         auto source_loc = getLocation(axiom);
         if (checkRanges(loc, source_loc, loc.start_column != -1)) {
-          rule_label = axiom->getStringAttribute("label");
+          rule_labels.push_back(axiom->getStringAttribute("label"));
         }
       }
     }
   }
 
   // Output the result or the error message.
-  if (rule_label.empty()) {
+  if (rule_labels.empty()) {
     std::cerr << "Error: Couldn't find rule label within the given location.\n";
   } else {
-    std::cout << rule_label << "\n";
+    for (auto rule_label : rule_labels)
+      std::cout << rule_label << "\n";
   }
 
   return 0;


### PR DESCRIPTION
Fixes #725

This PR updates the `k-rule-find` tool to return multiple rule labels when the given location has `cool` and `heat` rules, like when using `seqstrict` and `strict`.

This PR will break the [`context-labels`](https://github.com/runtimeverification/k/tree/master/k-distribution/tests/regression-new/context-labels) test on the K frontend as the output expected there has only one rule when more than one will be returned after this modification.