### PR TITLE
Set stack size for JVM when Nix-wrapping LLVM matching

### DIFF
--- a/nix/llvm-backend-matching.nix
+++ b/nix/llvm-backend-matching.nix
@@ -18,7 +18,7 @@ let
       test -f "$out/share/java/llvm-backend-matching-1.0-SNAPSHOT-jar-with-dependencies.jar"
 
       makeWrapper ${jdk11_headless}/bin/java $out/bin/llvm-backend-matching \
-          --add-flags "-jar $out/share/java/llvm-backend-matching-1.0-SNAPSHOT-jar-with-dependencies.jar"
+          --add-flags "-Xss32m -jar $out/share/java/llvm-backend-matching-1.0-SNAPSHOT-jar-with-dependencies.jar"
     '';
 
     # Add build dependencies


### PR DESCRIPTION
This is a small follow-up for #827