### PR TITLE
Fix shell quoting in cachix push

### DIFF
--- a/.github/workflows/test-flake.yml
+++ b/.github/workflows/test-flake.yml
@@ -50,6 +50,5 @@ jobs:
       - name: 'Push Flake to Cachix'
         run: |
           GC_DONT_GC=1 nix build --print-build-logs . --json \
-            | jq -r '.[].outputs \
-            | to_entries[].value' \
+            | jq -r '.[].outputs | to_entries[].value' \
             | cachix push k-framework


### PR DESCRIPTION
The github actions parser doesn't like the internal JQ pipeline being split across two lines; this was silently breaking the manual cachix push.