### PR TITLE
Add ZeroORMore option oto debug cl::opt

### DIFF
--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -50,8 +50,9 @@ cl::opt<std::string> DecisionTree(
 cl::opt<std::string> Directory(
     cl::Positional, cl::desc("<dir>"), cl::Required, cl::cat(CodegenCat));
 
-cl::opt<bool>
-    Debug("debug", cl::desc("Enable debug information"), cl::cat(CodegenCat));
+cl::opt<bool> Debug(
+  "debug", cl::desc("Enable debug information"), cl::ZeroOrMore,
+  cl::cat(CodegenCat));
 
 cl::opt<bool> NoOptimize(
     "no-optimize",

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -51,8 +51,8 @@ cl::opt<std::string> Directory(
     cl::Positional, cl::desc("<dir>"), cl::Required, cl::cat(CodegenCat));
 
 cl::opt<bool> Debug(
-  "debug", cl::desc("Enable debug information"), cl::ZeroOrMore,
-  cl::cat(CodegenCat));
+    "debug", cl::desc("Enable debug information"), cl::ZeroOrMore,
+    cl::cat(CodegenCat));
 
 cl::opt<bool> NoOptimize(
     "no-optimize",


### PR DESCRIPTION
This modification allows multiple `--debug` flags to be accepted by `llvm-kompile-codegen`