### PR TITLE
Tidy up and/or changes to llvm backend

### DIFF
--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
@@ -2,7 +2,10 @@ package org.kframework.backend.llvm.matching
 
 import org.kframework.backend.llvm.matching.dt.DecisionTree
 import org.kframework.backend.llvm.matching.pattern.{Pattern => P, SymbolP, LiteralP, VariableP, AsP, OrP, ListP, MapP, SetP, WildcardP, SortCategory}
-import org.kframework.parser.kore._
+import org.kframework.parser.kore.Pattern
+import org.kframework.parser.kore.Sort
+import org.kframework.parser.{kore => i}
+import org.kframework.parser.kore.implementation.ConcreteClasses._
 import org.kframework.utils.errorsystem.KException
 
 object Generator {
@@ -12,7 +15,7 @@ object Generator {
   case class Unit() extends CollectionCons
   case class Element() extends CollectionCons
 
-  private def listPattern(sym: SymbolOrAlias, cons: CollectionCons, ps: Seq[P[String]], c: SymbolOrAlias) : P[String] = {
+  private def listPattern(sym: i.SymbolOrAlias, cons: CollectionCons, ps: Seq[P[String]], c: i.SymbolOrAlias) : P[String] = {
     (cons, ps) match {
       case (Concat(), Seq(ListP(hd1, None, tl1, _, o1), ListP(hd2, frame, tl2, _, o2))) => ListP(hd1 ++ tl1 ++ hd2, frame, tl2, c, SymbolP(sym, Seq(o1, o2)))
       case (Concat(), Seq(ListP(hd1, frame, tl1, _, o1), ListP(hd2, None, tl2, _, o2))) => ListP(hd1, frame, tl1 ++ hd2 ++ tl2, c, SymbolP(sym, Seq(o1, o2)))
@@ -26,7 +29,7 @@ object Generator {
     }
   }
 
-  private def mapPattern(sym: SymbolOrAlias, cons: CollectionCons, ps: Seq[P[String]], c: SymbolOrAlias) : P[String] = {
+  private def mapPattern(sym: i.SymbolOrAlias, cons: CollectionCons, ps: Seq[P[String]], c: i.SymbolOrAlias) : P[String] = {
     (cons, ps) match {
       case (Concat(), Seq(MapP(ks1, vs1, None, _, o1), MapP(ks2, vs2, frame, _, o2))) => MapP(ks1 ++ ks2, vs1 ++ vs2, frame, c, SymbolP(sym, Seq(o1, o2)))
       case (Concat(), Seq(MapP(ks1, vs1, frame,_, o1), MapP(ks2, vs2, None, _, o2))) => MapP(ks1 ++ ks2, vs1 ++ vs2, frame, c, SymbolP(sym, Seq(o1, o2)))
@@ -40,7 +43,7 @@ object Generator {
     }
   }
 
-  private def setPattern(sym: SymbolOrAlias, cons: CollectionCons, ps: Seq[P[String]], c: SymbolOrAlias) : P[String] = {
+  private def setPattern(sym: i.SymbolOrAlias, cons: CollectionCons, ps: Seq[P[String]], c: i.SymbolOrAlias) : P[String] = {
     (cons, ps) match {
       case (Concat(), Seq(SetP(ks1, None, _, o1), SetP(ks2, frame, _, o2))) => SetP(ks1 ++ ks2, frame, c, SymbolP(sym, Seq(o1, o2)))
       case (Concat(), Seq(SetP(ks1, frame,_, o1), SetP(ks2, None, _, o2))) => SetP(ks1 ++ ks2, frame, c, SymbolP(sym, Seq(o1, o2)))
@@ -54,8 +57,8 @@ object Generator {
     }
   }
 
-  private def genPatterns(mod: Definition, symlib: Parser.SymLib, lhs: Seq[Pattern]) : List[P[String]] = {
-    def getElementSym(sort: Sort): SymbolOrAlias = {
+  private def genPatterns(mod: i.Definition, symlib: Parser.SymLib, lhs: Seq[Pattern]) : List[P[String]] = {
+    def getElementSym(sort: Sort): i.SymbolOrAlias = {
       Parser.getSymbolAtt(symlib.sortAtt(sort), "element").get
     }
     def genPattern(pat: Pattern) : P[String] = {
@@ -121,7 +124,7 @@ object Generator {
 
   def genClauseMatrix[T](
       symlib: Parser.SymLib,
-      mod: Definition,
+      mod: i.Definition,
       axioms: IndexedSeq[AxiomInfo],
       sorts: Seq[Sort]) :
       Matrix = {
@@ -137,7 +140,7 @@ object Generator {
     new Matrix(symlib, cols, actions).expand
   }
   
-  def mkDecisionTree(symlib: Parser.SymLib, mod: Definition, axioms: IndexedSeq[AxiomInfo], sorts: Seq[Sort], name: SymbolOrAlias, kem: KException => scala.Unit) : DecisionTree = {
+  def mkDecisionTree(symlib: Parser.SymLib, mod: i.Definition, axioms: IndexedSeq[AxiomInfo], sorts: Seq[Sort], name: i.SymbolOrAlias, kem: KException => scala.Unit) : DecisionTree = {
     val matrix = genClauseMatrix(symlib, mod, axioms, sorts)
     matrix.checkUsefulness(kem)
     if (!symlib.isHooked(name) && (Parser.hasAtt(symlib.signatures(name)._3, "functional") || Parser.hasAtt(symlib.signatures(name)._3, "total")) && Parser.hasAtt(symlib.signatures(name)._3, "function")) {
@@ -155,7 +158,7 @@ object Generator {
     numerator <= denominator
   }
 
-  def mkSpecialDecisionTree(symlib: Parser.SymLib, mod: Definition, matrix: Matrix, axiom: AxiomInfo, threshold: (Int, Int)) : Option[(DecisionTree, Seq[(P[String], Occurrence)])] = {
+  def mkSpecialDecisionTree(symlib: Parser.SymLib, mod: i.Definition, matrix: Matrix, axiom: AxiomInfo, threshold: (Int, Int)) : Option[(DecisionTree, Seq[(P[String], Occurrence)])] = {
     val rhs = genPatterns(mod, symlib, Seq(axiom.rewrite.getRightHandSide))
     val (specialized,residuals) = matrix.specializeBy(rhs.toIndexedSeq)
     val residualMap = (residuals, specialized.fringe.map(_.occurrence)).zipped.toSeq

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
@@ -2,10 +2,7 @@ package org.kframework.backend.llvm.matching
 
 import org.kframework.backend.llvm.matching.dt.DecisionTree
 import org.kframework.backend.llvm.matching.pattern.{Pattern => P, SymbolP, LiteralP, VariableP, AsP, OrP, ListP, MapP, SetP, WildcardP, SortCategory}
-import org.kframework.parser.kore.Pattern
-import org.kframework.parser.kore.Sort
-import org.kframework.parser.{kore => i}
-import org.kframework.parser.kore.implementation.ConcreteClasses._
+import org.kframework.parser.kore._
 import org.kframework.utils.errorsystem.KException
 
 object Generator {
@@ -15,7 +12,7 @@ object Generator {
   case class Unit() extends CollectionCons
   case class Element() extends CollectionCons
 
-  private def listPattern(sym: i.SymbolOrAlias, cons: CollectionCons, ps: Seq[P[String]], c: i.SymbolOrAlias) : P[String] = {
+  private def listPattern(sym: SymbolOrAlias, cons: CollectionCons, ps: Seq[P[String]], c: SymbolOrAlias) : P[String] = {
     (cons, ps) match {
       case (Concat(), Seq(ListP(hd1, None, tl1, _, o1), ListP(hd2, frame, tl2, _, o2))) => ListP(hd1 ++ tl1 ++ hd2, frame, tl2, c, SymbolP(sym, Seq(o1, o2)))
       case (Concat(), Seq(ListP(hd1, frame, tl1, _, o1), ListP(hd2, None, tl2, _, o2))) => ListP(hd1, frame, tl1 ++ hd2 ++ tl2, c, SymbolP(sym, Seq(o1, o2)))
@@ -29,7 +26,7 @@ object Generator {
     }
   }
 
-  private def mapPattern(sym: i.SymbolOrAlias, cons: CollectionCons, ps: Seq[P[String]], c: i.SymbolOrAlias) : P[String] = {
+  private def mapPattern(sym: SymbolOrAlias, cons: CollectionCons, ps: Seq[P[String]], c: SymbolOrAlias) : P[String] = {
     (cons, ps) match {
       case (Concat(), Seq(MapP(ks1, vs1, None, _, o1), MapP(ks2, vs2, frame, _, o2))) => MapP(ks1 ++ ks2, vs1 ++ vs2, frame, c, SymbolP(sym, Seq(o1, o2)))
       case (Concat(), Seq(MapP(ks1, vs1, frame,_, o1), MapP(ks2, vs2, None, _, o2))) => MapP(ks1 ++ ks2, vs1 ++ vs2, frame, c, SymbolP(sym, Seq(o1, o2)))
@@ -43,7 +40,7 @@ object Generator {
     }
   }
 
-  private def setPattern(sym: i.SymbolOrAlias, cons: CollectionCons, ps: Seq[P[String]], c: i.SymbolOrAlias) : P[String] = {
+  private def setPattern(sym: SymbolOrAlias, cons: CollectionCons, ps: Seq[P[String]], c: SymbolOrAlias) : P[String] = {
     (cons, ps) match {
       case (Concat(), Seq(SetP(ks1, None, _, o1), SetP(ks2, frame, _, o2))) => SetP(ks1 ++ ks2, frame, c, SymbolP(sym, Seq(o1, o2)))
       case (Concat(), Seq(SetP(ks1, frame,_, o1), SetP(ks2, None, _, o2))) => SetP(ks1 ++ ks2, frame, c, SymbolP(sym, Seq(o1, o2)))
@@ -57,8 +54,8 @@ object Generator {
     }
   }
 
-  private def genPatterns(mod: i.Definition, symlib: Parser.SymLib, lhs: Seq[Pattern]) : List[P[String]] = {
-    def getElementSym(sort: Sort): i.SymbolOrAlias = {
+  private def genPatterns(mod: Definition, symlib: Parser.SymLib, lhs: Seq[Pattern]) : List[P[String]] = {
+    def getElementSym(sort: Sort): SymbolOrAlias = {
       Parser.getSymbolAtt(symlib.sortAtt(sort), "element").get
     }
     def genPattern(pat: Pattern) : P[String] = {
@@ -124,7 +121,7 @@ object Generator {
 
   def genClauseMatrix[T](
       symlib: Parser.SymLib,
-      mod: i.Definition,
+      mod: Definition,
       axioms: IndexedSeq[AxiomInfo],
       sorts: Seq[Sort]) :
       Matrix = {
@@ -140,7 +137,7 @@ object Generator {
     new Matrix(symlib, cols, actions).expand
   }
   
-  def mkDecisionTree(symlib: Parser.SymLib, mod: i.Definition, axioms: IndexedSeq[AxiomInfo], sorts: Seq[Sort], name: i.SymbolOrAlias, kem: KException => scala.Unit) : DecisionTree = {
+  def mkDecisionTree(symlib: Parser.SymLib, mod: Definition, axioms: IndexedSeq[AxiomInfo], sorts: Seq[Sort], name: SymbolOrAlias, kem: KException => scala.Unit) : DecisionTree = {
     val matrix = genClauseMatrix(symlib, mod, axioms, sorts)
     matrix.checkUsefulness(kem)
     if (!symlib.isHooked(name) && (Parser.hasAtt(symlib.signatures(name)._3, "functional") || Parser.hasAtt(symlib.signatures(name)._3, "total")) && Parser.hasAtt(symlib.signatures(name)._3, "function")) {
@@ -158,7 +155,7 @@ object Generator {
     numerator <= denominator
   }
 
-  def mkSpecialDecisionTree(symlib: Parser.SymLib, mod: i.Definition, matrix: Matrix, axiom: AxiomInfo, threshold: (Int, Int)) : Option[(DecisionTree, Seq[(P[String], Occurrence)])] = {
+  def mkSpecialDecisionTree(symlib: Parser.SymLib, mod: Definition, matrix: Matrix, axiom: AxiomInfo, threshold: (Int, Int)) : Option[(DecisionTree, Seq[(P[String], Occurrence)])] = {
     val rhs = genPatterns(mod, symlib, Seq(axiom.rewrite.getRightHandSide))
     val (specialized,residuals) = matrix.specializeBy(rhs.toIndexedSeq)
     val residualMap = (residuals, specialized.fringe.map(_.occurrence)).zipped.toSeq

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -1,37 +1,41 @@
 package org.kframework.backend.llvm.matching
 
 import org.kframework.attributes.{Source, Location}
-import org.kframework.parser.kore._
+import org.kframework.parser.kore.GeneralizedRewrite
+import org.kframework.parser.kore.Pattern
+import org.kframework.parser.kore.Sort
+import org.kframework.parser.{kore => i}
+import org.kframework.parser.kore.implementation.ConcreteClasses._
 import org.kframework.parser.kore.parser.KoreToK
 import org.kframework.parser.kore.implementation.{DefaultBuilders => B}
 import java.util
 import java.util.Optional
 
-case class AxiomInfo(priority: Int, ordinal: Int, rewrite: GeneralizedRewrite, sideCondition: Option[Pattern], ensures: Option[Pattern], source: Optional[Source], location: Optional[Location], att: Attributes) {}
+case class AxiomInfo(priority: Int, ordinal: Int, rewrite: GeneralizedRewrite, sideCondition: Option[Pattern], ensures: Option[Pattern], source: Optional[Source], location: Optional[Location], att: i.Attributes) {}
 
 object Parser {
 
-  def hasAtt(axiom: AxiomDeclaration, att: String): Boolean = {
+  def hasAtt(axiom: i.AxiomDeclaration, att: String): Boolean = {
     hasAtt(axiom.att, att)
   }
 
-  def hasAtt(att: Attributes, attName: String): Boolean = {
+  def hasAtt(att: i.Attributes, attName: String): Boolean = {
     getAtt(att, attName).isDefined
   }
 
-  def getAtt(axiom: AxiomDeclaration, att: String): Option[Pattern] = {
+  def getAtt(axiom: i.AxiomDeclaration, att: String): Option[Pattern] = {
     getAtt(axiom.att, att)
   }
 
-  def getAtt(att: Attributes, attName: String): Option[Pattern] = {
+  def getAtt(att: i.Attributes, attName: String): Option[Pattern] = {
     att.patterns.find(isAtt(attName, _))
   }
 
-  def getStringAtt(att: Attributes, attName: String): Option[String] = {
+  def getStringAtt(att: i.Attributes, attName: String): Option[String] = {
     att.patterns.find(isAtt(attName, _)).map(_.asInstanceOf[Application].args.head.asInstanceOf[StringLiteral].str)
   }
 
-  def getSymbolAtt(att: Attributes, attName: String): Option[SymbolOrAlias] = {
+  def getSymbolAtt(att: i.Attributes, attName: String): Option[i.SymbolOrAlias] = {
     att.patterns.find(isAtt(attName, _)).map(_.asInstanceOf[Application].args.head.asInstanceOf[Application].head)
   }
 
@@ -42,12 +46,12 @@ object Parser {
     }
   }
 
-  class SymLib(symbols: Seq[SymbolOrAlias], sorts: Seq[Sort], mod: Definition, overloadSeq: Seq[(SymbolOrAlias, SymbolOrAlias)], val heuristics: Seq[Heuristic]) {
+  class SymLib(symbols: Seq[i.SymbolOrAlias], sorts: Seq[Sort], mod: i.Definition, overloadSeq: Seq[(i.SymbolOrAlias, i.SymbolOrAlias)], val heuristics: Seq[Heuristic]) {
     val sortCache = new util.HashMap[Sort, SortInfo]()
 
-    private val symbolDecls = mod.modules.flatMap(_.decls).filter(_.isInstanceOf[SymbolDeclaration]).map(_.asInstanceOf[SymbolDeclaration]).groupBy(_.symbol.ctr)
+    private val symbolDecls = mod.modules.flatMap(_.decls).filter(_.isInstanceOf[i.SymbolDeclaration]).map(_.asInstanceOf[i.SymbolDeclaration]).groupBy(_.symbol.ctr)
 
-    private val sortDecls = mod.modules.flatMap(_.decls).filter(_.isInstanceOf[SortDeclaration]).map(_.asInstanceOf[SortDeclaration]).groupBy(_.sort.asInstanceOf[CompoundSort].ctr)
+    private val sortDecls = mod.modules.flatMap(_.decls).filter(_.isInstanceOf[i.SortDeclaration]).map(_.asInstanceOf[i.SortDeclaration]).groupBy(_.sort.asInstanceOf[CompoundSort].ctr)
 
     private def instantiate(s: Sort, params: Seq[Sort], args: Seq[Sort]): Sort = {
       val map = (params, args).zipped.toMap
@@ -57,13 +61,13 @@ object Parser {
       }
     }
 
-    def isHooked(symbol: SymbolOrAlias): Boolean = {
+    def isHooked(symbol: i.SymbolOrAlias): Boolean = {
       return symbolDecls(symbol.ctr).head.isInstanceOf[HookSymbolDeclaration]
     }
 
     private def instantiate(s: Seq[Sort], params: Seq[Sort], args: Seq[Sort]): Seq[Sort] = s.map(instantiate(_, params, args))
 
-    val signatures: Map[SymbolOrAlias, (Seq[Sort], Sort, Attributes)] = {
+    val signatures: Map[i.SymbolOrAlias, (Seq[Sort], Sort, i.Attributes)] = {
       symbols.map(symbol => {
         if (symbol.ctr == "\\dv") {
           (symbol, (Seq(), symbol.params(0), B.Attributes(Seq())))
@@ -73,23 +77,23 @@ object Parser {
       }).toMap
     }
 
-    val constructorsForSort: Map[Sort, Seq[SymbolOrAlias]] = {
+    val constructorsForSort: Map[Sort, Seq[i.SymbolOrAlias]] = {
       signatures.groupBy(_._2._2).mapValues(_.keys.filter(k => !hasAtt(signatures(k)._3, "function")).toSeq)
     }
 
-    private val sortAttData: Map[String, Attributes] = {
-      sorts.filter(_.isInstanceOf[CompoundSort]).map(sort => (sort.asInstanceOf[CompoundSort].ctr, sortDecls(sort.asInstanceOf[CompoundSort].ctr).head.att)).toMap
+    private val sortAttData: Map[String, i.Attributes] = {
+      sorts.filter(_.isInstanceOf[i.CompoundSort]).map(sort => (sort.asInstanceOf[i.CompoundSort].ctr, sortDecls(sort.asInstanceOf[i.CompoundSort].ctr).head.att)).toMap
     }
 
-    def sortAtt(s: Sort): Attributes = {
-      sortAttData(s.asInstanceOf[CompoundSort].ctr)
+    def sortAtt(s: Sort): i.Attributes = {
+      sortAttData(s.asInstanceOf[i.CompoundSort].ctr)
     }
 
-    val functions: Seq[SymbolOrAlias] = {
+    val functions: Seq[i.SymbolOrAlias] = {
       signatures.filter(s => s._2._3.patterns.exists(isAtt("anywhere", _)) || s._2._3.patterns.exists(isAtt("function", _))).keys.toSeq
     }
 
-    val overloads: Map[SymbolOrAlias, Seq[SymbolOrAlias]] = {
+    val overloads: Map[i.SymbolOrAlias, Seq[i.SymbolOrAlias]] = {
       overloadSeq.groupBy(_._1).mapValues(_.map(_._2).toSeq)
     }
 
@@ -113,7 +117,7 @@ object Parser {
   private val SOURCE = "org'Stop'kframework'Stop'attributes'Stop'Source"
   private val LOCATION = "org'Stop'kframework'Stop'attributes'Stop'Location"
 
-  def source(att: Attributes): Optional[Source] = {
+  def source(att: i.Attributes): Optional[Source] = {
     if (hasAtt(att, SOURCE)) {
       val sourceStr = getStringAtt(att, SOURCE).get
       return Optional.of(Source(sourceStr.substring("Source(".length, sourceStr.length - 1)))
@@ -122,7 +126,7 @@ object Parser {
     }
   }
 
-  def location(att: Attributes): Optional[Location] = {
+  def location(att: i.Attributes): Optional[Location] = {
     if (hasAtt(att, LOCATION)) {
       val locStr = getStringAtt(att, LOCATION).get
       val splitted = locStr.split("[(,)]")
@@ -136,11 +140,11 @@ object Parser {
   private def location(axiom: AxiomDeclaration): Optional[Location] = location(axiom.att)
 
   private def parseAxiomSentence[T <: GeneralizedRewrite](
-      split: Pattern => Option[(Option[SymbolOrAlias], T, Option[Pattern], Option[Pattern])],
+      split: Pattern => Option[(Option[i.SymbolOrAlias], T, Option[Pattern], Option[Pattern])],
       axiom: (AxiomDeclaration, Int),
       simplification: Boolean,
       search: Boolean) :
-      Seq[(Option[SymbolOrAlias], AxiomInfo)] = {
+      Seq[(Option[i.SymbolOrAlias], AxiomInfo)] = {
     val splitted = split(axiom._1.pattern)
     if (splitted.isDefined) {
       val s = axiom._1
@@ -154,7 +158,7 @@ object Parser {
     }
   }
 
-  private def splitTop(topPattern: Pattern): Option[(Option[SymbolOrAlias], Rewrites, Option[Pattern], Option[Pattern])] = {
+  private def splitTop(topPattern: Pattern): Option[(Option[i.SymbolOrAlias], i.Rewrites, Option[Pattern], Option[Pattern])] = {
     topPattern match {
       case Rewrites(s, And(_, req @ Equals(_, _, _, _), l), And(_, ens, r)) => Some((None, B.Rewrites(s, l, r), splitPredicate(req), splitPredicate(ens)))
       case Rewrites(s, And(_, req @ Top(_), l), And(_, ens, r)) => Some((None, B.Rewrites(s, l, r), splitPredicate(req), splitPredicate(ens)))
@@ -178,7 +182,7 @@ object Parser {
     }
   }
 
-  private def splitFunction(topPattern: Pattern): Option[(Option[SymbolOrAlias], Equals, Option[Pattern], Option[Pattern])] = {
+  private def splitFunction(topPattern: Pattern): Option[(Option[i.SymbolOrAlias], i.Equals, Option[Pattern], Option[Pattern])] = {
     topPattern match {
       case Implies(_, And(_, Not(_, _), And (_, req, args)), Equals(i, o, Application(symbol, _), And(_, rhs, ens))) => Some(Some(symbol), B.Equals(i, o, B.Application(symbol, getPatterns(args)), rhs), splitPredicate(req), splitPredicate(ens))
       case Implies(_, And(_, req, args), Equals(i, o, Application(symbol, _), And(_, rhs, ens))) => Some(Some(symbol), B.Equals(i, o, B.Application(symbol, getPatterns(args)), rhs), splitPredicate(req), splitPredicate(ens))
@@ -246,13 +250,13 @@ object Parser {
     B.AxiomDeclaration(axiom.params, expandAliases(axiom.pattern, aliases), axiom.att).asInstanceOf[AxiomDeclaration]
   }
 
-  def getAxioms(defn: Definition) : Seq[AxiomDeclaration] = {
+  def getAxioms(defn: i.Definition) : Seq[AxiomDeclaration] = {
     val aliases = defn.modules.flatMap(_.decls).filter(_.isInstanceOf[AliasDeclaration]).map(_.asInstanceOf[AliasDeclaration]).map(al => (al.alias.ctr, al)).toMap
     defn.modules.flatMap(_.decls).filter(_.isInstanceOf[AxiomDeclaration]).map(_.asInstanceOf[AxiomDeclaration]).map(expandAliases(_, aliases))
   }
 
-  def getSorts(defn: Definition): Seq[Sort] = {
-    defn.modules.flatMap(_.decls).filter(_.isInstanceOf[SortDeclaration]).map(_.asInstanceOf[SortDeclaration].sort)
+  def getSorts(defn: i.Definition): Seq[Sort] = {
+    defn.modules.flatMap(_.decls).filter(_.isInstanceOf[i.SortDeclaration]).map(_.asInstanceOf[i.SortDeclaration].sort)
   }
 
   def parseTopAxioms(axioms: Seq[AxiomDeclaration], search: Boolean) : IndexedSeq[AxiomInfo] = {
@@ -260,16 +264,16 @@ object Parser {
     withOwise.map(_._2).sortWith(_.priority < _.priority).toIndexedSeq
   }
 
-  def parseFunctionAxioms(axioms: Seq[AxiomDeclaration], simplification: Boolean) : Map[SymbolOrAlias, IndexedSeq[AxiomInfo]] = {
+  def parseFunctionAxioms(axioms: Seq[AxiomDeclaration], simplification: Boolean) : Map[i.SymbolOrAlias, IndexedSeq[AxiomInfo]] = {
     val withOwise = axioms.zipWithIndex.flatMap(parseAxiomSentence(a => splitFunction(a), _, simplification, true))
     withOwise.sortWith(_._2.priority < _._2.priority).toIndexedSeq.filter(_._1.isDefined).map(t => (t._1.get, t._2)).groupBy(_._1).mapValues(_.map(_._2))
   }
 
-  private def isConcrete(symbol: SymbolOrAlias) : Boolean = {
+  private def isConcrete(symbol: i.SymbolOrAlias) : Boolean = {
     symbol.params.forall(_.isInstanceOf[CompoundSort])
   }
 
-  private def parsePatternForSymbols(pat: Pattern): Seq[SymbolOrAlias] = {
+  private def parsePatternForSymbols(pat: Pattern): Seq[i.SymbolOrAlias] = {
     pat match {
       case And(_, p1, p2) => parsePatternForSymbols(p1) ++ parsePatternForSymbols(p2)
       case Application(s, ps) => Seq(s).filter(isConcrete) ++ ps.flatMap(parsePatternForSymbols)
@@ -290,7 +294,7 @@ object Parser {
     }
   }
 
-  private def getOverloads(axioms: Seq[AxiomDeclaration]): Seq[(SymbolOrAlias, SymbolOrAlias)] = {
+  private def getOverloads(axioms: Seq[AxiomDeclaration]): Seq[(i.SymbolOrAlias, i.SymbolOrAlias)] = {
     if (axioms.isEmpty) {
       Seq()
     }
@@ -329,7 +333,7 @@ object Parser {
     heuristics.toList.map(parseHeuristic(_))
   }
 
-  def parseSymbols(defn: Definition, heuristics: String) : SymLib = {
+  def parseSymbols(defn: i.Definition, heuristics: String) : SymLib = {
     val axioms = getAxioms(defn)
     val symbols = axioms.flatMap(a => parsePatternForSymbols(a.pattern))
     val allSorts = getSorts(defn)


### PR DESCRIPTION
Blocked on https://github.com/runtimeverification/k/pull/3678

This is the second wave of changes to the llvm backend to implement the multi-ary \and and \or. The change simply reverts the temporary changes made in the previous PR in the sequence in this repo. It cannot be merged until after the second PR to the frontend. This should be the final required change to the scala code in the backend.