### PR TITLE
Refactoring proof trace code

### DIFF
--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -79,24 +79,24 @@ private:
   llvm::LoadInst *emitGetOutputFileName(llvm::BasicBlock *insertAtEnd);
 
 public:
-  llvm::BasicBlock *
+  [[nodiscard]] llvm::BasicBlock *
   hookEvent_pre(std::string name, llvm::BasicBlock *current_block);
 
-  llvm::BasicBlock *hookEvent_post(
+  [[nodiscard]] llvm::BasicBlock *hookEvent_post(
       llvm::Value *val, KORECompositeSort *sort,
       llvm::BasicBlock *current_block);
 
-  llvm::BasicBlock *hookArg(
+  [[nodiscard]] llvm::BasicBlock *hookArg(
       llvm::Value *val, KORECompositeSort *sort,
       llvm::BasicBlock *current_block);
 
-  llvm::BasicBlock *rewriteEvent(
+  [[nodiscard]] llvm::BasicBlock *rewriteEvent(
       KOREAxiomDeclaration *axiom, llvm::Value *return_value, uint64_t arity,
       std::map<std::string, KOREVariablePattern *> vars,
       llvm::StringMap<llvm::Value *> const &subst,
       llvm::BasicBlock *current_block);
 
-  llvm::BasicBlock *functionEvent(
+  [[nodiscard]] llvm::BasicBlock *functionEvent(
       llvm::BasicBlock *current_block, KORECompositePattern *pattern,
       std::string const &locationStack);
 

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -32,6 +32,17 @@ private:
       KORECompositeSort &sort, llvm::Value *outputFile, llvm::Value *term,
       llvm::BasicBlock *insertAtEnd);
 
+  /* 
+   * Emit an instruction that has no effect and will be removed by optimization
+   * passes.
+   *
+   * We need this workaround because some callsites will try to use
+   * llvm::Instruction::insertAfter on the back of the MergeBlock after a proof
+   * branch is created. If the MergeBlock has no instructions, this has resulted
+   * in a segfault when printing the IR. Adding an effective no-op prevents this.
+   */
+  llvm::BinaryOperator *emitNoOp(llvm::BasicBlock *insertAtEnd);
+
 public:
   llvm::BasicBlock *hookEvent_pre(std::string name);
   llvm::BasicBlock *hookEvent_post(llvm::Value *val, KORECompositeSort *sort);

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -48,6 +48,13 @@ private:
   llvm::CallInst *emitWriteUInt64(
       llvm::Value *outputFile, uint64_t value, llvm::BasicBlock *insertAtEnd);
 
+  /*
+   * Emit a call that will serialize `str` to the specified `outputFile`.
+   */
+  llvm::CallInst *emitWriteString(
+      llvm::Value *outputFile, std::string const &str,
+      llvm::BasicBlock *insertAtEnd);
+
   /* 
    * Emit an instruction that has no effect and will be removed by optimization
    * passes.

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -9,7 +9,7 @@
 
 namespace kllvm {
 
-void writeUInt64(
+llvm::CallInst *writeUInt64(
     llvm::Value *outputFile, llvm::Module *Module, uint64_t value,
     llvm::BasicBlock *Block);
 
@@ -25,12 +25,17 @@ private:
 
   /*
    * Emit a call that will serialize `term` to the specified `outputFile` as
-   * binary KORE. The returned call instruction is inserted at the end of the
-   * basic block `insertAtEnd`.
+   * binary KORE.
    */
   llvm::CallInst *emitSerializeTerm(
       KORECompositeSort &sort, llvm::Value *outputFile, llvm::Value *term,
       llvm::BasicBlock *insertAtEnd);
+
+  /*
+   * Emit a call that will serialize `value` to the specified `outputFile`.
+   */
+  llvm::CallInst *emitWriteUInt64(
+      llvm::Value *outputFile, uint64_t value, llvm::BasicBlock *insertAtEnd);
 
   /* 
    * Emit an instruction that has no effect and will be removed by optimization

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -11,10 +11,6 @@
 
 namespace kllvm {
 
-llvm::CallInst *writeUInt64(
-    llvm::Value *outputFile, llvm::Module *Module, uint64_t value,
-    llvm::BasicBlock *Block);
-
 class ProofEvent {
 private:
   KOREDefinition *Definition;

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -7,6 +7,8 @@
 
 #include "llvm/IR/Instructions.h"
 
+#include <map>
+
 namespace kllvm {
 
 llvm::CallInst *writeUInt64(
@@ -73,6 +75,12 @@ public:
 
   llvm::BasicBlock *hookArg(
       llvm::Value *val, KORECompositeSort *sort,
+      llvm::BasicBlock *current_block);
+
+  llvm::BasicBlock *rewriteEvent(
+      KOREAxiomDeclaration *axiom, llvm::Value *return_value, uint64_t arity,
+      std::map<std::string, KOREVariablePattern *> vars,
+      llvm::StringMap<llvm::Value *> const &subst,
       llvm::BasicBlock *current_block);
 
 public:

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -19,8 +19,18 @@ private:
   llvm::BasicBlock *CurrentBlock;
   llvm::Module *Module;
   llvm::LLVMContext &Ctx;
+
   std::pair<llvm::BasicBlock *, llvm::BasicBlock *>
   proofBranch(std::string label);
+
+  /*
+   * Emit a call that will serialize `term` to the specified `outputFile` as
+   * binary KORE. The returned call instruction is inserted at the end of the
+   * basic block `insertAtEnd`.
+   */
+  llvm::CallInst *emitSerializeTerm(
+      KORECompositeSort &sort, llvm::Value *outputFile, llvm::Value *term,
+      llvm::BasicBlock *insertAtEnd);
 
 public:
   llvm::BasicBlock *hookEvent_pre(std::string name);

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -8,6 +8,7 @@
 #include "llvm/IR/Instructions.h"
 
 #include <map>
+#include <tuple>
 
 namespace kllvm {
 
@@ -29,6 +30,17 @@ private:
    */
   std::pair<llvm::BasicBlock *, llvm::BasicBlock *>
   proofBranch(std::string const &label, llvm::BasicBlock *insertAtEnd);
+
+  /*
+   * Set up a standard event prelude by creating a pair of basic blocks for the
+   * proof output and continuation, then loading the output filename from its
+   * global.
+   *
+   * Returns a triple [proof enabled, merge, output_file]; see `proofBranch` and
+   * `emitGetOutputFileName`.
+   */
+  std::tuple<llvm::BasicBlock *, llvm::BasicBlock *, llvm::Value *>
+  eventPrelude(std::string const &label, llvm::BasicBlock *insertAtEnd);
 
   /*
    * Emit a call that will serialize `term` to the specified `outputFile` as

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -16,7 +16,6 @@ llvm::CallInst *writeUInt64(
 class ProofEvent {
 private:
   KOREDefinition *Definition;
-  llvm::BasicBlock *CurrentBlock;
   llvm::Module *Module;
   llvm::LLVMContext &Ctx;
 
@@ -32,12 +31,6 @@ private:
    */
   std::pair<llvm::BasicBlock *, llvm::BasicBlock *>
   proofBranch(std::string const &label, llvm::BasicBlock *insertAtEnd);
-
-  /*
-   * Overload to branch at the end of CurrentBlock
-   */
-  std::pair<llvm::BasicBlock *, llvm::BasicBlock *>
-  proofBranch(std::string const &label);
 
   /*
    * Emit a call that will serialize `term` to the specified `outputFile` as
@@ -71,16 +64,20 @@ private:
   llvm::LoadInst *emitGetOutputFileName(llvm::BasicBlock *insertAtEnd);
 
 public:
-  llvm::BasicBlock *hookEvent_pre(std::string name);
-  llvm::BasicBlock *hookEvent_post(llvm::Value *val, KORECompositeSort *sort);
-  llvm::BasicBlock *hookArg(llvm::Value *val, KORECompositeSort *sort);
+  llvm::BasicBlock *
+  hookEvent_pre(std::string name, llvm::BasicBlock *current_block);
+
+  llvm::BasicBlock *hookEvent_post(
+      llvm::Value *val, KORECompositeSort *sort,
+      llvm::BasicBlock *current_block);
+
+  llvm::BasicBlock *hookArg(
+      llvm::Value *val, KORECompositeSort *sort,
+      llvm::BasicBlock *current_block);
 
 public:
-  ProofEvent(
-      KOREDefinition *Definition, llvm::BasicBlock *EntryBlock,
-      llvm::Module *Module)
+  ProofEvent(KOREDefinition *Definition, llvm::Module *Module)
       : Definition(Definition)
-      , CurrentBlock(EntryBlock)
       , Module(Module)
       , Ctx(Module->getContext()) { }
 };

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -48,6 +48,12 @@ private:
    */
   llvm::BinaryOperator *emitNoOp(llvm::BasicBlock *insertAtEnd);
 
+  /*
+   * Emit instructions to load the path of the interpreter's current output
+   * file; used here for binary proof trace data.
+   */
+  llvm::LoadInst *emitGetOutputFileName(llvm::BasicBlock *insertAtEnd);
+
 public:
   llvm::BasicBlock *hookEvent_pre(std::string name);
   llvm::BasicBlock *hookEvent_post(llvm::Value *val, KORECompositeSort *sort);

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -100,6 +100,10 @@ public:
       llvm::StringMap<llvm::Value *> const &subst,
       llvm::BasicBlock *current_block);
 
+  llvm::BasicBlock *functionEvent(
+      llvm::BasicBlock *current_block, KORECompositePattern *pattern,
+      std::string const &locationStack);
+
 public:
   ProofEvent(KOREDefinition *Definition, llvm::Module *Module)
       : Definition(Definition)

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -36,10 +36,20 @@ private:
 
   /*
    * Emit a call that will serialize `term` to the specified `outputFile` as
-   * binary KORE.
+   * binary KORE. This function can be called on any term, but the sort of that
+   * term must be known.
    */
   llvm::CallInst *emitSerializeTerm(
       KORECompositeSort &sort, llvm::Value *outputFile, llvm::Value *term,
+      llvm::BasicBlock *insertAtEnd);
+
+  /*
+   * Emit a call that will serialize `config` to the specified `outputFile` as
+   * binary KORE. This function does not require a sort, but the configuration
+   * passed must be a top-level configuration.
+   */
+  llvm::CallInst *emitSerializeConfiguration(
+      llvm::Value *outputFile, llvm::Value *config,
       llvm::BasicBlock *insertAtEnd);
 
   /*

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -20,8 +20,24 @@ private:
   llvm::Module *Module;
   llvm::LLVMContext &Ctx;
 
+  /*
+   * Load the boolean flag that controls whether proof hint output is enabled or
+   * not, then create a branch at the end of this basic block depending on the
+   * result.
+   *
+   * Returns a pair of blocks [proof enabled, merge]; the first of these is
+   * intended for self-contained behaviour only relevant in proof output mode,
+   * while the second is for the continuation of the interpreter's previous
+   * behaviour.
+   */
   std::pair<llvm::BasicBlock *, llvm::BasicBlock *>
-  proofBranch(std::string label);
+  proofBranch(std::string const &label, llvm::BasicBlock *insertAtEnd);
+
+  /*
+   * Overload to branch at the end of CurrentBlock
+   */
+  std::pair<llvm::BasicBlock *, llvm::BasicBlock *>
+  proofBranch(std::string const &label);
 
   /*
    * Emit a call that will serialize `term` to the specified `outputFile` as

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -698,7 +698,7 @@ llvm::Value *CreateTerm::createFunctionCall(
   }
 
   auto event = ProofEvent(Definition, Module);
-  event.functionEvent(CurrentBlock, pattern, locationStack);
+  CurrentBlock = event.functionEvent(CurrentBlock, pattern, locationStack);
 
   return createFunctionCall(name, returnCat, args, sret, tailcc, locationStack);
 }
@@ -1070,7 +1070,7 @@ bool makeFunction(
   auto CurrentBlock = creator.getCurrentBlock();
   if (apply && bigStep) {
     auto event = ProofEvent(definition, Module);
-    event.rewriteEvent(
+    CurrentBlock = event.rewriteEvent(
         axiom, retval, applyRule->arg_end() - applyRule->arg_begin(), vars,
         subst, CurrentBlock);
   }

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 
 #include "runtime/header.h" //for macros
+
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -116,10 +117,6 @@ declare void @printConfiguration(i8 *, %block *)
   return target_dependent + rest;
 }
 } // namespace
-
-void writeUInt64(
-    llvm::Value *outputFile, llvm::Module *Module, uint64_t value,
-    llvm::BasicBlock *Block);
 
 std::unique_ptr<llvm::Module>
 newModule(std::string name, llvm::LLVMContext &Context) {

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1110,91 +1110,10 @@ bool makeFunction(
 
   auto CurrentBlock = creator.getCurrentBlock();
   if (apply && bigStep) {
-    auto ProofOutputFlag = Module->getOrInsertGlobal(
-        "proof_output", llvm::Type::getInt1Ty(Module->getContext()));
-    auto OutputFileName = Module->getOrInsertGlobal(
-        "output_file", llvm::Type::getInt8PtrTy(Module->getContext()));
-    auto proofOutput = new llvm::LoadInst(
-        llvm::Type::getInt1Ty(Module->getContext()), ProofOutputFlag,
-        "proof_output", CurrentBlock);
-    llvm::BasicBlock *TrueBlock
-        = llvm::BasicBlock::Create(Module->getContext(), "if", applyRule);
-    auto ir = new llvm::IRBuilder(TrueBlock);
-    llvm::BasicBlock *MergeBlock
-        = llvm::BasicBlock::Create(Module->getContext(), "tail", applyRule);
-    llvm::BranchInst::Create(TrueBlock, MergeBlock, proofOutput, CurrentBlock);
-    auto outputFile = new llvm::LoadInst(
-        llvm::Type::getInt8PtrTy(Module->getContext()), OutputFileName,
-        "output", TrueBlock);
-    writeUInt64(outputFile, Module, axiom->getOrdinal(), TrueBlock);
-    writeUInt64(
-        outputFile, Module, applyRule->arg_end() - applyRule->arg_begin(),
-        TrueBlock);
-    for (auto entry = subst.begin(); entry != subst.end(); ++entry) {
-      auto key = entry->getKey();
-      auto val = entry->getValue();
-      auto var = vars[key.str()];
-      auto sort = dynamic_cast<KORECompositeSort *>(var->getSort().get());
-      auto cat = sort->getCategory(definition);
-      std::ostringstream Out;
-      sort->print(Out);
-      auto sortptr = ir->CreateGlobalStringPtr(Out.str(), "", 0, Module);
-      auto varname = ir->CreateGlobalStringPtr(key, "", 0, Module);
-      ir->CreateCall(
-          getOrInsertFunction(
-              Module, "printVariableToFile",
-              llvm::Type::getVoidTy(Module->getContext()),
-              llvm::Type::getInt8PtrTy(Module->getContext()),
-              llvm::Type::getInt8PtrTy(Module->getContext())),
-          {outputFile, varname});
-      if (cat.cat == SortCategory::Symbol
-          || cat.cat == SortCategory::Variable) {
-        ir->CreateCall(
-            getOrInsertFunction(
-                Module, "serializeTermToFile",
-                llvm::Type::getVoidTy(Module->getContext()),
-                llvm::Type::getInt8PtrTy(Module->getContext()),
-                getValueType({SortCategory::Symbol, 0}, Module),
-                llvm::Type::getInt8PtrTy(Module->getContext())),
-            {outputFile, val, sortptr});
-      } else if (val->getType()->isIntegerTy()) {
-        val = ir->CreateIntToPtr(
-            val, llvm::Type::getInt8PtrTy(Module->getContext()));
-        ir->CreateCall(
-            getOrInsertFunction(
-                Module, "serializeRawTermToFile",
-                llvm::Type::getVoidTy(Module->getContext()),
-                llvm::Type::getInt8PtrTy(Module->getContext()),
-                llvm::Type::getInt8PtrTy(Module->getContext()),
-                llvm::Type::getInt8PtrTy(Module->getContext())),
-            {outputFile, val, sortptr});
-      } else {
-        val = ir->CreatePointerCast(
-            val, llvm::Type::getInt8PtrTy(Module->getContext()));
-        ir->CreateCall(
-            getOrInsertFunction(
-                Module, "serializeRawTermToFile",
-                llvm::Type::getVoidTy(Module->getContext()),
-                llvm::Type::getInt8PtrTy(Module->getContext()),
-                llvm::Type::getInt8PtrTy(Module->getContext()),
-                llvm::Type::getInt8PtrTy(Module->getContext())),
-            {outputFile, val, sortptr});
-      }
-      writeUInt64(outputFile, Module, 0xcccccccccccccccc, TrueBlock);
-    }
-
-    writeUInt64(outputFile, Module, 0xffffffffffffffff, TrueBlock);
-    ir->CreateCall(
-        getOrInsertFunction(
-            Module, "serializeConfigurationToFile",
-            llvm::Type::getVoidTy(Module->getContext()),
-            llvm::Type::getInt8PtrTy(Module->getContext()),
-            getValueType({SortCategory::Symbol, 0}, Module)),
-        {outputFile, retval});
-    writeUInt64(outputFile, Module, 0xcccccccccccccccc, TrueBlock);
-
-    llvm::BranchInst::Create(MergeBlock, TrueBlock);
-    CurrentBlock = MergeBlock;
+    auto event = ProofEvent(definition, Module);
+    event.rewriteEvent(
+        axiom, retval, applyRule->arg_end() - applyRule->arg_begin(), vars,
+        subst, CurrentBlock);
   }
 
   if (bigStep) {

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -315,8 +315,8 @@ llvm::Value *CreateTerm::alloc_arg(
   llvm::Value *ret
       = createAllocation(p, fmt::format("{}:{}", locationStack, idx)).first;
   auto sort = dynamic_cast<KORECompositeSort *>(p->getSort().get());
-  ProofEvent e(Definition, CurrentBlock, Module);
-  CurrentBlock = e.hookArg(ret, sort);
+  ProofEvent e(Definition, Module);
+  CurrentBlock = e.hookArg(ret, sort, CurrentBlock);
   return ret;
 }
 
@@ -929,13 +929,12 @@ CreateTerm::createAllocation(KOREPattern *pattern, std::string locationStack) {
                                                     .get());
         std::string name = strPattern->getContents();
 
-        ProofEvent p1(Definition, CurrentBlock, Module);
-        CurrentBlock = p1.hookEvent_pre(name);
+        ProofEvent p(Definition, Module);
+        CurrentBlock = p.hookEvent_pre(name, CurrentBlock);
         llvm::Value *val = createHook(
             symbolDecl->getAttributes().at("hook").get(), constructor,
             locationStack);
-        ProofEvent p2(Definition, CurrentBlock, Module);
-        CurrentBlock = p2.hookEvent_post(val, sort);
+        CurrentBlock = p.hookEvent_post(val, sort, CurrentBlock);
 
         return std::make_pair(val, true);
       } else {

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -1119,7 +1119,7 @@ static llvm::Constant *getOffsetOfMember(
   auto offset
       = llvm::DataLayout(mod).getStructLayout(struct_ty)->getElementOffset(
           nth_member);
-  auto offset_ty = llvm::Type::getInt32Ty(mod->getContext());
+  auto offset_ty = llvm::Type::getInt64Ty(mod->getContext());
   return llvm::ConstantInt::get(offset_ty, offset);
 #else
   return llvm::ConstantExpr::getOffsetOf(struct_ty, nth_member);

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -22,6 +22,15 @@ llvm::Constant *createGlobalSortStringPtr(
       os.str(), fmt::format("{}_str", sort.getName()), 0, mod);
 }
 
+constexpr uint64_t word(uint8_t byte) {
+  auto ret = uint64_t{0};
+  for (auto i = 0u; i < sizeof(ret); ++i) {
+    ret <<= 8;
+    ret |= byte;
+  }
+  return ret;
+}
+
 } // namespace
 
 llvm::CallInst *writeUInt64(
@@ -161,7 +170,7 @@ ProofEvent::hookEvent_pre(std::string name, llvm::BasicBlock *current_block) {
   auto [true_block, merge_block] = proofBranch("hookpre", current_block);
   auto outputFile = emitGetOutputFileName(true_block);
 
-  emitWriteUInt64(outputFile, 0xaaaaaaaaaaaaaaaa, true_block);
+  emitWriteUInt64(outputFile, word(0xAA), true_block);
   emitWriteString(outputFile, name, true_block);
 
   llvm::BranchInst::Create(merge_block, true_block);
@@ -176,7 +185,7 @@ llvm::BasicBlock *ProofEvent::hookEvent_post(
   auto [true_block, merge_block] = proofBranch("hookpost", current_block);
   auto outputFile = emitGetOutputFileName(true_block);
 
-  emitWriteUInt64(outputFile, 0xbbbbbbbbbbbbbbbb, true_block);
+  emitWriteUInt64(outputFile, word(0xBB), true_block);
 
   emitSerializeTerm(*sort, outputFile, val, true_block);
 
@@ -221,12 +230,12 @@ llvm::BasicBlock *ProofEvent::rewriteEvent(
 
     emitWriteString(outputFile, key.str(), true_block);
     emitSerializeTerm(*sort, outputFile, val, true_block);
-    emitWriteUInt64(outputFile, 0xcccccccccccccccc, true_block);
+    emitWriteUInt64(outputFile, word(0xCC), true_block);
   }
 
-  emitWriteUInt64(outputFile, 0xffffffffffffffff, true_block);
+  emitWriteUInt64(outputFile, word(0xFF), true_block);
   emitSerializeConfiguration(outputFile, return_value, true_block);
-  emitWriteUInt64(outputFile, 0xcccccccccccccccc, true_block);
+  emitWriteUInt64(outputFile, word(0xCC), true_block);
 
   llvm::BranchInst::Create(merge_block, true_block);
   return merge_block;

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -216,7 +216,6 @@ llvm::BasicBlock *ProofEvent::rewriteEvent(
     llvm::StringMap<llvm::Value *> const &subst,
     llvm::BasicBlock *current_block) {
   auto [true_block, merge_block] = proofBranch("hookarg", current_block);
-  auto ir = llvm::IRBuilder(true_block);
   auto outputFile = emitGetOutputFileName(true_block);
 
   emitWriteUInt64(outputFile, axiom->getOrdinal(), true_block);
@@ -245,7 +244,6 @@ llvm::BasicBlock *ProofEvent::functionEvent(
     llvm::BasicBlock *current_block, KORECompositePattern *pattern,
     std::string const &locationStack) {
   auto [true_block, merge_block] = proofBranch("hookarg", current_block);
-  auto ir = llvm::IRBuilder(true_block);
   auto outputFile = emitGetOutputFileName(true_block);
 
   std::ostringstream symbolName;

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -31,6 +31,8 @@ constexpr uint64_t word(uint8_t byte) {
   return ret;
 }
 
+static_assert(word(0xAA) == 0xAAAAAAAAAAAAAAAA);
+
 } // namespace
 
 llvm::CallInst *ProofEvent::emitSerializeTerm(

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -241,4 +241,22 @@ llvm::BasicBlock *ProofEvent::rewriteEvent(
   return merge_block;
 }
 
+llvm::BasicBlock *ProofEvent::functionEvent(
+    llvm::BasicBlock *current_block, KORECompositePattern *pattern,
+    std::string const &locationStack) {
+  auto [true_block, merge_block] = proofBranch("hookarg", current_block);
+  auto ir = llvm::IRBuilder(true_block);
+  auto outputFile = emitGetOutputFileName(true_block);
+
+  std::ostringstream symbolName;
+  pattern->getConstructor()->print(symbolName);
+
+  emitWriteUInt64(outputFile, word(0xDD), true_block);
+  emitWriteString(outputFile, symbolName.str(), true_block);
+  emitWriteString(outputFile, locationStack, true_block);
+
+  llvm::BranchInst::Create(merge_block, true_block);
+  return merge_block;
+}
+
 } // namespace kllvm

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -210,7 +210,7 @@ llvm::BasicBlock *ProofEvent::rewriteEvent(
     std::map<std::string, KOREVariablePattern *> vars,
     llvm::StringMap<llvm::Value *> const &subst,
     llvm::BasicBlock *current_block) {
-  auto [true_block, merge_block] = proofBranch("hookarg", current_block);
+  auto [true_block, merge_block] = proofBranch("rewrite", current_block);
   auto outputFile = emitGetOutputFileName(true_block);
 
   emitWriteUInt64(outputFile, axiom->getOrdinal(), true_block);
@@ -240,7 +240,7 @@ llvm::BasicBlock *ProofEvent::rewriteEvent(
 llvm::BasicBlock *ProofEvent::functionEvent(
     llvm::BasicBlock *current_block, KORECompositePattern *pattern,
     std::string const &locationStack) {
-  auto [true_block, merge_block] = proofBranch("hookarg", current_block);
+  auto [true_block, merge_block] = proofBranch("function", current_block);
   auto outputFile = emitGetOutputFileName(true_block);
 
   std::ostringstream symbolName;

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -205,6 +205,10 @@ llvm::BasicBlock *ProofEvent::hookArg(
   return merge_block;
 }
 
+/*
+ * Rewrite Events
+ */
+
 llvm::BasicBlock *ProofEvent::rewriteEvent(
     KOREAxiomDeclaration *axiom, llvm::Value *return_value, uint64_t arity,
     std::map<std::string, KOREVariablePattern *> vars,
@@ -236,6 +240,10 @@ llvm::BasicBlock *ProofEvent::rewriteEvent(
 
   return merge_block;
 }
+
+/*
+ * Function Events
+ */
 
 llvm::BasicBlock *ProofEvent::functionEvent(
     llvm::BasicBlock *current_block, KORECompositePattern *pattern,

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -33,24 +33,6 @@ constexpr uint64_t word(uint8_t byte) {
 
 } // namespace
 
-llvm::CallInst *writeUInt64(
-    llvm::Value *outputFile, llvm::Module *Module, uint64_t value,
-    llvm::BasicBlock *Block) {
-  auto &Ctx = Module->getContext();
-
-  auto void_ty = llvm::Type::getVoidTy(Ctx);
-  auto i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
-  auto i64_ptr_ty = llvm::Type::getInt64Ty(Ctx);
-
-  auto func_ty
-      = llvm::FunctionType::get(void_ty, {i8_ptr_ty, i64_ptr_ty}, false);
-  auto func = getOrInsertFunction(Module, "writeUInt64ToFile", func_ty);
-
-  auto i64_value = llvm::ConstantInt::get(i64_ptr_ty, value);
-
-  return llvm::CallInst::Create(func, {outputFile, i64_value}, "", Block);
-}
-
 llvm::CallInst *ProofEvent::emitSerializeTerm(
     KORECompositeSort &sort, llvm::Value *outputFile, llvm::Value *term,
     llvm::BasicBlock *insert_at_end) {
@@ -106,7 +88,18 @@ llvm::CallInst *ProofEvent::emitSerializeConfiguration(
 
 llvm::CallInst *ProofEvent::emitWriteUInt64(
     llvm::Value *outputFile, uint64_t value, llvm::BasicBlock *insert_at_end) {
-  return writeUInt64(outputFile, Module, value, insert_at_end);
+  auto void_ty = llvm::Type::getVoidTy(Ctx);
+  auto i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
+  auto i64_ptr_ty = llvm::Type::getInt64Ty(Ctx);
+
+  auto func_ty
+      = llvm::FunctionType::get(void_ty, {i8_ptr_ty, i64_ptr_ty}, false);
+  auto func = getOrInsertFunction(Module, "writeUInt64ToFile", func_ty);
+
+  auto i64_value = llvm::ConstantInt::get(i64_ptr_ty, value);
+
+  return llvm::CallInst::Create(
+      func, {outputFile, i64_value}, "", insert_at_end);
 }
 
 llvm::CallInst *ProofEvent::emitWriteString(

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -226,7 +226,7 @@ llvm::BasicBlock *ProofEvent::rewriteEvent(
     auto val = entry->getValue();
     auto var = vars[key.str()];
 
-    auto sort = dynamic_cast<KORECompositeSort *>(var->getSort().get());
+    auto sort = std::dynamic_pointer_cast<KORECompositeSort>(var->getSort());
 
     emitWriteString(outputFile, key.str(), true_block);
     emitSerializeTerm(*sort, outputFile, val, true_block);

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -230,6 +230,8 @@ llvm::BasicBlock *ProofEvent::rewriteEvent(
   emitWriteUInt64(outputFile, word(0xCC), true_block);
 
   llvm::BranchInst::Create(merge_block, true_block);
+  emitNoOp(merge_block);
+
   return merge_block;
 }
 
@@ -247,6 +249,8 @@ llvm::BasicBlock *ProofEvent::functionEvent(
   emitWriteString(outputFile, locationStack, true_block);
 
   llvm::BranchInst::Create(merge_block, true_block);
+  emitNoOp(merge_block);
+
   return merge_block;
 }
 


### PR DESCRIPTION
As discussed previously, this PR is an initial cleanup and refactoring effort for the existing proof-hint generation code implemented for rewrite, function and hook events. The changes in this PR don't add any new features to the traces; they just reorganise the existing code.

Most of the changes made are documentation and identifying duplicated code across different call-sites that can be merged together.

I plan to port the reorganisation in #862 over to the infrastructure in this PR once it is merged.

The trace format is not tested in the backend currently (this is future work), but I have verified that a proof trace (that uses all event types) generated using this branch is byte-for-byte identical to one generated from the current master branch.