### PR TITLE
Refactor usages of `std::ostringstream`

### DIFF
--- a/bindings/c/lib.cpp
+++ b/bindings/c/lib.cpp
@@ -25,8 +25,7 @@ namespace fs = std::filesystem;
 // Internal implementation details
 namespace {
 
-template <typename OS>
-char *get_c_string(OS const &);
+char *get_c_string(std::string const &);
 
 kore_pattern *kore_string_pattern_new_internal(std::string const &);
 
@@ -85,9 +84,7 @@ struct kore_symbol {
 /* KOREPattern */
 
 char *kore_pattern_dump(kore_pattern const *pat) {
-  auto os = std::ostringstream{};
-  pat->ptr_->print(os);
-  return get_c_string(os);
+  return get_c_string(ast_to_string(*pat->ptr_));
 }
 
 char *kore_pattern_pretty_print(kore_pattern const *pat) {
@@ -320,9 +317,7 @@ kore_string_pattern_new_with_len(char const *contents, size_t len) {
 /* KORESort */
 
 char *kore_sort_dump(kore_sort const *sort) {
-  auto os = std::ostringstream{};
-  sort->ptr_->print(os);
-  return get_c_string(os);
+  return get_c_string(ast_to_string(*sort->ptr_));
 }
 
 void kore_sort_free(kore_sort const *sort) {
@@ -372,9 +367,7 @@ void kore_symbol_free(kore_symbol const *sym) {
 }
 
 char *kore_symbol_dump(kore_symbol const *sym) {
-  auto os = std::ostringstream{};
-  sym->ptr_->print(os);
-  return get_c_string(os);
+  return get_c_string(ast_to_string(*sym->ptr_));
 }
 
 void kore_symbol_add_formal_argument(kore_symbol *sym, kore_sort const *sort) {
@@ -394,10 +387,7 @@ void kllvm_free_all_memory(void) {
 
 namespace {
 
-template <typename OS>
-char *get_c_string(OS const &os) {
-  auto str = os.str();
-
+char *get_c_string(std::string const &str) {
   // Include null terminator
   auto total_length = str.length() + 1;
 

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -41,10 +41,10 @@ std::string decodeKore(std::string);
  * just want the string representation of a node, rather than to print it to a
  * stream.
  */
-template <typename T>
-std::string ast_to_string(T &&node) {
+template <typename T, typename... Args>
+std::string ast_to_string(T &&node, Args &&...args) {
   auto os = std::ostringstream{};
-  std::forward<T>(node).print(os);
+  std::forward<T>(node).print(os, std::forward<Args>(args)...);
   return os.str();
 }
 

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -74,9 +74,7 @@ static inline std::ostream &operator<<(std::ostream &out, const KORESort &s) {
 
 struct HashSort {
   size_t operator()(const kllvm::KORESort &s) const noexcept {
-    std::ostringstream Out;
-    s.print(Out);
-    return std::hash<std::string>{}(Out.str());
+    return std::hash<std::string>{}(ast_to_string(s));
   }
 };
 
@@ -88,9 +86,7 @@ struct EqualSortPtr {
 
 struct HashSortPtr {
   size_t operator()(kllvm::KORESort *const &s) const noexcept {
-    std::ostringstream Out;
-    s->print(Out);
-    return std::hash<std::string>{}(Out.str());
+    return std::hash<std::string>{}(ast_to_string(*s));
   }
 };
 
@@ -293,18 +289,13 @@ struct HashSymbol {
 
 struct EqualSymbolPtr {
   bool operator()(KORESymbol *const &first, KORESymbol *const &second) const {
-    std::ostringstream Out1, Out2;
-    first->print(Out1);
-    second->print(Out2);
-    return Out1.str() == Out2.str();
+    return ast_to_string(*first) == ast_to_string(*second);
   }
 };
 
 struct HashSymbolPtr {
   size_t operator()(kllvm::KORESymbol *const &s) const noexcept {
-    std::ostringstream Out;
-    s->print(Out);
-    return std::hash<std::string>{}(Out.str());
+    return std::hash<std::string>{}(ast_to_string(*s));
   }
 };
 

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -970,9 +970,7 @@ sptr<KOREPattern> KORECompositePattern::dedupeDisjuncts(void) {
   flatten(this, "\\or", items);
   std::set<std::string> printed;
   for (sptr<KOREPattern> item : items) {
-    std::ostringstream Out;
-    item->print(Out);
-    if (printed.insert(Out.str()).second) {
+    if (printed.insert(ast_to_string(*item)).second) {
       dedupedItems.push_back(item);
     }
   }
@@ -1170,10 +1168,7 @@ bool KOREVariablePattern::matches(
     substitution &subst, SubsortMap const &subsorts, SymbolMap const &overloads,
     sptr<KOREPattern> subject) {
   if (subst[name->getName()]) {
-    std::ostringstream Out1, Out2;
-    subst[name->getName()]->print(Out1);
-    subject->print(Out2);
-    return Out1.str() == Out2.str();
+    return ast_to_string(*subst[name->getName()]) == ast_to_string(*subject);
   } else {
     subst[name->getName()] = subject;
     return true;
@@ -1796,9 +1791,7 @@ void KOREDefinition::preprocess() {
         symbol->firstTag = symbol->lastTag = instantiations.at(*symbol);
         symbol->layout = layouts.at(layoutStr);
         objectSymbols[symbol->firstTag] = symbol;
-        std::ostringstream Out;
-        symbol->print(Out);
-        allObjectSymbols[Out.str()] = symbol;
+        allObjectSymbols[ast_to_string(*symbol)] = symbol;
       }
     }
     uint32_t lastTag = nextSymbol - 1;

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -18,10 +18,8 @@ namespace {
 template <typename IRBuilder>
 llvm::Constant *createGlobalSortStringPtr(
     IRBuilder &B, KORECompositeSort &sort, llvm::Module *mod) {
-  auto os = std::ostringstream{};
-  sort.print(os);
   return B.CreateGlobalStringPtr(
-      os.str(), fmt::format("{}_str", sort.getName()), 0, mod);
+      ast_to_string(sort), fmt::format("{}_str", sort.getName()), 0, mod);
 }
 
 constexpr uint64_t word(uint8_t byte) {
@@ -293,11 +291,9 @@ llvm::BasicBlock *ProofEvent::functionEvent_pre(
   auto [true_block, merge_block, outputFile]
       = eventPrelude("function_pre", current_block);
 
-  std::ostringstream symbolName;
-  pattern->getConstructor()->print(symbolName);
-
   emitWriteUInt64(outputFile, word(0xDD), true_block);
-  emitWriteString(outputFile, symbolName.str(), true_block);
+  emitWriteString(
+      outputFile, ast_to_string(*pattern->getConstructor()), true_block);
   emitWriteString(outputFile, locationStack, true_block);
 
   llvm::BranchInst::Create(merge_block, true_block);

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -44,9 +44,8 @@ uint32_t getTagForSymbolName(const char *name) {
 }
 
 static uint32_t getTagForSymbol(KORESymbol const &symbol) {
-  std::ostringstream out;
-  symbol.print(out);
-  return getTagForSymbolName(out.str().c_str());
+  auto name = ast_to_string(symbol);
+  return getTagForSymbolName(name.c_str());
 }
 
 void *constructCompositePattern(uint32_t tag, std::vector<void *> &arguments) {

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -189,11 +189,10 @@ int main(int argc, char **argv) {
       auto funcDt = parseYamlDecisionTree(
           mod.get(), filename, definition->getAllSymbols(),
           definition->getHookedSorts());
-      std::ostringstream Out;
-      decl->getSymbol()->print(Out);
+
       makeAnywhereFunction(
-          definition->getAllSymbols().at(Out.str()), definition.get(),
-          mod.get(), funcDt);
+          definition->getAllSymbols().at(ast_to_string(*decl->getSymbol())),
+          definition.get(), mod.get(), funcDt);
     }
   }
 


### PR DESCRIPTION
A common pattern in the backend's code is to do the following:
```c++
std::ostringstream out;
pattern->print(out);
do_something(out.str());
```

In #911, we introduced a helper function `ast_to_string` that wraps this common pattern up; this PR follows up that change by mechanically refactoring the remainder of the codebase to use the helper. After the change, the above code would be:
```c++
do_something(ast_to_string(*pattern));
```

Each commit in the PR (bar the first) applies the same conceptual refactoring to a single file; no actual behavioural changes other than in the first commit are implemented, and so this should be an easy PR to review.

In future work, I'd like to further clean up this code and make better use of `fmt` across the codebase, but for now this is a useful self-contained change to make.