### PR TITLE
Drop LLVM <15

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,11 +1,11 @@
 # Dependencies
 
-## Ubuntu 20.04:
+## Ubuntu 22.04:
 
 ```shell
 sudo apt update
 sudo apt install      \
-  clang-12            \
+  clang-15            \
   cmake               \
   curl                \
   flex                \
@@ -17,9 +17,10 @@ sudo apt install      \
   libjemalloc-dev     \
   libmpfr-dev         \
   libyaml-dev         \
-  lld-12              \
-  llvm-12-tools       \
+  lld-15              \
+  llvm-15-tools       \
   maven               \
+  openjdk-17-jdk      \
   pkg-config          \
   python3             \
   python3-pip         \

--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -8,21 +8,9 @@ if (NOT LLVM_FOUND)
   find_package(LLVM 15 QUIET CONFIG)
 endif()
 
-if (NOT LLVM_FOUND)
-  find_package(LLVM 14 QUIET CONFIG)
-endif()
-
-if (NOT LLVM_FOUND)
-  find_package(LLVM 13 QUIET CONFIG)
-endif()
-
-if (NOT LLVM_FOUND)
-  find_package(LLVM 12 QUIET CONFIG)
-endif()
-
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-if (${LLVM_PACKAGE_VERSION} VERSION_LESS 12)
-  message(FATAL_ERROR "LLVM 12 or newer is required")
+if (${LLVM_PACKAGE_VERSION} VERSION_LESS 15)
+  message(FATAL_ERROR "LLVM 15 or newer is required")
 endif()
 
 find_program(OPT opt

--- a/default.nix
+++ b/default.nix
@@ -36,7 +36,7 @@ let
           # Avoid spurious rebuilds by ignoring files that don't affect the build.
           mavenix = import sources."mavenix" { inherit (prev) pkgs; };
         in {
-          llvm-version = 13;
+          llvm-version = 15;
           llvm-backend-build-type = cmakeBuildType;
           inherit (mavenix) buildMaven;
           mavenix-cli = mavenix.cli;

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
           builtins.listToAttrs (lib.imap0 (i: v: { name = "check_${toString i}"; value = v; }) checks);
 
         matrix = builtins.listToAttrs (lib.forEach (lib.cartesianProductOfSets {
-          llvm-version = [12 13 14 15 16];
+          llvm-version = [15 16];
           build-type = ["Debug" "Release" "RelWithDebInfo" "FastBuild" "GcStats"];
         }) (
           args:
@@ -116,15 +116,15 @@
           llvm-backend-release = llvm-backend-16-Release.llvm-backend;
         };
         checks = listToChecks [
-          # Check that the backend compiles on each supported version of LLVM,
-          # but don't run the test suite on all possible configurations.
-          llvm-backend-12-FastBuild.llvm-backend
-          llvm-backend-13-FastBuild.llvm-backend
-          llvm-backend-14-FastBuild.llvm-backend
-          llvm-backend-15-FastBuild.llvm-backend
+          llvm-backend-16-Debug.llvm-backend
+          llvm-backend-16-Release.llvm-backend
+          llvm-backend-16-RelWithDebInfo.llvm-backend
+          llvm-backend-16-GcStats.llvm-backend
+
+          llvm-backend-15-FastBuild.integration-tests
           llvm-backend-16-FastBuild.integration-tests
         ];
-        devShells.default = llvm-backend-15-FastBuild.devShell;
+        devShells.default = llvm-backend-16-FastBuild.devShell;
       }) // {
         # non-system suffixed items should go here
         overlays.default = llvm-backend-overlay;

--- a/include/kllvm/codegen/Util.h
+++ b/include/kllvm/codegen/Util.h
@@ -16,15 +16,18 @@ namespace kllvm {
 // one does not yet exist
 llvm::Function *koreHeapAlloc(std::string name, llvm::Module *module);
 
-// If Value is an instance of llvm::Function, cast and return. Otherwise, print
-// errors and abort.
-llvm::Function *castToFunctionOrAbort(llvm::Value *value);
-
 // getOrInsertFunction on module, aborting on failure
 template <class... Ts>
-static llvm::Function *getOrInsertFunction(llvm::Module *module, Ts... Args) {
-  auto ret = module->getOrInsertFunction(Args...);
-  return castToFunctionOrAbort(ret.getCallee());
+llvm::Function *getOrInsertFunction(llvm::Module *module, Ts... Args) {
+  auto callee = module->getOrInsertFunction(Args...).getCallee();
+  auto func = llvm::dyn_cast<llvm::Function>(callee);
+
+  if (!func) {
+    func->print(llvm::errs());
+    abort();
+  }
+
+  return func;
 }
 
 } // namespace kllvm

--- a/include/kllvm/codegen/Util.h
+++ b/include/kllvm/codegen/Util.h
@@ -23,14 +23,8 @@ llvm::Function *castToFunctionOrAbort(llvm::Value *value);
 // getOrInsertFunction on module, aborting on failure
 template <class... Ts>
 static llvm::Function *getOrInsertFunction(llvm::Module *module, Ts... Args) {
-  llvm::Value *callee;
   auto ret = module->getOrInsertFunction(Args...);
-#if LLVM_VERSION_MAJOR >= 9
-  callee = ret.getCallee();
-#else
-  callee = ret;
-#endif
-  return castToFunctionOrAbort(callee);
+  return castToFunctionOrAbort(ret.getCallee());
 }
 
 llvm::StructType *getTypeByName(llvm::Module *module, std::string name);

--- a/include/kllvm/codegen/Util.h
+++ b/include/kllvm/codegen/Util.h
@@ -27,8 +27,6 @@ static llvm::Function *getOrInsertFunction(llvm::Module *module, Ts... Args) {
   return castToFunctionOrAbort(ret.getCallee());
 }
 
-llvm::StructType *getTypeByName(llvm::Module *module, std::string name);
-
 } // namespace kllvm
 
 #endif // KLLVM_UTIL_H

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -2,14 +2,6 @@
 
 #include "runtime/header.h"
 
-#if LLVM_VERSION_MAJOR >= 14
-#include <llvm/MC/TargetRegistry.h>
-#else
-#include <llvm/Support/TargetRegistry.h>
-#endif
-
-#include <llvm/IR/LegacyPassManager.h>
-
 #if LLVM_VERSION_MAJOR >= 17
 #include <llvm/TargetParser/Host.h>
 #include <llvm/TargetParser/SubtargetFeature.h>
@@ -18,6 +10,8 @@
 #include <llvm/Support/Host.h>
 #endif
 
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/MC/TargetRegistry.h>
 #include <llvm/Pass.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Target/TargetMachine.h>
@@ -68,19 +62,11 @@ void apply_kllvm_opt_passes(llvm::Module &mod) {
 }
 
 void generate_object_file(llvm::Module &mod, llvm::raw_ostream &os) {
-  // The frame-pointer retention code in LLVM 12 and older is tied strongly to
-  // the actual command-line flag used to specify it for code generation, rather
-  // than being decoupled as it is in 13 and newer. Because LLVM 12 will be
-  // deprecated for our purposes sooner rather than later, and is not the
-  // default version for packaged versions of K, we simply disable the FP
-  // feature.
-#if LLVM_VERSION_MAJOR > 12
   if (KeepFramePointer) {
     mod.setFramePointer(FramePointerKind::All);
   } else {
     mod.setFramePointer(FramePointerKind::None);
   }
-#endif
 
   auto triple = BACKEND_TARGET_TRIPLE;
   mod.setTargetTriple(triple);

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -773,14 +773,8 @@ llvm::Value *CreateTerm::createFunctionCall(
     call->setCallingConv(llvm::CallingConv::Tail);
   }
   if (sret) {
-#if LLVM_VERSION_MAJOR >= 12
     llvm::Attribute sretAttr
         = llvm::Attribute::get(Ctx, llvm::Attribute::StructRet, sretType);
-#else
-    (void)sretType;
-    llvm::Attribute sretAttr
-        = llvm::Attribute::get(Ctx, llvm::Attribute::StructRet);
-#endif
     func->arg_begin()->addAttr(sretAttr);
     call->addParamAttr(0, sretAttr);
     return AllocSret;

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -174,27 +174,36 @@ llvm::Type *getParamType(ValueType sort, llvm::Module *Module) {
 }
 
 llvm::StructType *getBlockType(llvm::Module *Module) {
-  return getTypeByName(Module, BLOCK_STRUCT);
+  return llvm::StructType::getTypeByName(Module->getContext(), BLOCK_STRUCT);
 }
 
 llvm::Type *getValueType(ValueType sort, llvm::Module *Module) {
   switch (sort.cat) {
-  case SortCategory::Map: return getTypeByName(Module, MAP_STRUCT);
-  case SortCategory::RangeMap: return getTypeByName(Module, RANGEMAP_STRUCT);
-  case SortCategory::List: return getTypeByName(Module, LIST_STRUCT);
-  case SortCategory::Set: return getTypeByName(Module, SET_STRUCT);
+  case SortCategory::Map:
+    return llvm::StructType::getTypeByName(Module->getContext(), MAP_STRUCT);
+  case SortCategory::RangeMap:
+    return llvm::StructType::getTypeByName(
+        Module->getContext(), RANGEMAP_STRUCT);
+  case SortCategory::List:
+    return llvm::StructType::getTypeByName(Module->getContext(), LIST_STRUCT);
+  case SortCategory::Set:
+    return llvm::StructType::getTypeByName(Module->getContext(), SET_STRUCT);
   case SortCategory::Int:
-    return llvm::PointerType::getUnqual(getTypeByName(Module, INT_STRUCT));
+    return llvm::PointerType::getUnqual(
+        llvm::StructType::getTypeByName(Module->getContext(), INT_STRUCT));
   case SortCategory::Float:
-    return llvm::PointerType::getUnqual(getTypeByName(Module, FLOAT_STRUCT));
+    return llvm::PointerType::getUnqual(
+        llvm::StructType::getTypeByName(Module->getContext(), FLOAT_STRUCT));
   case SortCategory::StringBuffer:
-    return llvm::PointerType::getUnqual(getTypeByName(Module, BUFFER_STRUCT));
+    return llvm::PointerType::getUnqual(
+        llvm::StructType::getTypeByName(Module->getContext(), BUFFER_STRUCT));
   case SortCategory::Bool: return llvm::Type::getInt1Ty(Module->getContext());
   case SortCategory::MInt:
     return llvm::IntegerType::get(Module->getContext(), sort.bits);
   case SortCategory::Symbol:
   case SortCategory::Variable:
-    return llvm::PointerType::getUnqual(getTypeByName(Module, BLOCK_STRUCT));
+    return llvm::PointerType::getUnqual(
+        llvm::StructType::getTypeByName(Module->getContext(), BLOCK_STRUCT));
   case SortCategory::Uncomputed: abort();
   }
 }
@@ -202,7 +211,8 @@ llvm::Type *getValueType(ValueType sort, llvm::Module *Module) {
 llvm::StructType *getBlockType(
     llvm::Module *Module, KOREDefinition *definition,
     const KORESymbol *symbol) {
-  llvm::StructType *BlockHeaderType = getTypeByName(Module, BLOCKHEADER_STRUCT);
+  llvm::StructType *BlockHeaderType = llvm::StructType::getTypeByName(
+      Module->getContext(), BLOCKHEADER_STRUCT);
   llvm::ArrayType *EmptyArrayType
       = llvm::ArrayType::get(llvm::Type::getInt64Ty(Module->getContext()), 0);
   llvm::SmallVector<llvm::Type *, 4> Types;
@@ -229,7 +239,8 @@ uint64_t getBlockHeaderVal(
 llvm::Value *getBlockHeader(
     llvm::Module *Module, KOREDefinition *definition, const KORESymbol *symbol,
     llvm::Type *BlockType) {
-  llvm::StructType *BlockHeaderType = getTypeByName(Module, BLOCKHEADER_STRUCT);
+  llvm::StructType *BlockHeaderType = llvm::StructType::getTypeByName(
+      Module->getContext(), BLOCKHEADER_STRUCT);
   uint64_t headerVal = getBlockHeaderVal(Module, symbol, BlockType);
   return llvm::ConstantStruct::get(
       BlockHeaderType,
@@ -831,8 +842,8 @@ llvm::Value *CreateTerm::notInjectionCase(
     new llvm::StoreInst(ChildValue, ChildPtr, CurrentBlock);
   }
 
-  auto BlockPtr
-      = llvm::PointerType::getUnqual(getTypeByName(Module, BLOCK_STRUCT));
+  auto BlockPtr = llvm::PointerType::getUnqual(
+      llvm::StructType::getTypeByName(Module->getContext(), BLOCK_STRUCT));
   auto bitcast = new llvm::BitCastInst(Block, BlockPtr, "", CurrentBlock);
   if (symbolDecl->getAttributes().count("binder")) {
     auto call = llvm::CallInst::Create(
@@ -1350,9 +1361,12 @@ llvm::Type *getArgType(ValueType cat, llvm::Module *mod) {
   case SortCategory::Set: {
     return getValueType(cat, mod);
   }
-  case SortCategory::Int: return getTypeByName(mod, INT_STRUCT);
-  case SortCategory::Float: return getTypeByName(mod, FLOAT_STRUCT);
-  case SortCategory::StringBuffer: return getTypeByName(mod, BUFFER_STRUCT);
+  case SortCategory::Int:
+    return llvm::StructType::getTypeByName(mod->getContext(), INT_STRUCT);
+  case SortCategory::Float:
+    return llvm::StructType::getTypeByName(mod->getContext(), FLOAT_STRUCT);
+  case SortCategory::StringBuffer:
+    return llvm::StructType::getTypeByName(mod->getContext(), BUFFER_STRUCT);
   case SortCategory::Symbol:
   case SortCategory::Variable: {
     return getBlockType(mod);

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -69,14 +69,9 @@ void initDebugFunction(
     return;
   auto Unit = Dbg->createFile(DbgFile->getFilename(), DbgFile->getDirectory());
   llvm::DIScope *FContext = Unit;
-#if LLVM_VERSION_MAJOR >= 8
   DbgSP = Dbg->createFunction(
       FContext, name, name, Unit, DbgLine, type, DbgLine,
       llvm::DINode::DIFlags::FlagZero, llvm::DISubprogram::SPFlagDefinition);
-#else
-  DbgSP = Dbg->createFunction(
-      FContext, name, name, Unit, DbgLine, type, false, true, DbgLine);
-#endif
   func->setSubprogram(DbgSP);
 }
 

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -506,13 +506,8 @@ void MakeIteratorNode::codegen(Decision *d) {
   llvm::Function *func = getOrInsertFunction(d->Module, hookName, funcType);
   auto call = llvm::CallInst::Create(func, args, "", d->CurrentBlock);
   setDebugLoc(call);
-#if __clang_major__ >= 12
   llvm::Attribute sretAttr
       = llvm::Attribute::get(d->Ctx, llvm::Attribute::StructRet, sretType);
-#else
-  llvm::Attribute sretAttr
-      = llvm::Attribute::get(d->Ctx, llvm::Attribute::StructRet);
-#endif
   func->arg_begin()->addAttr(sretAttr);
   call->addParamAttr(0, sretAttr);
   d->store(std::make_pair(name, type), AllocSret);

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -266,8 +266,9 @@ void SwitchNode::codegen(Decision *d) {
               binding.first.substr(0, max_name_length), d->CurrentBlock);
           break;
         }
-        auto BlockPtr = llvm::PointerType::getUnqual(
-            getTypeByName(d->Module, BLOCK_STRUCT));
+        auto BlockPtr
+            = llvm::PointerType::getUnqual(llvm::StructType::getTypeByName(
+                d->Module->getContext(), BLOCK_STRUCT));
         if (symbolDecl->getAttributes().count("binder")) {
           if (offset == 0) {
             Renamed = llvm::CallInst::Create(
@@ -492,7 +493,8 @@ void MakeIteratorNode::codegen(Decision *d) {
   llvm::Value *arg = d->load(std::make_pair(collection, collectionType));
   args.push_back(arg);
   types.push_back(arg->getType());
-  llvm::Type *sretType = getTypeByName(d->Module, "iter");
+  llvm::Type *sretType
+      = llvm::StructType::getTypeByName(d->Module->getContext(), "iter");
   llvm::Value *AllocSret
       = allocateTerm(sretType, d->CurrentBlock, "koreAllocAlwaysGC");
   AllocSret->setName(name.substr(0, max_name_length));
@@ -777,8 +779,8 @@ void abortWhenStuck(
   symbol = d->getAllSymbols().at(Out.str());
   auto BlockType = getBlockType(Module, d, symbol);
   llvm::Value *Ptr;
-  auto BlockPtr
-      = llvm::PointerType::getUnqual(getTypeByName(Module, BLOCK_STRUCT));
+  auto BlockPtr = llvm::PointerType::getUnqual(
+      llvm::StructType::getTypeByName(Module->getContext(), BLOCK_STRUCT));
   if (symbol->getArguments().empty()) {
     Ptr = llvm::ConstantExpr::getIntToPtr(
         llvm::ConstantInt::get(
@@ -953,7 +955,8 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(
     case SortCategory::Int:
     case SortCategory::Float:
       elements.push_back(llvm::ConstantStruct::get(
-          getTypeByName(module, LAYOUTITEM_STRUCT),
+          llvm::StructType::getTypeByName(
+              module->getContext(), LAYOUTITEM_STRUCT),
           llvm::ConstantInt::get(
               llvm::Type::getInt64Ty(module->getContext()), i++ * 8),
           llvm::ConstantInt::get(
@@ -967,7 +970,9 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(
   }
   auto layoutArr = llvm::ConstantArray::get(
       llvm::ArrayType::get(
-          getTypeByName(module, LAYOUTITEM_STRUCT), elements.size()),
+          llvm::StructType::getTypeByName(
+              module->getContext(), LAYOUTITEM_STRUCT),
+          elements.size()),
       elements);
   auto layout = module->getOrInsertGlobal(
       "layout_item_rule_" + std::to_string(ordinal), layoutArr->getType());
@@ -976,8 +981,9 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(layoutArr);
   }
-  auto ptrTy = llvm::PointerType::getUnqual(
-      llvm::ArrayType::get(getTypeByName(module, LAYOUTITEM_STRUCT), 0));
+  auto ptrTy = llvm::PointerType::getUnqual(llvm::ArrayType::get(
+      llvm::StructType::getTypeByName(module->getContext(), LAYOUTITEM_STRUCT),
+      0));
   auto koreCollect = getOrInsertFunction(
       module, "koreCollect",
       llvm::FunctionType::get(

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -218,8 +218,9 @@ public:
 
     return MakeIteratorNode::Create(
         name, type, name + "_iter",
-        llvm::PointerType::getUnqual(getTypeByName(mod, "iter")), function,
-        child);
+        llvm::PointerType::getUnqual(
+            llvm::StructType::getTypeByName(mod->getContext(), "iter")),
+        function, child);
   }
 
   DecisionNode *iterNext(yaml_node_t *node) {
@@ -231,7 +232,9 @@ public:
     auto child = (*this)(get(node, "next"));
 
     return IterNextNode::Create(
-        iterator, llvm::PointerType::getUnqual(getTypeByName(mod, "iter")),
+        iterator,
+        llvm::PointerType::getUnqual(
+            llvm::StructType::getTypeByName(mod->getContext(), "iter")),
         name, type, function, child);
   }
 

--- a/lib/codegen/Util.cpp
+++ b/lib/codegen/Util.cpp
@@ -22,13 +22,4 @@ llvm::Function *koreHeapAlloc(std::string name, llvm::Module *module) {
   return getOrInsertFunction(module, name, allocType);
 }
 
-llvm::Function *castToFunctionOrAbort(llvm::Value *value) {
-  llvm::Function *func = llvm::dyn_cast<llvm::Function>(value);
-  if (!func) {
-    value->print(llvm::errs());
-    abort();
-  }
-  return func;
-}
-
 } // namespace kllvm

--- a/lib/codegen/Util.cpp
+++ b/lib/codegen/Util.cpp
@@ -31,8 +31,4 @@ llvm::Function *castToFunctionOrAbort(llvm::Value *value) {
   return func;
 }
 
-llvm::StructType *getTypeByName(llvm::Module *module, std::string name) {
-  return llvm::StructType::getTypeByName(module->getContext(), name);
-}
-
 } // namespace kllvm

--- a/lib/codegen/Util.cpp
+++ b/lib/codegen/Util.cpp
@@ -32,13 +32,7 @@ llvm::Function *castToFunctionOrAbort(llvm::Value *value) {
 }
 
 llvm::StructType *getTypeByName(llvm::Module *module, std::string name) {
-  llvm::StructType *t;
-#if LLVM_VERSION_MAJOR >= 12
-  t = llvm::StructType::getTypeByName(module->getContext(), name);
-#else
-  t = module->getTypeByName(name);
-#endif
-  return t;
+  return llvm::StructType::getTypeByName(module->getContext(), name);
 }
 
 } // namespace kllvm


### PR DESCRIPTION
Having dropped support for Ubuntu Focal in K, we no longer need to support versions of LLVM older than 15; this PR makes the required changes to the backend to drop support for those older versions. I will follow up with a K PR to update the corresponding documentation.

Fixes https://github.com/runtimeverification/llvm-backend/issues/868