### PR TITLE
Expose sort parser to Python bindings

### DIFF
--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -332,6 +332,7 @@ void bind_parser(py::module_ &mod) {
       .def(
           "pattern",
           [](KOREParser &parser) { return std::shared_ptr(parser.pattern()); })
+      .def("sort", [](KOREParser &parser) { return parser.sort(); })
       .def("definition", [](KOREParser &parser) {
         return std::shared_ptr(parser.definition());
       });

--- a/include/kllvm/parser/KOREParser.h
+++ b/include/kllvm/parser/KOREParser.h
@@ -21,10 +21,10 @@ public:
 
   static std::unique_ptr<KOREParser> from_string(std::string text);
 
-  ptr<KOREDefinition> definition(void);
-  sptr<KOREPattern> pattern(void);
-  sptr<KORESort> sort(void);
-  std::vector<ptr<KOREDeclaration>> declarations(void);
+  ptr<KOREDefinition> definition();
+  sptr<KOREPattern> pattern();
+  sptr<KORESort> sort();
+  std::vector<ptr<KOREDeclaration>> declarations();
 
   std::pair<std::string, std::vector<sptr<KORESort>>> symbol_sort_list();
 
@@ -34,7 +34,7 @@ private:
   [[noreturn]] void error(const location &loc, const std::string &err_message);
 
   std::string consume(token next);
-  token peek(void);
+  token peek();
 
   template <typename Node>
   void attributes(Node *node);
@@ -43,10 +43,10 @@ private:
   void attributesNE(Node *node);
 
   void modules(KOREDefinition *node);
-  ptr<KOREModule> module(void);
+  ptr<KOREModule> module();
 
   void sentences(KOREModule *node);
-  ptr<KOREDeclaration> sentence(void);
+  ptr<KOREDeclaration> sentence();
 
   void sortVariables(KOREDeclaration *node);
   void sortVariablesNE(KOREDeclaration *node);
@@ -56,15 +56,15 @@ private:
   template <typename Node>
   void sortsNE(Node *node);
 
-  sptr<KOREPattern> _pattern(void);
+  sptr<KOREPattern> _pattern();
   void patterns(KORECompositePattern *node);
   void patternsNE(KORECompositePattern *node);
   void patterns(std::vector<sptr<KOREPattern>> &node);
   void patternsNE(std::vector<sptr<KOREPattern>> &node);
 
-  sptr<KOREPattern> applicationPattern(void);
+  sptr<KOREPattern> applicationPattern();
   sptr<KOREPattern> applicationPattern(std::string name);
-  ptr<KORECompositePattern> _applicationPattern(void);
+  ptr<KORECompositePattern> _applicationPattern();
   ptr<KORECompositePattern> _applicationPattern(std::string name);
 
   struct {

--- a/include/kllvm/parser/KOREParser.h
+++ b/include/kllvm/parser/KOREParser.h
@@ -23,6 +23,7 @@ public:
 
   ptr<KOREDefinition> definition(void);
   sptr<KOREPattern> pattern(void);
+  sptr<KORESort> sort(void);
   std::vector<ptr<KOREDeclaration>> declarations(void);
 
   std::pair<std::string, std::vector<sptr<KORESort>>> symbol_sort_list();
@@ -54,7 +55,6 @@ private:
   void sorts(Node *node);
   template <typename Node>
   void sortsNE(Node *node);
-  sptr<KORESort> sort(void);
 
   sptr<KOREPattern> _pattern(void);
   void patterns(KORECompositePattern *node);

--- a/test/python/test_parser.py
+++ b/test/python/test_parser.py
@@ -17,6 +17,14 @@ class TestParser(unittest.TestCase):
             "A{}(X:S, Y:Z, Int{}())").pattern()
         self.assertEqual(str(pat), "A{}(X : S,Y : Z,Int{}())")
 
+    def test_composite_sort(self):
+        sort = kllvm.parser.Parser.from_string("SortInt{}").sort()
+        self.assertEqual(str(sort), 'SortInt{}')
+
+    def test_sort_variable(self):
+        sort = kllvm.parser.Parser.from_string('X { A }').sort()
+        self.assertEqual(str(sort), 'X{A}')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is a small PR to expose the KORE sort parser to Python in the same way that we already do for patterns and definitions; as usual for Python binding features it adds a small smoke test, but Pyk should add more comprehensive tests when this change is upstreamed.

Fixes https://github.com/runtimeverification/llvm-backend/issues/901