### PR TITLE
Drop ephemeral runner for Flake test

### DIFF
--- a/.github/workflows/test-flake.yml
+++ b/.github/workflows/test-flake.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: [self-hosted, linux, normal-ephemeral]
+          - runner: [self-hosted, linux, normal]
             os: ubuntu-20.04
           - runner: macos-12
             os: macos-12


### PR DESCRIPTION
These tests seem prone to [timing out in the post Cachix step](https://github.com/runtimeverification/llvm-backend/actions/runs/6885333562/job/18729317083?pr=882); this PR attempts to fix the issue by moving the tests off the ephemeral runner and onto regular self-hosted ones.