### PR TITLE
fix bug in kore_block_get_bool

### DIFF
--- a/bindings/c/lib.cpp
+++ b/bindings/c/lib.cpp
@@ -268,7 +268,7 @@ kore_pattern *kore_pattern_from_block(block *term) {
 
 bool kore_block_get_bool(block *term) {
   assert((((uintptr_t)term) & 1) == 0);
-  return (bool)(term->children[0]);
+  return *(bool *)term->children;
 }
 
 bool kore_simplify_bool(kore_pattern const *pattern) {


### PR DESCRIPTION
We discovered a bug in the kore_block_get_bool function. It was reading 8 bytes and then casting the result to a bool, but a block containing a boolean as a child has one byte that is determined and 7 unspecified bytes that contain padding. As a result, if the padding was nonzero, the function would return true even if the injection actually contained the boolean `false`. This should fix that bug by casting the pointer to `bool*` before reading.