### PR TITLE
Missing cases for proof instrumentation flag

### DIFF
--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -259,6 +259,10 @@ llvm::BasicBlock *ProofEvent::rewriteEvent_pre(
 llvm::BasicBlock *ProofEvent::rewriteEvent_post(
     KOREAxiomDeclaration *axiom, llvm::Value *return_value,
     llvm::BasicBlock *current_block) {
+  if (!ProofHintInstrumentation) {
+    return current_block;
+  }
+
   auto [true_block, merge_block, output_file]
       = eventPrelude("rewrite_post", current_block);
 
@@ -300,6 +304,10 @@ llvm::BasicBlock *ProofEvent::functionEvent_pre(
 
 llvm::BasicBlock *
 ProofEvent::functionEvent_post(llvm::BasicBlock *current_block) {
+  if (!ProofHintInstrumentation) {
+    return current_block;
+  }
+
   auto [true_block, merge_block, outputFile]
       = eventPrelude("function_post", current_block);
 


### PR DESCRIPTION
We were incorrectly emitting proof instrumentation when these event functions were called; this PR adds the same flag check to their preludes as the other events have. I have verified that there is no proof-related generated code in the module produced by the code generator after this change.