### PR TITLE
Remove old interpreter input when running tests

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -129,8 +129,8 @@ config.substitutions.extend([
         done
     ''')),
 
-    ('%run-binary-out', '%t.interpreter %test-input -1 %t.out.bin --binary-output'),
-    ('%run-binary', '%convert-input && %t.interpreter %t.bin -1 /dev/stdout'),
+    ('%run-binary-out', 'rm -f %t.out.bin && %t.interpreter %test-input -1 %t.out.bin --binary-output'),
+    ('%run-binary', 'rm -f %t.bin && %convert-input && %t.interpreter %t.bin -1 /dev/stdout'),
     ('%run-proof-out', '%t.interpreter %test-input -1 %t.out.bin --proof-output'),
     ('%run', '%t.interpreter %test-input -1 /dev/stdout'),
 


### PR DESCRIPTION
This PR makes a small change to the `lit` lines we use to run checks on interpreter output; currently they can receive partially stale input if the test suite has previously been run. The solution is simply to remove any old output from previous interpreter runs before we run them again.

Fixes #863 