### PR TITLE
Hotfix for K LLVM backend update

### DIFF
--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -7,10 +7,17 @@
 #endif
 
 #include <llvm/IR/LegacyPassManager.h>
+
+#if LLVM_VERSION_MAJOR >= 17
+#include <llvm/TargetParser/Host.h>
+#include <llvm/TargetParser/SubtargetFeature.h>
+#else
 #include <llvm/MC/SubtargetFeature.h>
+#include <llvm/Support/Host.h>
+#endif
+
 #include <llvm/Pass.h>
 #include <llvm/Support/CommandLine.h>
-#include <llvm/Support/Host.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 #include <llvm/Transforms/Scalar.h>

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -73,7 +73,7 @@ void generate_object_file(llvm::Module &mod, llvm::raw_ostream &os) {
   }
 #endif
 
-  auto triple = sys::getDefaultTargetTriple();
+  auto triple = "@BACKEND_TARGET_TRIPLE@";
   mod.setTargetTriple(triple);
 
   auto error = std::string{};

--- a/lib/codegen/CMakeLists.txt
+++ b/lib/codegen/CMakeLists.txt
@@ -1,8 +1,9 @@
 configure_file(CreateTerm.cpp CreateTerm.cpp @ONLY)
+configure_file(ApplyPasses.cpp ApplyPasses.cpp @ONLY)
 
 add_library(Codegen
   ${CMAKE_CURRENT_BINARY_DIR}/CreateTerm.cpp
-  ApplyPasses.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/ApplyPasses.cpp
   CreateStaticTerm.cpp
   Debug.cpp
   Decision.cpp

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -77,7 +77,13 @@ def one_line(s):
 
 config.substitutions.extend([
     ('%kompile', 'llvm-kompile-testing'),
-    ('%interpreter', '%kompile %s main -o %t.interpreter'),
+    ('%interpreter', one_line('''
+        output=$(%kompile %s main -o %t.interpreter 2>&1)
+        if [[ -n "$output" ]]; then
+            echo "llvm-kompile error or warning: $output"
+            exit 1
+        fi
+    ''')),
     ('%search-interpreter', '%kompile %s search -o %t.interpreter'),
     ('%convert-input', '%kore-convert %test-input -o %t.bin'),
     ('%strip-binary', 'kore-strip'),


### PR DESCRIPTION
This PR is a hotfix for a [broken](https://github.com/runtimeverification/k/pull/3728) backend update job.

When using the new [inlined version of `llvm-kompile`](https://github.com/runtimeverification/llvm-backend/pull/814), we were incorrectly using the result of `sys::getDefaultTargetTriple()` as our target for machine code emission, rather than the consistent value selected by running Clang on an empty input file.

On newer versions of macOS, this produces warnings like:
```
ld: warning: object file (tmp.1YutNb2k5B.o) was built for newer macOS version (14.0) than being linked (10.12)
```
when running `llvm-kompile`. These warnings were silently absorbed by CI as they are just warnings, but they are a) noisy and b) break the K test suite when grepping for error messages in failed compilations (`kompile ... 2>&1 | grep ...`).

The fix is just to use our existing technique for target triple selection in the one place we weren't previously.

Additionally, the PR makes two small related changes:
* Add conditional compilation guards for some LLVM headers that give deprecation warnings in LLVM 17
* Catch future errors of this kind in the backend CI by ensuring that `llvm-kompile` is silent and doesn't pollute `stderr` with extra output when it runs successfully