### PR TITLE
Function event proof hint documentation

### DIFF
--- a/docs/proof-trace.md
+++ b/docs/proof-trace.md
@@ -38,7 +38,7 @@ rewrite_trace := rule_ordinal rule_arity variable* delimited_serial_kore
 
 initial_config := delimited_serial_kore
 
-proof_trace := initial_config (function_event|rewrite_trace)*
+proof_trace := function_event* initial_config (function_event|rewrite_trace)*
 ```
 
 ## Notes
@@ -46,3 +46,5 @@ proof_trace := initial_config (function_event|rewrite_trace)*
 - The `rule_arity` should be used to determine how many variable substitutions to read
 - The serialized term for a variable substitution does not begin with the sentinel delimiter.
   This is because the null terminated variable name can act as the sentinel.
+- The `function_event`s at the beginning of the proof_trace are related to configuration initialization.
+- The `relative_position` is a null terminated string of positive integers separated by `:` (ie. `0:1:1`)

--- a/docs/proof-trace.md
+++ b/docs/proof-trace.md
@@ -25,6 +25,9 @@ Here is a BNF styled description of the format
 delimited_serial_kore := 0xffffffffffffffff serialized_term 0xcccccccccccccccc
 
 null_terminated_name := <c-style null terminated string>
+relative_position := [0-9]+(:[0-9]+)* 0x00
+
+function_event := 0xdddddddddddddddd null_terminated_name relative_position
 
 variable := null_terminated_name serialized_term 0xcccccccccccccccc
 
@@ -35,7 +38,7 @@ rewrite_trace := rule_ordinal rule_arity variable* delimited_serial_kore
 
 initial_config := delimited_serial_kore
 
-proof_trace := initial_config rewrite_trace*
+proof_trace := initial_config (function_event|rewrite_trace)*
 ```
 
 ## Notes


### PR DESCRIPTION
This documents the function event in the proof hints that were added in an earlier commit.