### PR TITLE
Fix flaky IO test

### DIFF
--- a/test/defn/io.kore
+++ b/test/defn/io.kore
@@ -1,8 +1,9 @@
+// RUN: rm -f %S/*io_log*
 // RUN: %interpreter
 // RUN: %check-dir-grep
 // RUN: diff %S/io_output1.txt %output-dir/ioTest1.output
-// RUN: diff %S/`ls %S | grep io_log` %output-dir/ioTest3.output
-// RUN: (ls %S | grep io_log && rm %S/`ls %S | grep io_log`) || true
+// RUN: diff %S/*io_log* %output-dir/ioTest3.output
+// RUN: ls %S | grep -q io_log
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/llvm-backend/test/defn/k-files/io.k)")]
 
 module BASIC-K


### PR DESCRIPTION
Similarly to https://github.com/runtimeverification/llvm-backend/pull/864, this PR addresses a flaky test that can be left in an intermediate state between runs of the test suite. In this case, we solve the problem by cleaning up all old `io_log.txt` files _before_ the relevant test runs, rather than at the end.