### PR TITLE
Creating `debug-command` flag on `llvm-krun`

### DIFF
--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -18,6 +18,7 @@ trap 'cleanup' INT TERM EXIT
 initializer="LblinitGeneratedTopCell{}"
 dir=.
 debug=
+debug_command=
 depth=-1
 verbose=0
 binary_input=false
@@ -64,7 +65,9 @@ Mandatory arguments to long options are mandatory for short options too.
                            KORE format, rather than the textual syntax;
   -p, --pretty-print       Pretty print output configuration. By default,
                            output is in kore syntax
-      --debug              Use GDB to debug program
+      --debug              Use GDB to debug the program
+      --debug-batch        Use GDB in batch mode to debug the program
+      --debug-command FILE Execute GDB commands from FILE to debug the program
       --depth INT          Execute up to INT steps
   -i, --initializer INIT   Use INIT as the top cell initializer 
   -nm, --no-expand-macros  Don't expand macros in initial configuration
@@ -154,6 +157,20 @@ do
     --debug)
     debug="gdb --args "
     shift;
+    ;;
+
+    --debug-command)
+    debug_command="$2"
+    if [[ -z $debug ]]; then
+      debug="gdb -x ${debug_command} --args "
+    else
+      debug="${debug/--args /} -x ${debug_command} --args "
+    fi
+    shift;
+    ;;
+
+    --debug-batch)
+    debug="gdb --batch --args "
     ;;
 
     --depth)

--- a/nix/llvm-backend-matching.mavenix.lock
+++ b/nix/llvm-backend-matching.mavenix.lock
@@ -246,15 +246,15 @@
       "sha1": "fdec6f2d2514787039928bcb781f9e67f4738899"
     },
     {
-      "path": "com/runtimeverification/k/kore/1.0-SNAPSHOT/kore-1.0-20230930.025149-29.jar",
-      "sha1": "04972642a285d27d20767761d593840798a5ffd5"
+      "path": "com/runtimeverification/k/kore/1.0-SNAPSHOT/kore-1.0-20231003.172436-30.jar",
+      "sha1": "8c3e43f073c3344e745919b0df8d3dbce36bef81"
     },
     {
-      "path": "com/runtimeverification/k/kore/1.0-SNAPSHOT/kore-1.0-20230930.025149-29.pom",
+      "path": "com/runtimeverification/k/kore/1.0-SNAPSHOT/kore-1.0-20231003.172436-30.pom",
       "sha1": "2706d868319a03bc491350cb3a1af0927ef1a839"
     },
     {
-      "path": "com/runtimeverification/k/parent/1.0-SNAPSHOT/parent-1.0-20230930.025126-29.pom",
+      "path": "com/runtimeverification/k/parent/1.0-SNAPSHOT/parent-1.0-20231003.172408-30.pom",
       "sha1": "62b92746f9104b7966075e98dc7b69c44475c72c"
     },
     {
@@ -5337,11 +5337,11 @@
   "groupId": "com.runtimeverification.k",
   "metas": [
     {
-      "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata modelVersion=\"1.1.0\">\n  <groupId>com.runtimeverification.k</groupId>\n  <artifactId>kore</artifactId>\n  <version>1.0-SNAPSHOT</version>\n  <versioning>\n    <snapshot>\n      <timestamp>20230930.025149</timestamp>\n      <buildNumber>29</buildNumber>\n    </snapshot>\n    <lastUpdated>20230930025149</lastUpdated>\n    <snapshotVersions>\n      <snapshotVersion>\n        <extension>jar</extension>\n        <value>1.0-20230930.025149-29</value>\n        <updated>20230930025149</updated>\n      </snapshotVersion>\n      <snapshotVersion>\n        <extension>pom</extension>\n        <value>1.0-20230930.025149-29</value>\n        <updated>20230930025149</updated>\n      </snapshotVersion>\n    </snapshotVersions>\n  </versioning>\n</metadata>",
+      "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata modelVersion=\"1.1.0\">\n  <groupId>com.runtimeverification.k</groupId>\n  <artifactId>kore</artifactId>\n  <version>1.0-SNAPSHOT</version>\n  <versioning>\n    <snapshot>\n      <timestamp>20231003.172436</timestamp>\n      <buildNumber>30</buildNumber>\n    </snapshot>\n    <lastUpdated>20231003172436</lastUpdated>\n    <snapshotVersions>\n      <snapshotVersion>\n        <extension>jar</extension>\n        <value>1.0-20231003.172436-30</value>\n        <updated>20231003172436</updated>\n      </snapshotVersion>\n      <snapshotVersion>\n        <extension>pom</extension>\n        <value>1.0-20231003.172436-30</value>\n        <updated>20231003172436</updated>\n      </snapshotVersion>\n    </snapshotVersions>\n  </versioning>\n</metadata>",
       "path": "com/runtimeverification/k/kore/1.0-SNAPSHOT"
     },
     {
-      "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata modelVersion=\"1.1.0\">\n  <groupId>com.runtimeverification.k</groupId>\n  <artifactId>parent</artifactId>\n  <version>1.0-SNAPSHOT</version>\n  <versioning>\n    <snapshot>\n      <timestamp>20230930.025126</timestamp>\n      <buildNumber>29</buildNumber>\n    </snapshot>\n    <lastUpdated>20230930025126</lastUpdated>\n    <snapshotVersions>\n      <snapshotVersion>\n        <extension>pom</extension>\n        <value>1.0-20230930.025126-29</value>\n        <updated>20230930025126</updated>\n      </snapshotVersion>\n    </snapshotVersions>\n  </versioning>\n</metadata>",
+      "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata modelVersion=\"1.1.0\">\n  <groupId>com.runtimeverification.k</groupId>\n  <artifactId>parent</artifactId>\n  <version>1.0-SNAPSHOT</version>\n  <versioning>\n    <snapshot>\n      <timestamp>20231003.172408</timestamp>\n      <buildNumber>30</buildNumber>\n    </snapshot>\n    <lastUpdated>20231003172408</lastUpdated>\n    <snapshotVersions>\n      <snapshotVersion>\n        <extension>pom</extension>\n        <value>1.0-20231003.172408-30</value>\n        <updated>20231003172408</updated>\n      </snapshotVersion>\n    </snapshotVersions>\n  </versioning>\n</metadata>",
       "path": "com/runtimeverification/k/parent/1.0-SNAPSHOT"
     }
   ],


### PR DESCRIPTION
This PR introduces the `--debug-command` to the `llvm-krun` flag that enables the use of GDB and LLDB in a non-iterative mode by passing a file with the debugger commands appropriate for the OS.

This PR is part of #840 and will enable testing the debugger on the CI.