### PR TITLE
Replacing date/gdate with perl program

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -5,14 +5,9 @@ export DEPTH=0
 verbose=${verbose:-false}
 profile=${profile:-false}
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  DATE_CMD="gdate"
-else
-  DATE_CMD="date"
-fi
 
 time_now_ms () {
-  "$DATE_CMD" "+%s%3N"
+  perl -MTime::HiRes=time -e 'printf "%d\n", time*1000'
 }
 
 indented () {

--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -28,9 +28,6 @@ stdenv.mkDerivation {
       --replace 'extra_python_flags=()' \
                 'extra_python_flags=($(${python-env}/bin/pybind11-config --includes))'
 
-    substituteInPlace bin/utils.sh \
-      --replace 'gdate' 'date'
-
     substituteInPlace bin/llvm-kompile-clang \
       --replace 'uname' '${coreutils}/bin/uname' \
       --replace '"-lgmp"' '"-I${gmp.dev}/include" "-L${gmp}/lib" "-lgmp"' \


### PR DESCRIPTION
Fixes https://github.com/runtimeverification/k/issues/3610
This PR replaces the use of `date` and `gdate`, depending on the user system, to get the current timestamp in milliseconds with a simple `Perl` program to improve compatibility across Unix-like systems.
 
This modification is needed due to the following:
- `date` in MacOS is a FreeBSD version that doesn't support (return) timestamps in milliseconds as we need in `llvm-kompile --profile` introduced by #793.
- `gdate` isn't a default package nor a standalone package to be installed in MacOS. Instead, it's commonly installed with `coreutils`. We do not want to ask our users to install all `coreutils` when we only need `gdate` from it and to use it in an optional flag.
- Other options were considered as `python time` and `bash ${EPOCHREALTIME}`, but this was the simplest to use and with common default dependencies in Unix-like systems.  