### PR TITLE
Refactor cmake-configured C++ code

### DIFF
--- a/config/macros.h
+++ b/config/macros.h
@@ -1,3 +1,6 @@
+// The CMake @ symbols in this file break clang-format
+// clang-format off
+
 #ifndef RUNTIME_MACROS_H
 #define RUNTIME_MACROS_H
 
@@ -30,5 +33,8 @@
 #define GDB_SCRIPT_NAME TOSTRING(@GDB_SCRIPT_NAME@)
 
 #define ERROR_TAG @ERROR_TAG@
+
+#define BACKEND_TARGET_DATALAYOUT TOSTRING(@BACKEND_TARGET_DATALAYOUT@)
+#define BACKEND_TARGET_TRIPLE TOSTRING(@BACKEND_TARGET_TRIPLE@)
 
 #endif

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -1,5 +1,7 @@
 #include <kllvm/codegen/ApplyPasses.h>
 
+#include "runtime/header.h"
+
 #if LLVM_VERSION_MAJOR >= 14
 #include <llvm/MC/TargetRegistry.h>
 #else
@@ -80,7 +82,7 @@ void generate_object_file(llvm::Module &mod, llvm::raw_ostream &os) {
   }
 #endif
 
-  auto triple = "@BACKEND_TARGET_TRIPLE@";
+  auto triple = BACKEND_TARGET_TRIPLE;
   mod.setTargetTriple(triple);
 
   auto error = std::string{};

--- a/lib/codegen/CMakeLists.txt
+++ b/lib/codegen/CMakeLists.txt
@@ -1,9 +1,6 @@
-configure_file(CreateTerm.cpp CreateTerm.cpp @ONLY)
-configure_file(ApplyPasses.cpp ApplyPasses.cpp @ONLY)
-
 add_library(Codegen
-  ${CMAKE_CURRENT_BINARY_DIR}/CreateTerm.cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/ApplyPasses.cpp
+  CreateTerm.cpp
+  ApplyPasses.cpp
   CreateStaticTerm.cpp
   Debug.cpp
   Decision.cpp


### PR DESCRIPTION
This PR follows up on #869 to refactor our use of CMake to configure C++ code with build-specific information. Instead of configuring individual files, we push all `@...@` stanzas into `config/macros.h` and use that file as the single source of configured literals.

There is a small change to the implementation of the LLVM header in `CreateTerm.h` to support this.