### PR TITLE
Flags to turn on/off proof hint instrumenation and output

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -12,28 +12,29 @@ Usage: $0 <definition.kore> <dt_dir> <object type> [options] [clang flags]
    or: $0 <interpreter.o>            <object type> [options] [clang flags]
 
 Options:
-  -h, --help                Print this message and exit.
-  -v, --verbose             Print commands executed to stderr.
-      --profile             Print profiling information to stderr.
-  --save-temps              Do not delete temporary files on exit.
-  --bindings-path           Print the absolute path of the compiled Python bindings for
-                            the LLVM backend, then exit.
-  --include-dir             Print the absolute include path for the LLVM backend
-                            runtime and binding headers, then exit.
-  --use-opt                 Use standalone LLVM opt to apply optimization passes
-                            to the generated LLVM IR for this definition.
-  --emit-ir                 Emit LLVM IR at intermediate compilation steps, rather than
-                            directly generating an object file.
-  --python PATH             The path to a Python interpreter with Pybind installed. Only
-                            meaningful in "python" or "pythonast" mode.
-  --python-output-dir PATH  Output directory to place automatically-named Python
-                            modules. Only meaningful in "python" or "pythonast"
-                            mode.
-  --embed PATH NAME         Embed additional information into shared library
-                            bindings. This is a low-level interface designed to
-                            be called from kompile. Only meaningful in "c" mode.
-  -fno-omit-frame-pointer   Keep the frame pointer in compiled code for debugging purposes.
-  -O[0123]                  Set the optimization level for code generation.
+  -h, --help                   Print this message and exit.
+  -v, --verbose                Print commands executed to stderr.
+      --profile                Print profiling information to stderr.
+  --save-temps                 Do not delete temporary files on exit.
+  --bindings-path              Print the absolute path of the compiled Python bindings for
+                               the LLVM backend, then exit.
+  --include-dir                Print the absolute include path for the LLVM backend
+                               runtime and binding headers, then exit.
+  --use-opt                    Use standalone LLVM opt to apply optimization passes
+                               to the generated LLVM IR for this definition.
+  --emit-ir                    Emit LLVM IR at intermediate compilation steps, rather than
+                               directly generating an object file.
+  --python PATH                The path to a Python interpreter with Pybind installed. Only
+                               meaningful in "python" or "pythonast" mode.
+  --python-output-dir PATH     Output directory to place automatically-named Python
+                               modules. Only meaningful in "python" or "pythonast"
+                               mode.
+  --embed PATH NAME            Embed additional information into shared library
+                               bindings. This is a low-level interface designed to
+                               be called from kompile. Only meaningful in "c" mode.
+  -fno-omit-frame-pointer      Keep the frame pointer in compiled code for debugging purposes.
+  --proof-hint-instrumentation Enable instrumentation for generation of proof hints.
+  -O[0123]                     Set the optimization level for code generation.
 
 Any option not listed above will be passed through to clang; use '--' to
 separate additional positional arguments to clang from those for $0.
@@ -160,6 +161,10 @@ while [[ $# -gt 0 ]]; do
     -fno-omit-frame-pointer)
       kompile_clang_flags+=("$1")
       frame_pointer=true
+      shift
+      ;;
+    --proof-hint-instrumentation)
+      codegen_flags+=("--proof-hint-instrumentation")
       shift
       ;;
     -O*)

--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -24,6 +24,7 @@ verbose=0
 binary_input=false
 binary_output=false
 pretty_print=false
+proof_hints=false
 interpreter_flags=()
 dryRun=false
 expandMacros=true
@@ -65,6 +66,9 @@ Mandatory arguments to long options are mandatory for short options too.
                            KORE format, rather than the textual syntax;
   -p, --pretty-print       Pretty print output configuration. By default,
                            output is in kore syntax
+      --proof-hints        Enable output of proof hints; requires proof hint
+                           instrumentation to have been enabled during
+                           compilation.
       --debug              Use GDB to debug the program
       --debug-batch        Use GDB in batch mode to debug the program
       --debug-command FILE Execute GDB commands from FILE to debug the program
@@ -136,6 +140,11 @@ do
 
     -p|--pretty-print)
     pretty_print=true
+    shift
+    ;;
+
+    --proof-hints)
+    proof_hints=true
     shift
     ;;
 
@@ -221,6 +230,10 @@ fi
 
 if $binary_output; then
   interpreter_flags+=("--binary-output")
+fi
+
+if $proof_hints; then
+  interpreter_flags+=("--proof-output")
 fi
 
 for name in "${pretty[@]}"; do

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -2,8 +2,16 @@
 #include "kllvm/codegen/CreateTerm.h"
 
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/Support/CommandLine.h"
 
 #include <fmt/format.h>
+
+extern llvm::cl::OptionCategory CodegenCat;
+
+llvm::cl::opt<bool> ProofHintInstrumentation(
+    "proof-hint-instrumentation",
+    llvm::cl::desc("Enable instrumentation for generation of proof hints"),
+    llvm::cl::cat(CodegenCat));
 
 namespace kllvm {
 
@@ -171,6 +179,10 @@ ProofEvent::eventPrelude(
 
 llvm::BasicBlock *
 ProofEvent::hookEvent_pre(std::string name, llvm::BasicBlock *current_block) {
+  if (!ProofHintInstrumentation) {
+    return current_block;
+  }
+
   auto [true_block, merge_block, outputFile]
       = eventPrelude("hookpre", current_block);
 
@@ -184,6 +196,10 @@ ProofEvent::hookEvent_pre(std::string name, llvm::BasicBlock *current_block) {
 llvm::BasicBlock *ProofEvent::hookEvent_post(
     llvm::Value *val, KORECompositeSort *sort,
     llvm::BasicBlock *current_block) {
+  if (!ProofHintInstrumentation) {
+    return current_block;
+  }
+
   auto [true_block, merge_block, outputFile]
       = eventPrelude("hookpost", current_block);
 
@@ -198,6 +214,10 @@ llvm::BasicBlock *ProofEvent::hookEvent_post(
 llvm::BasicBlock *ProofEvent::hookArg(
     llvm::Value *val, KORECompositeSort *sort,
     llvm::BasicBlock *current_block) {
+  if (!ProofHintInstrumentation) {
+    return current_block;
+  }
+
   auto [true_block, merge_block, outputFile]
       = eventPrelude("hookarg", current_block);
 
@@ -216,6 +236,10 @@ llvm::BasicBlock *ProofEvent::rewriteEvent(
     std::map<std::string, KOREVariablePattern *> vars,
     llvm::StringMap<llvm::Value *> const &subst,
     llvm::BasicBlock *current_block) {
+  if (!ProofHintInstrumentation) {
+    return current_block;
+  }
+
   auto [true_block, merge_block, outputFile]
       = eventPrelude("rewrite", current_block);
 
@@ -248,6 +272,10 @@ llvm::BasicBlock *ProofEvent::rewriteEvent(
 llvm::BasicBlock *ProofEvent::functionEvent(
     llvm::BasicBlock *current_block, KORECompositePattern *pattern,
     std::string const &locationStack) {
+  if (!ProofHintInstrumentation) {
+    return current_block;
+  }
+
   auto [true_block, merge_block, outputFile]
       = eventPrelude("function", current_block);
 

--- a/test/defn/imp-proof.kore
+++ b/test/defn/imp-proof.kore
@@ -1,4 +1,4 @@
-// RUN: %interpreter
+// RUN: %proof-interpreter
 // RUN: %run-proof-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/gtrepta/runtimeverification/llvm-backend/tmp/imp.k)")]
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -84,6 +84,13 @@ config.substitutions.extend([
             exit 1
         fi
     ''')),
+    ('%proof-interpreter', one_line('''
+        output=$(%kompile %s main --proof-hint-instrumentation -o %t.interpreter 2>&1)
+        if [[ -n "$output" ]]; then
+            echo "llvm-kompile error or warning: $output"
+            exit 1
+        fi
+    ''')),
     ('%search-interpreter', '%kompile %s search -o %t.interpreter'),
     ('%convert-input', '%kore-convert %test-input -o %t.bin'),
     ('%strip-binary', 'kore-strip'),


### PR DESCRIPTION
This PR adds two flags to our scripts to turn the proof hint instrumentation and output on and off:
- a flag `--proof-hint-instrumentation` is added to the `llvm-kompile` script. When the flag is passed the generated llvm code is instrumented with proof hint generation code.
- a flag `--proof-hints` is added to the `llvm-krun` script. When the flag is passed to an instrumented interpreter binary, the binary will output proof hints.