### PR TITLE
Use domain value argument sort if possible

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -12,9 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Check that C and C++ code is correctly formatted
-      uses: jidicula/clang-format-action@v4.8.0
+      uses: jidicula/clang-format-action@v4.11.0
       with:
         exclude-regex: '(build|config|deps)'
+        clang-format-version: 17
 
   shell-check:
     name: Shell check

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -390,8 +390,8 @@ public:
   virtual sptr<KOREPattern> substitute(const substitution &) = 0;
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) = 0;
 
-  virtual void
-  prettyPrint(std::ostream &, PrettyPrintData const &data) const = 0;
+  virtual void prettyPrint(std::ostream &, PrettyPrintData const &data) const
+      = 0;
   virtual sptr<KOREPattern> sortCollections(PrettyPrintData const &data) = 0;
   std::set<std::string> gatherSingletonVars(void);
   virtual std::map<std::string, int> gatherVarCounts(void) = 0;
@@ -540,7 +540,16 @@ public:
         new KORECompositePattern(std::move(newSym)));
   }
 
-  sptr<KORESort> getSort() const override { return constructor->getSort(); }
+  sptr<KORESort> getSort() const override {
+    if (constructor->getName() == "\\dv"
+        && !constructor->getFormalArguments().empty()) {
+      if (auto arg = constructor->getFormalArguments()[0]) {
+        return arg;
+      }
+    }
+
+    return constructor->getSort();
+  }
 
   KORESymbol *getConstructor() const { return constructor.get(); }
   const std::vector<sptr<KOREPattern>> &getArguments() const {

--- a/tools/k-rule-apply/auxiliar.h
+++ b/tools/k-rule-apply/auxiliar.h
@@ -65,9 +65,8 @@ void *printMatchResult(
   if (funcPtr == NULL) {
     return NULL;
   }
-  auto f = reinterpret_cast<
-      void *(*)(std::ostream &, MatchLog *, size_t, std::string const &)>(
-      funcPtr);
+  auto f = reinterpret_cast<void *(*)(std::ostream &, MatchLog *, size_t,
+                                      std::string const &)>(funcPtr);
   return f(os, log, logSize, dir);
 }
 


### PR DESCRIPTION
This PR implements a feature requested by @gtrepta whereby `getSort()` calls on _domain value_ patterns that are part of a definition will return the first formal sort argument (e.g. `SortX{}` in `\dv{SortX{}}("...")` rather than `nullptr`. Doing so simplifies printing and serialization logic in some parts of the backend.

As well as CI passing, I have tested this on upstream K and it does not appear to break anything; my suspicion is that we just weren't relying on these sorts being `nullptr` previously.

The PR also pins a specific version of `clang-format`, which we weren't doing previously.