### PR TITLE
Fix type printing in LLVM >= 16

### DIFF
--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -201,7 +201,7 @@ public:
 class FunctionNode : public DecisionNode {
 private:
   /* the list of arguments to the function. */
-  std::vector<var_type> bindings;
+  std::vector<std::pair<var_type, ValueType>> bindings;
   /* the name of the variable to bind to the result of the function. */
   std::string name;
   /* the name of the function to call */
@@ -227,9 +227,11 @@ public:
     return new FunctionNode(name, function, child, cat, type);
   }
 
-  const std::vector<var_type> &getBindings() const { return bindings; }
+  const std::vector<std::pair<var_type, ValueType>> &getBindings() const {
+    return bindings;
+  }
   void addBinding(std::string name, ValueType type, llvm::Module *mod) {
-    bindings.push_back(std::make_pair(name, getParamType(type, mod)));
+    bindings.push_back({{name, getParamType(type, mod)}, type});
   }
 
   virtual void codegen(Decision *d);

--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -2,6 +2,7 @@
 #define DECISION_H
 
 #include "kllvm/ast/AST.h"
+#include "kllvm/codegen/CreateTerm.h"
 #include "kllvm/codegen/DecisionParser.h"
 
 #include <llvm/ADT/APInt.h>
@@ -110,8 +111,8 @@ public:
 
   KORESymbol *getConstructor() const { return constructor; }
   const std::vector<var_type> &getBindings() const { return bindings; }
-  void addBinding(std::string name, llvm::Type *type) {
-    bindings.push_back(std::make_pair(name, type));
+  void addBinding(std::string name, ValueType type, llvm::Module *mod) {
+    bindings.push_back(std::make_pair(name, getParamType(type, mod)));
   }
   llvm::APInt getLiteral() const { return literal; }
   DecisionNode *getChild() const { return child; }
@@ -227,8 +228,8 @@ public:
   }
 
   const std::vector<var_type> &getBindings() const { return bindings; }
-  void addBinding(std::string name, llvm::Type *type) {
-    bindings.push_back(std::make_pair(name, type));
+  void addBinding(std::string name, ValueType type, llvm::Module *mod) {
+    bindings.push_back(std::make_pair(name, getParamType(type, mod)));
   }
 
   virtual void codegen(Decision *d);
@@ -262,8 +263,8 @@ public:
   }
 
   const std::vector<var_type> &getBindings() const { return bindings; }
-  void addBinding(std::string name, llvm::Type *type) {
-    bindings.push_back(std::make_pair(name, type));
+  void addBinding(std::string name, ValueType type, llvm::Module *mod) {
+    bindings.push_back(std::make_pair(name, getParamType(type, mod)));
   }
   void setChild(DecisionNode *child) { this->child = child; }
 

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -415,5 +415,6 @@ void init_float2(floating *, std::string);
 std::string intToStringInBase(mpz_t, uint64_t);
 std::string intToString(mpz_t);
 void printValueOfType(
-    std::ostream &os, std::string definitionPath, void *, std::string);
+    std::ostream &os, std::string const &definitionPath, void *value,
+    std::string const &type);
 #endif // RUNTIME_HEADER_H

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -138,12 +138,10 @@ public:
       if (occurrence.size() == 3 && occurrence[0] == "lit"
           && occurrence[2] == "MINT.MInt 64") {
         result->addBinding(
-            occurrence[1],
-            getParamType(KORECompositeSort::getCategory(hook), mod));
+            occurrence[1], KORECompositeSort::getCategory(hook), mod);
       } else {
         result->addBinding(
-            to_string(occurrence),
-            getParamType(KORECompositeSort::getCategory(hook), mod));
+            to_string(occurrence), KORECompositeSort::getCategory(hook), mod);
       }
     }
     return result;
@@ -306,7 +304,7 @@ public:
       auto occurrence = vec(get(var, 0));
       auto hook = str(get(var, 1));
       ValueType cat = KORECompositeSort::getCategory(hook);
-      result->addBinding(to_string(occurrence), getParamType(cat, mod));
+      result->addBinding(to_string(occurrence), cat, mod);
     }
     if (auto next = get(node, "next")) {
       auto child = (*this)(next);

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -351,8 +351,8 @@ extern "C" void printMatchResult(
 }
 
 void printValueOfType(
-    std::ostream &os, std::string definitionPath, void *value,
-    std::string type) {
+    std::ostream &os, std::string const &definitionPath, void *value,
+    std::string const &type) {
   if (type.compare("%mpz*") == 0) {
     os << reinterpret_cast<mpz_ptr>(value);
   } else if (type.compare("%block*") == 0) {

--- a/test/k-rule-apply/definition.kore
+++ b/test/k-rule-apply/definition.kore
@@ -1,4 +1,3 @@
-// XFAIL: opaque-pointers
 // RUN: %kompile %s c
 // RUN: %apply-rule %S TEST.testArray %input-dir/`basename %S`/foo_Array_Success.in %S/definition.o | diff - %output-dir/`basename %S`/foo_Array_Success.out.diff
 // RUN: %apply-rule %S TEST.testArray %input-dir/`basename %S`/foo_Array_Fail.in %S/definition.o | diff - %output-dir/`basename %S`/foo_Array_Fail.out.diff


### PR DESCRIPTION
This PR fixes https://github.com/runtimeverification/llvm-backend/issues/810, the last outstanding bit of migration that needed to happen for us to support LLVM 16+ opaque pointers. The full context for this change is in the original issue.

To fix the issue, we need to delay the conversion from `ValueType` to `llvm::Type *` until a deeper point in the call stack when emitting calls to `addMatchFunction`. The changes here are designed to minimise the surface area of modified code; we can get away without changing the `MatchLog` data structure or the `printValueOfType` function by just converting `ValueType`s to an _imitation_ of the legacy LLVM type strings. We might want to revisit this architecture in the future, but for now I'm happy with the design.

The changes made here are tested by the tests for `k-rule-apply`; on platforms with LLVM 16+ we had marked these tests as expectedly failing, and we just remove that label here. In the second commit you can see CI failing because the `XFAIL` is incorrect.