### PR TITLE
revert Add llvm-backend-matching as an executable #827

### DIFF
--- a/nix/llvm-backend-matching.nix
+++ b/nix/llvm-backend-matching.nix
@@ -1,4 +1,4 @@
-{ jdk11_headless, makeWrapper, buildMaven, src }:
+{ buildMaven, src }:
 
 let
   self = buildMaven {
@@ -12,14 +12,9 @@ let
         "${self}/share/java/llvm-backend-matching-1.0-SNAPSHOT-jar-with-dependencies.jar";
     };
 
-    nativeBuildInputs = [ makeWrapper ];
-
     postInstall = ''
       test -f "$out/share/java/llvm-backend-matching-1.0-SNAPSHOT-jar-with-dependencies.jar"
-
-      makeWrapper ${jdk11_headless}/bin/java $out/bin/llvm-backend-matching \
-          --add-flags "-Xss32m -jar $out/share/java/llvm-backend-matching-1.0-SNAPSHOT-jar-with-dependencies.jar"
-    '';
+      '';
 
     # Add build dependencies
     #

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -51,7 +51,7 @@ let
   };
 
   llvm-backend-matching = import ./llvm-backend-matching.nix {
-    inherit (prev) buildMaven jdk11_headless makeWrapper;
+    inherit (prev) buildMaven;
     src = prev.llvm-backend-matching-src;
   };
 


### PR DESCRIPTION
No longer needed as it has been implemented in the K repo as `llvm-kompile-matching` (https://github.com/runtimeverification/k/pull/3659)