### PR TITLE
Print hooked sort elements correctly

### DIFF
--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -131,12 +131,12 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   flags=(
     "-L@BREW_PREFIX@/opt/libffi/lib"
     "-L@BREW_PREFIX@/lib"
-    "-Wl,-u,_sort_table"
+    "-Wl,-u,_table_getArgumentSortsForTag"
     "-I" "@BREW_PREFIX@/include"
   )
 else
   libraries=("-ltinfo")
-  flags=("-Wl,-u,sort_table")
+  flags=("-Wl,-u,table_getArgumentSortsForTag")
 fi
 
 llc_flags+=("--relocation-model=pic")

--- a/debug/kgdb.py
+++ b/debug/kgdb.py
@@ -610,7 +610,7 @@ class termPrinter:
             argData = layoutData['args'] + i
             arg = subject.cast(self.long_int) + int(argData.dereference()['offset'])
             cat = argData.dereference()['cat']
-            sort = gdb.lookup_global_symbol("sort_table").value()[tag][i].string("iso-8859-1")
+            sort = gdb.lookup_global_symbol("table_getArgumentSortsForTag").value()[tag][i].string("iso-8859-1")
             if cat == @MAP_LAYOUT@:
                 self.appendMap(arg.cast(self.map_ptr), sort)
             elif cat == @RANGEMAP_LAYOUT@:

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -351,6 +351,7 @@ bool hook_STRING_eq(SortString, SortString);
 
 const char *getSymbolNameForTag(uint32_t tag);
 const char *getReturnSortForTag(uint32_t tag);
+const char **getArgumentSortsForTag(uint32_t tag);
 const char *topSort(void);
 
 typedef struct {

--- a/runtime/collections/lists.cpp
+++ b/runtime/collections/lists.cpp
@@ -246,6 +246,9 @@ void printList(
     return;
   }
 
+  auto tag = getTagForSymbolName(element);
+  auto arg_sorts = getArgumentSortsForTag(tag);
+
   sfprintf(file, "\\left-assoc{}(%s(", concat);
 
   bool once = true;
@@ -256,7 +259,7 @@ void printList(
       sfprintf(file, ",");
     }
     sfprintf(file, "%s(", element);
-    printConfigurationInternal(file, *iter, "SortKItem{}", false, state);
+    printConfigurationInternal(file, *iter, arg_sorts[0], false, state);
     sfprintf(file, ")");
   }
   sfprintf(file, "))");

--- a/runtime/collections/maps.cpp
+++ b/runtime/collections/maps.cpp
@@ -200,6 +200,9 @@ void printMap(
     return;
   }
 
+  auto tag = getTagForSymbolName(element);
+  auto arg_sorts = getArgumentSortsForTag(tag);
+
   sfprintf(file, "\\left-assoc{}(%s(", concat);
 
   bool once = true;
@@ -212,9 +215,9 @@ void printMap(
 
     sfprintf(file, "%s(", element);
     auto entry = *iter;
-    printConfigurationInternal(file, entry.first, "SortKItem{}", false, state);
+    printConfigurationInternal(file, entry.first, arg_sorts[0], false, state);
     sfprintf(file, ",");
-    printConfigurationInternal(file, entry.second, "SortKItem{}", false, state);
+    printConfigurationInternal(file, entry.second, arg_sorts[1], false, state);
     sfprintf(file, ")");
   }
   sfprintf(file, "))");

--- a/runtime/collections/rangemaps.cpp
+++ b/runtime/collections/rangemaps.cpp
@@ -265,6 +265,9 @@ void printRangeMap(
     return;
   }
 
+  auto tag = getTagForSymbolName(element);
+  auto arg_sorts = getArgumentSortsForTag(tag);
+
   sfprintf(file, "\\left-assoc{}(%s(", concat);
 
   bool once = true;
@@ -285,7 +288,7 @@ void printRangeMap(
     printConfigurationInternal(
         file, entry.first.end(), "SortKItem{}", false, state);
     sfprintf(file, "),");
-    printConfigurationInternal(file, entry.second, "SortKItem{}", false, state);
+    printConfigurationInternal(file, entry.second, arg_sorts[1], false, state);
     sfprintf(file, ")");
   }
   sfprintf(file, "))");

--- a/runtime/collections/sets.cpp
+++ b/runtime/collections/sets.cpp
@@ -146,6 +146,9 @@ void printSet(
     return;
   }
 
+  auto tag = getTagForSymbolName(element);
+  auto arg_sorts = getArgumentSortsForTag(tag);
+
   sfprintf(file, "\\left-assoc{}(%s(", concat);
 
   bool once = true;
@@ -157,7 +160,7 @@ void printSet(
     }
 
     sfprintf(file, "%s(", element);
-    printConfigurationInternal(file, *iter, "SortKItem{}", false, state);
+    printConfigurationInternal(file, *iter, arg_sorts[0], false, state);
     sfprintf(file, ")");
   }
   sfprintf(file, "))");

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -114,11 +114,14 @@ void serializeMap(
     return;
   }
 
+  auto tag = getTagForSymbolName(element);
+  auto arg_sorts = getArgumentSortsForTag(tag);
+
   for (auto iter = map->begin(); iter != map->end(); ++iter) {
     serializeConfigurationInternal(
-        file, iter->first, "SortKItem{}", false, state);
+        file, iter->first, arg_sorts[0], false, state);
     serializeConfigurationInternal(
-        file, iter->second, "SortKItem{}", false, state);
+        file, iter->second, arg_sorts[1], false, state);
     emitSymbol(instance, element, 2);
 
     if (iter != map->begin()) {
@@ -138,6 +141,9 @@ void serializeRangeMap(
     return;
   }
 
+  auto tag = getTagForSymbolName(element);
+  auto arg_sorts = getArgumentSortsForTag(tag);
+
   bool once = true;
   for (auto iter = rng_map::ConstRangeMapIterator<KElem, KElem>(*map);
        iter.has_next(); ++iter) {
@@ -147,7 +153,7 @@ void serializeRangeMap(
         file, iter->first.end(), "SortKItem{}", false, state);
     emitSymbol(instance, "LblRangemap'Coln'Range{}", 2);
     serializeConfigurationInternal(
-        file, iter->second, "SortKItem{}", false, state);
+        file, iter->second, arg_sorts[1], false, state);
     emitSymbol(instance, element, 2);
 
     if (once) {
@@ -169,8 +175,11 @@ void serializeList(
     return;
   }
 
+  auto tag = getTagForSymbolName(element);
+  auto arg_sorts = getArgumentSortsForTag(tag);
+
   for (auto iter = list->begin(); iter != list->end(); ++iter) {
-    serializeConfigurationInternal(file, *iter, "SortKItem{}", false, state);
+    serializeConfigurationInternal(file, *iter, arg_sorts[0], false, state);
     emitSymbol(instance, element, 1);
 
     if (iter != list->begin()) {
@@ -190,8 +199,11 @@ void serializeSet(
     return;
   }
 
+  auto tag = getTagForSymbolName(element);
+  auto arg_sorts = getArgumentSortsForTag(tag);
+
   for (auto iter = set->begin(); iter != set->end(); ++iter) {
-    serializeConfigurationInternal(file, *iter, "SortKItem{}", false, state);
+    serializeConfigurationInternal(file, *iter, arg_sorts[0], false, state);
     emitSymbol(instance, element, 1);
 
     if (iter != set->begin()) {

--- a/runtime/util/util.cpp
+++ b/runtime/util/util.cpp
@@ -2,12 +2,6 @@
 
 extern "C" {
 
-extern char *return_sort_table;
-
-const char *getReturnSortForTag(uint32_t tag) {
-  return (&return_sort_table)[tag];
-}
-
 block *dot_k() {
   return leaf_block(getTagForSymbolName("dotk{}"));
 }

--- a/test/defn/k-files/wasm-maps.k
+++ b/test/defn/k-files/wasm-maps.k
@@ -1,0 +1,85 @@
+module WASM-MAPS
+  imports MAP-INT-TO-VAL
+  // imports MAP-INT-TO-INT
+
+  configuration
+        <wasm>
+          <instrs> $PGM </instrs>
+          <locals> .MapIntToVal </locals>
+          // <locals> .MapIntToInt </locals>
+        </wasm>
+
+  syntax Instr ::= "init_local"  Int Int
+  // -----------------------------------
+  rule <instrs> init_local INDEX VALUE => . ... </instrs>
+       <locals> LOCALS => LOCALS {{ INDEX <- wrap(VALUE) }} </locals>
+
+endmodule
+
+module MAP-INT-TO-INT
+  imports WRAPPED-INT
+
+  syntax MapIntToInt [hook(MAP.Map)]
+  syntax MapIntToInt ::= MapIntToInt MapIntToInt
+         [ left, function, hook(MAP.concat), klabel(_MapIntToInt_),
+           symbol, assoc, comm, unit(.MapIntToInt), element(_Int2Int|->_)
+         ]
+  syntax MapIntToInt ::= ".MapIntToInt"
+         [function, total, hook(MAP.unit),klabel(.MapIntToInt), symbol]
+  syntax MapIntToInt ::= WrappedInt "Int2Int|->" WrappedInt
+         [function, total, hook(MAP.element), klabel(_Int2Int|->_), symbol]
+
+  syntax MapIntToInt ::= MapIntToInt "[" key: WrappedInt "<-" value: WrappedInt "]" [function, total, klabel(MapInt2Int:update), symbol, hook(MAP.update), prefer]
+
+  syntax priorities _Int2Int|->_ > _MapIntToInt_ .MapIntToInt
+  syntax non-assoc _Int2Int|->_
+
+  syntax MapIntToInt ::= MapIntToInt "{{" key: Int "<-" value: Int "}}"
+                 [ function, total, klabel(MapIntToInt:primitiveUpdate), symbol,
+                   prefer
+                 ]
+  rule M:MapIntToInt {{ Key:Int <- Value:Int }}
+      => M[wrap(Key) <- wrap(Value)]
+
+endmodule
+
+module MAP-INT-TO-VAL
+  imports WRAPPED-INT
+
+  syntax Val ::= WrappedInt
+ // -----------------------
+
+  syntax MapIntToVal [hook(MAP.Map)]
+  syntax MapIntToVal ::= MapIntToVal MapIntToVal
+         [ left, function, hook(MAP.concat), klabel(_MapIntToVal_),
+           symbol, assoc, comm, unit(.MapIntToVal), element(_Int2Val|->_)
+         ]
+  syntax MapIntToVal ::= ".MapIntToVal"
+         [function, total, hook(MAP.unit),klabel(.MapIntToVal), symbol]
+  syntax MapIntToVal ::= WrappedInt "Int2Val|->" Val
+         [function, total, hook(MAP.element), klabel(_Int2Val|->_), symbol]
+
+  syntax MapIntToVal ::= MapIntToVal "[" key: WrappedInt "<-" value: Val "]" [function, total, klabel(MapInt2Val:update), symbol, hook(MAP.update), prefer]
+
+  syntax priorities _Int2Val|->_ > _MapIntToVal_ .MapIntToVal
+  syntax non-assoc _Int2Val|->_
+
+  syntax MapIntToVal ::= MapIntToVal "{{" key: Int "<-" value: Val "}}"
+                 [ function, total, klabel(MapIntToVal:primitiveUpdate), symbol,
+                   prefer
+                 ]
+  rule M:MapIntToVal {{ Key:Int <- Value:Val }}
+      => M[wrap(Key) <- Value]
+
+endmodule
+
+module WRAPPED-INT
+  imports INT
+
+  syntax WrappedInt ::= wrap(Int)  [symbol, klabel(wrapInt)]
+  // -------------------------------------------------------
+
+  syntax Int ::= unwrap(WrappedInt)  [function, total, injective, symbol, klabel(unwrapInt)]
+  // ---------------------------------------------------------------------------------------
+  rule unwrap(wrap(A:Int)) => A
+endmodule

--- a/test/defn/wasm-maps.kore
+++ b/test/defn/wasm-maps.kore
@@ -1,0 +1,2900 @@
+// RUN: %interpreter
+// RUN: %t.interpreter %test-input 1 /dev/stdout | diff - %test-diff-out
+// RUN: rm -f %t.out.bin && %t.interpreter %test-input 1 %t.out.bin --binary-output
+// RUN: %kore-convert %t.out.bin -o %t.out.kore
+// RUN: %kore-convert %test-diff-out --to=text | diff - %t.out.kore
+[topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)")]
+
+module BASIC-K
+    sort SortK{} []
+    sort SortKItem{} []
+endmodule
+[]
+module KSEQ
+    import BASIC-K []
+    symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol dotk{}() : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol append{}(SortK{}, SortK{}) : SortK{} [function{}(), functional{}()]
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, dotk{}()),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                TAIL:SortK{},
+                \top{SortK{}}()
+            )
+        )
+    ) []
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, kseq{}(K:SortKItem{}, KS:SortK{})),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                kseq{}(K:SortKItem{}, append{}(KS:SortK{}, TAIL:SortK{})),
+                \top{SortK{}}()
+            )
+        )
+    ) []
+endmodule
+[]
+module INJ
+    symbol inj{From, To}(From) : To [sortInjection{}()]
+    axiom {S1, S2, S3, R} \equals{S3, R}(inj{S2, S3}(inj{S1, S2}(T:S1)), inj{S1, S3}(T:S1)) [simplification{}()]
+endmodule
+[]
+module K
+    import KSEQ []
+    import INJ []
+    alias weakExistsFinally{A}(A) : A where weakExistsFinally{A}(@X:A) := @X:A []
+    alias weakAlwaysFinally{A}(A) : A where weakAlwaysFinally{A}(@X:A) := @X:A []
+    alias allPathGlobally{A}(A) : A where allPathGlobally{A}(@X:A) := @X:A []
+endmodule
+[]
+
+module WASM-MAPS
+
+// imports
+  import K []
+
+// sorts
+  hooked-sort SortMapIntToVal{} [concat{}(Lbl'Unds'MapIntToVal'Unds'{}()), element{}(Lbl'Unds'Int2Val'Pipe'-'-GT-Unds'{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(52,3,52,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), unit{}(Lbl'Stop'MapIntToVal{}())]
+  sort SortWasmCell{} []
+  sort SortVal{} []
+  sort SortLocalsCellOpt{} []
+  sort SortGeneratedTopCellFragment{} []
+  hooked-sort SortList{} [concat{}(Lbl'Unds'List'Unds'{}()), element{}(LblListItem{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(913,3,913,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'List{}())]
+  sort SortGeneratedTopCell{} []
+  sort SortGeneratedCounterCell{} []
+  sort SortWasmCellFragment{} []
+  sort SortWasmCellOpt{} []
+  sort SortLocalsCell{} []
+  hooked-sort SortMap{} [concat{}(Lbl'Unds'Map'Unds'{}()), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(218,3,218,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Map{}())]
+  sort SortGeneratedCounterCellOpt{} []
+  sort SortKConfigVar{} [hasDomainValues{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(40,3,40,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/kast.md)"), token{}()]
+  sort SortInstrsCellOpt{} []
+  hooked-sort SortInt{} [hasDomainValues{}(), hook{}("INT.Int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1189,3,1189,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)")]
+  sort SortWrappedInt{} []
+  hooked-sort SortSet{} [concat{}(Lbl'Unds'Set'Unds'{}()), element{}(LblSetItem{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(700,3,700,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Set{}())]
+  sort SortInstrsCell{} []
+  sort SortInstr{} []
+  hooked-sort SortBool{} [hasDomainValues{}(), hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1068,3,1068,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)")]
+
+// symbols
+  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(SortBool{}, SortSort, SortSort) : SortSort [format{}("%c#if%r %1 %c#then%r %2 %c#else%r %3 %c#fi%r"), function{}(), functional{}(), hook{}("KEQUAL.ite"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2277,26,2277,121)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("ite"), terminals{}("1010101"), total{}()]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [format{}("%c.List%r"), function{}(), functional{}(), hook{}("LIST.unit"), klabel{}(".List"), latex{}("\\dotCt{List}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(937,19,937,142)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_nil"), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [format{}("%c.Map%r"), function{}(), functional{}(), hook{}("MAP.unit"), klabel{}(".Map"), latex{}("\\dotCt{Map}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(248,18,248,124)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  hooked-symbol Lbl'Stop'MapIntToVal{}() : SortMapIntToVal{} [format{}("%c.MapIntToVal%r"), function{}(), functional{}(), hook{}("MAP.unit"), klabel{}(".MapIntToVal"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(57,26,58,72)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [format{}("%c.Set%r"), function{}(), functional{}(), hook{}("SET.unit"), klabel{}(".Set"), latex{}("\\dotCt{Set}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(729,18,729,118)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1"), total{}()]
+  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [cell{}(), cellName{}("generatedCounter"), constructor{}(), format{}("%c<generatedCounter>%r%i%n%1%d%n%c</generatedCounter>%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("101")]
+  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortWasmCell{}, SortGeneratedCounterCell{}) : SortGeneratedTopCell{} [cell{}(), cellName{}("generatedTop"), constructor{}(), format{}("%1"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1001")]
+  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortWasmCellOpt{}, SortGeneratedCounterCellOpt{}) : SortGeneratedTopCellFragment{} [cellFragment{}("GeneratedTopCell"), constructor{}(), format{}("%c<generatedTop>-fragment%r %1 %2 %c</generatedTop>-fragment%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1001")]
+  symbol Lbl'-LT-'instrs'-GT-'{}(SortK{}) : SortInstrsCell{} [cell{}(), cellName{}("instrs"), constructor{}(), format{}("%c<instrs>%r%i%n%1%d%n%c</instrs>%r"), functional{}(), injective{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(7,11,7,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), priorities{}(), right{}(), terminals{}("101")]
+  symbol Lbl'-LT-'locals'-GT-'{}(SortMapIntToVal{}) : SortLocalsCell{} [cell{}(), cellName{}("locals"), constructor{}(), format{}("%c<locals>%r%i%n%1%d%n%c</locals>%r"), functional{}(), injective{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(8,11,8,42)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), priorities{}(), right{}(), terminals{}("101")]
+  symbol Lbl'-LT-'wasm'-GT-'{}(SortInstrsCell{}, SortLocalsCell{}) : SortWasmCell{} [cell{}(), cellName{}("wasm"), constructor{}(), format{}("%c<wasm>%r%i%n%1%n%2%d%n%c</wasm>%r"), functional{}(), injective{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,9,10,16)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), priorities{}(), right{}(), terminals{}("1001")]
+  symbol Lbl'-LT-'wasm'-GT-'-fragment{}(SortInstrsCellOpt{}, SortLocalsCellOpt{}) : SortWasmCellFragment{} [cellFragment{}("WasmCell"), constructor{}(), format{}("%c<wasm>-fragment%r %1 %2 %c</wasm>-fragment%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1001")]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [format{}("%1 %c[%r %2 %c]%r"), function{}(), hook{}("LIST.get"), klabel{}("List:get"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(956,20,956,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("0101")]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [format{}("%crange%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("LIST.range"), klabel{}("List:range"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1003,19,1003,120)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("11010101")]
+  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [format{}("%cListItem%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("LIST.element"), klabel{}("ListItem"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(945,19,945,132)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_elem"), symbol'Kywd'{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [format{}("%1 %c[%r %2 %c]%r"), function{}(), hook{}("MAP.lookup"), klabel{}("Map:lookup"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(271,20,271,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("0101")]
+  hooked-symbol LblMap'Coln'update{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}(), functional{}(), hook{}("MAP.update"), klabel{}("Map:update"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,18,290,140)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), prefer{}(), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010101"), total{}()]
+  hooked-symbol LblMapInt2Val'Coln'update{}(SortMapIntToVal{}, SortWrappedInt{}, SortVal{}) : SortMapIntToVal{} [format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}(), functional{}(), hook{}("MAP.update"), klabel{}("MapInt2Val:update"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(62,26,62,156)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), prefer{}(), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010101"), total{}()]
+  symbol LblMapIntToVal'Coln'primitiveUpdate{}(SortMapIntToVal{}, SortInt{}, SortVal{}) : SortMapIntToVal{} [format{}("%1 %c{{%r %2 %c<-%r %3 %c}}%r"), function{}(), functional{}(), klabel{}("MapIntToVal:primitiveUpdate"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(67,26,70,19)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), prefer{}(), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010101"), total{}()]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [format{}("%1 %c-Set%r %2"), function{}(), functional{}(), hook{}("SET.difference"), klabel{}("Set:difference"), latex{}("{#1}-_{\\it Set}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(769,18,769,142)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [format{}("%1 %cin%r %2"), function{}(), functional{}(), hook{}("SET.in"), klabel{}("Set:in"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(777,19,777,102)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [format{}("%cSetItem%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("SET.element"), injective{}(), klabel{}("SetItem"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(737,18,737,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lbl'UndsPerc'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c%%Int%r %2"), function{}(), hook{}("INT.tmod"), klabel{}("_%Int_"), latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1237,18,1237,171)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("mod"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'UndsAnd-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c&Int%r %2"), function{}(), functional{}(), hook{}("INT.and"), klabel{}("_&Int_"), latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsAnd-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1248,18,1248,184)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("andInt"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsStar'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c*Int%r %2"), function{}(), functional{}(), hook{}("INT.mul"), klabel{}("_*Int_"), latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds'modInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1233,18,1233,183)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("*"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c+Int%r %2"), function{}(), functional{}(), hook{}("INT.add"), klabel{}("_+Int_"), latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1242,18,1242,180)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smt-hook{}("+"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'-Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c-Int%r %2"), function{}(), functional{}(), hook{}("INT.sub"), klabel{}("_-Int_"), latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1243,18,1243,174)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smt-hook{}("-"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [format{}("%1 %c-Map%r %2"), function{}(), functional{}(), hook{}("MAP.difference"), latex{}("{#1}-_{\\it Map}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,18,311,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsSlsh'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c/Int%r %2"), function{}(), hook{}("INT.tdiv"), klabel{}("_/Int_"), latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1236,18,1236,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("div"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c<<Int%r %2"), function{}(), hook{}("INT.shl"), klabel{}("_<<Int_"), latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1246,18,1246,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shlInt"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c<=Int%r %2"), function{}(), functional{}(), hook{}("INT.le"), klabel{}("_<=Int_"), latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1304,19,1304,166)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("<="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [format{}("%1 %c<=Map%r %2"), function{}(), functional{}(), hook{}("MAP.inclusion"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,19,383,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [format{}("%1 %c<=Set%r %2"), function{}(), functional{}(), hook{}("SET.inclusion"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(786,19,786,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c<Int%r %2"), function{}(), functional{}(), hook{}("INT.lt"), klabel{}("_<Int_"), latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1305,19,1305,161)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("<"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [comm{}(), format{}("%1 %c=/=Bool%r %2"), function{}(), functional{}(), hook{}("BOOL.ne"), klabel{}("_=/=Bool_"), left{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1109,19,1109,134)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("distinct"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [comm{}(), format{}("%1 %c=/=Int%r %2"), function{}(), functional{}(), hook{}("INT.ne"), klabel{}("_=/=Int_"), latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1309,19,1309,184)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("distinct"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [comm{}(), format{}("%1 %c=/=K%r %2"), function{}(), functional{}(), group{}("notEqualEqualK"), hook{}("KEQUAL.ne"), klabel{}("_=/=K_"), latex{}("{#1}\\mathrel{\\neq_K}{#2}"), left{}(Lbl'UndsEqlsEqls'K'Unds'{}(),Lbl'UndsEqlsSlshEqls'K'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2273,19,2273,179)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), right{}(), smt-hook{}("distinct"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [comm{}(), format{}("%1 %c==Bool%r %2"), function{}(), functional{}(), hook{}("BOOL.eq"), klabel{}("_==Bool_"), left{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1108,19,1108,126)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [comm{}(), format{}("%1 %c==Int%r %2"), function{}(), functional{}(), hook{}("INT.eq"), klabel{}("_==Int_"), latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1308,19,1308,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [comm{}(), format{}("%1 %c==K%r %2"), function{}(), functional{}(), group{}("equalEqualK"), hook{}("KEQUAL.eq"), klabel{}("_==K_"), latex{}("{#1}\\mathrel{=_K}{#2}"), left{}(Lbl'UndsEqlsSlshEqls'K'Unds'{}(),Lbl'UndsEqlsEqls'K'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2272,19,2272,165)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), right{}(), smt-hook{}("="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c>=Int%r %2"), function{}(), functional{}(), hook{}("INT.ge"), klabel{}("_>=Int_"), latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1306,19,1306,166)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}(">="), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c>>Int%r %2"), function{}(), hook{}("INT.shr"), klabel{}("_>>Int_"), latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1245,18,1245,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shrInt"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds-GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %c>Int%r %2"), function{}(), functional{}(), hook{}("INT.gt"), klabel{}("_>Int_"), latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1307,19,1307,161)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}(">"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'Int2Val'Pipe'-'-GT-Unds'{}(SortWrappedInt{}, SortVal{}) : SortMapIntToVal{} [format{}("%1 %cInt2Val|->%r %2"), function{}(), functional{}(), hook{}("MAP.element"), klabel{}("_Int2Val|->_"), left{}(Lbl'Unds'Int2Val'Pipe'-'-GT-Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(59,26,60,76)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), priorities{}(Lbl'Stop'MapIntToVal{}(),Lbl'Unds'MapIntToVal'Unds'{}()), right{}(Lbl'Unds'Int2Val'Pipe'-'-GT-Unds'{}()), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [assoc{}(), element{}(LblListItem{}()), format{}("%1%n%2"), function{}(), functional{}(), hook{}("LIST.concat"), klabel{}("_List_"), left{}(Lbl'Unds'List'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(929,19,929,188)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_concat"), symbol'Kywd'{}(), terminals{}("00"), total{}(), unit{}(Lbl'Stop'List{}())]
+  hooked-symbol Lbl'Unds'MapIntToVal'Unds'{}(SortMapIntToVal{}, SortMapIntToVal{}) : SortMapIntToVal{} [assoc{}(), comm{}(), element{}(Lbl'Unds'Int2Val'Pipe'-'-GT-Unds'{}()), format{}("%1 %2"), function{}(), hook{}("MAP.concat"), klabel{}("_MapIntToVal_"), left{}(Lbl'Unds'MapIntToVal'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(53,26,56,11)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("00"), unit{}(Lbl'Stop'MapIntToVal{}())]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [assoc{}(), comm{}(), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), format{}("%1%n%2"), function{}(), hook{}("MAP.concat"), index{}("0"), klabel{}("_Map_"), left{}(Lbl'Unds'Map'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,18,240,173)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("00"), unit{}(Lbl'Stop'Map{}())]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [assoc{}(), comm{}(), element{}(LblSetItem{}()), format{}("%1%n%2"), function{}(), hook{}("SET.concat"), idem{}(), klabel{}("_Set_"), left{}(Lbl'Unds'Set'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(721,18,721,165)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("00"), unit{}(Lbl'Stop'Set{}())]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}(), hook{}("LIST.update"), klabel{}("List:set"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(965,19,965,108)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010101")]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [format{}("%1 %c[%r %2 %c<-%r %cundef%r %c]%r"), function{}(), functional{}(), hook{}("MAP.remove"), klabel{}("_[_<-undef]"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(299,18,299,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("010111"), total{}()]
+  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'Unds'KItem'Unds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [format{}("%1 %c[%r %2 %c]%r %corDefault%r %3"), function{}(), functional{}(), hook{}("MAP.lookupOrDefault"), klabel{}("Map:lookupOrDefault"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(281,20,281,134)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010110"), total{}()]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUnds'{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c^%%Int%r %2 %3"), function{}(), hook{}("INT.powmod"), klabel{}("_^%Int__"), left{}(Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'UndsXor-'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1231,18,1231,139)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("(mod (^ #1 #2) #3)"), symbol'Kywd'{}(), terminals{}("0100")]
+  hooked-symbol Lbl'UndsXor-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %c^Int%r %2"), function{}(), hook{}("INT.pow"), klabel{}("_^Int_"), latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsXor-'Int'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1230,18,1230,178)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("^"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [format{}("%1 %candBool%r %2"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.and"), klabel{}("_andBool_"), latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), left{}(Lbl'Unds'andBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1101,19,1101,192)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("and"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'andThenBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [format{}("%1 %candThenBool%r %2"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.andThen"), klabel{}("_andThenBool_"), left{}(Lbl'Unds'andThenBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1102,19,1102,154)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("and"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'divInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %cdivInt%r %2"), function{}(), hook{}("INT.ediv"), klabel{}("_divInt_"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1239,18,1239,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("div"), symbol'Kywd'{}(), terminals{}("010")]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [format{}("%1 %cdividesInt%r %2"), function{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1318,19,1318,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'impliesBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [format{}("%1 %cimpliesBool%r %2"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.implies"), klabel{}("_impliesBool_"), left{}(Lbl'Unds'impliesBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1106,19,1106,153)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("=>"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(SortKItem{}, SortList{}) : SortBool{} [format{}("%1 %cin%r %2"), function{}(), functional{}(), hook{}("LIST.in"), klabel{}("_inList_"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1012,19,1012,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [format{}("%1 %cin_keys%r %c(%r %2 %c)%r"), function{}(), functional{}(), hook{}("MAP.in_keys"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(357,19,357,89)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("01101"), total{}()]
+  hooked-symbol Lbl'Unds'modInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%1 %cmodInt%r %2"), function{}(), hook{}("INT.emod"), klabel{}("_modInt_"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1240,18,1240,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smt-hook{}("mod"), symbol'Kywd'{}(), terminals{}("010")]
+  hooked-symbol Lbl'Unds'orBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [format{}("%1 %corBool%r %2"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.or"), klabel{}("_orBool_"), latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), left{}(Lbl'Unds'orBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1104,19,1104,187)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("or"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'orElseBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [format{}("%1 %corElseBool%r %2"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.orElse"), klabel{}("_orElseBool_"), left{}(Lbl'Unds'orElseBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1105,19,1105,151)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("or"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'xorBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [format{}("%1 %cxorBool%r %2"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.xor"), klabel{}("_xorBool_"), left{}(Lbl'Unds'xorBool'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1103,19,1103,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), right{}(), smt-hook{}("xor"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'Unds'xorInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %cxorInt%r %2"), function{}(), functional{}(), hook{}("INT.xor"), klabel{}("_xorInt_"), latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'Unds'xorInt'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1250,18,1250,190)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("xorInt"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [format{}("%1 %c|->%r %2"), function{}(), functional{}(), hook{}("MAP.element"), injective{}(), klabel{}("_|->_"), latex{}("{#1}\\mapsto{#2}"), left{}(Lbl'UndsPipe'-'-GT-Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(257,18,257,151)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Stop'Map{}(),Lbl'Unds'Map'Unds'{}()), right{}(Lbl'UndsPipe'-'-GT-Unds'{}()), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [comm{}(), format{}("%1 %c|Int%r %2"), function{}(), functional{}(), hook{}("INT.or"), klabel{}("_|Int_"), latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), left{}(Lbl'UndsPipe'Int'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1252,18,1252,181)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("orInt"), symbol'Kywd'{}(), terminals{}("010"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [comm{}(), format{}("%1 %c|Set%r %2"), function{}(), functional{}(), hook{}("SET.union"), left{}(Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(748,18,748,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), total{}()]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%cabsInt%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("INT.abs"), klabel{}("absInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1269,18,1269,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("(ite (< #1 0) (- 0 #1) #1)"), terminals{}("1101"), total{}()]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [format{}("%cbitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("INT.bitRange"), klabel{}("bitRangeInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1294,18,1294,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'Unds'KItem'Unds'Map{}(SortMap{}) : SortKItem{} [format{}("%cchoice%r %c(%r %1 %c)%r"), function{}(), hook{}("MAP.choice"), klabel{}("Map:choice"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,20,393,101)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'SET'Unds'KItem'Unds'Set{}(SortSet{}) : SortKItem{} [format{}("%cchoice%r %c(%r %1 %c)%r"), function{}(), hook{}("SET.choice"), klabel{}("Set:choice"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(804,20,804,95)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [format{}("%cfillList%r %c(%r %1 %c,%r %2 %c,%r %3 %c,%r %4 %c)%r"), function{}(), hook{}("LIST.fill"), klabel{}("fillList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(993,19,993,100)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101010101")]
+  symbol LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%cfreshInt%r %c(%r %1 %c)%r"), freshGenerator{}(), function{}(), functional{}(), klabel{}("freshInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1432,18,1432,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), private{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblgetGeneratedCounterCell{}(SortGeneratedTopCell{}) : SortGeneratedCounterCell{} [format{}("%cgetGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [format{}("%cinitGeneratedCounterCell%r"), function{}(), initializer{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [format{}("%cinitGeneratedTopCell%r %c(%r %1 %c)%r"), function{}(), initializer{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol LblinitInstrsCell{}(SortMap{}) : SortInstrsCell{} [format{}("%cinitInstrsCell%r %c(%r %1 %c)%r"), function{}(), initializer{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol LblinitLocalsCell{}() : SortLocalsCell{} [format{}("%cinitLocalsCell%r"), function{}(), initializer{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  symbol LblinitWasmCell{}(SortMap{}) : SortWasmCell{} [format{}("%cinitWasmCell%r %c(%r %1 %c)%r"), function{}(), initializer{}(), left{}(), priorities{}(), right{}(), terminals{}("1101")]
+  symbol Lblinit'Unds'local'UndsUndsUnds'WASM-MAPS'Unds'Instr'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInstr{} [constructor{}(), format{}("%cinit_local%r %1 %2"), functional{}(), injective{}(), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,20,12,41)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), priorities{}(), right{}(), terminals{}("100")]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [comm{}(), format{}("%cintersectSet%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("SET.intersection"), klabel{}("intersectSet"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(759,18,759,90)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  symbol LblisBool{}(SortK{}) : SortBool{} [format{}("%cisBool%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Bool"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [format{}("%cisGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedCounterCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [format{}("%cisGeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedCounterCellOpt"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [format{}("%cisGeneratedTopCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedTopCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [format{}("%cisGeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("GeneratedTopCellFragment"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisInstr{}(SortK{}) : SortBool{} [format{}("%cisInstr%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Instr"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisInstrsCell{}(SortK{}) : SortBool{} [format{}("%cisInstrsCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("InstrsCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisInstrsCellOpt{}(SortK{}) : SortBool{} [format{}("%cisInstrsCellOpt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("InstrsCellOpt"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisInt{}(SortK{}) : SortBool{} [format{}("%cisInt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Int"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisK{}(SortK{}) : SortBool{} [format{}("%cisK%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("K"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [format{}("%cisKConfigVar%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KConfigVar"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [format{}("%cisKItem%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("KItem"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisList{}(SortK{}) : SortBool{} [format{}("%cisList%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("List"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisLocalsCell{}(SortK{}) : SortBool{} [format{}("%cisLocalsCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("LocalsCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisLocalsCellOpt{}(SortK{}) : SortBool{} [format{}("%cisLocalsCellOpt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("LocalsCellOpt"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisMap{}(SortK{}) : SortBool{} [format{}("%cisMap%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Map"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisMapIntToVal{}(SortK{}) : SortBool{} [format{}("%cisMapIntToVal%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("MapIntToVal"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [format{}("%cisSet%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Set"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisVal{}(SortK{}) : SortBool{} [format{}("%cisVal%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("Val"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisWasmCell{}(SortK{}) : SortBool{} [format{}("%cisWasmCell%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("WasmCell"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisWasmCellFragment{}(SortK{}) : SortBool{} [format{}("%cisWasmCellFragment%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("WasmCellFragment"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisWasmCellOpt{}(SortK{}) : SortBool{} [format{}("%cisWasmCellOpt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("WasmCellOpt"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  symbol LblisWrappedInt{}(SortK{}) : SortBool{} [format{}("%cisWrappedInt%r %c(%r %1 %c)%r"), function{}(), functional{}(), left{}(), predicate{}("WrappedInt"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(SortMap{}) : SortSet{} [format{}("%ckeys%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("MAP.keys"), klabel{}("keys"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,18,341,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [format{}("%ckeys_list%r %c(%r %1 %c)%r"), function{}(), hook{}("MAP.keys_list"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,19,349,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%clog2Int%r %c(%r %1 %c)%r"), function{}(), hook{}("INT.log2"), klabel{}("log2Int"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1280,18,1280,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'Unds'List'Unds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [format{}("%cmakeList%r %c(... %r length: %1 %c,%r value: %2 %c)%r"), function{}(), hook{}("LIST.make"), klabel{}("makeList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(974,19,974,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101")]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%cmaxInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("INT.max"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1261,18,1261,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("(ite (< #1 #2) #2 #1)"), terminals{}("110101"), total{}()]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [format{}("%cminInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("INT.min"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1260,18,1260,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smt-hook{}("(ite (< #1 #2) #1 #2)"), terminals{}("110101"), total{}()]
+  symbol LblnoGeneratedCounterCell{}() : SortGeneratedCounterCellOpt{} [cellOptAbsent{}("GeneratedCounterCell"), constructor{}(), format{}("%cnoGeneratedCounterCell%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  symbol LblnoInstrsCell{}() : SortInstrsCellOpt{} [cellOptAbsent{}("InstrsCell"), constructor{}(), format{}("%cnoInstrsCell%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  symbol LblnoLocalsCell{}() : SortLocalsCellOpt{} [cellOptAbsent{}("LocalsCell"), constructor{}(), format{}("%cnoLocalsCell%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  symbol LblnoWasmCell{}() : SortWasmCellOpt{} [cellOptAbsent{}("WasmCell"), constructor{}(), format{}("%cnoWasmCell%r"), functional{}(), injective{}(), left{}(), priorities{}(), right{}(), terminals{}("1")]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [format{}("%cnotBool%r %1"), function{}(), functional{}(), group{}("boolOperation"), hook{}("BOOL.not"), klabel{}("notBool_"), latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1100,19,1100,179)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), right{}(), smt-hook{}("not"), symbol'Kywd'{}(), terminals{}("10"), total{}()]
+  symbol Lblproject'Coln'Bool{}(SortK{}) : SortBool{} [format{}("%cproject:Bool%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedCounterCell{}(SortK{}) : SortGeneratedCounterCell{} [format{}("%cproject:GeneratedCounterCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedCounterCellOpt{}(SortK{}) : SortGeneratedCounterCellOpt{} [format{}("%cproject:GeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedTopCell{}(SortK{}) : SortGeneratedTopCell{} [format{}("%cproject:GeneratedTopCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'GeneratedTopCellFragment{}(SortK{}) : SortGeneratedTopCellFragment{} [format{}("%cproject:GeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Instr{}(SortK{}) : SortInstr{} [format{}("%cproject:Instr%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'InstrsCell{}(SortK{}) : SortInstrsCell{} [format{}("%cproject:InstrsCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'InstrsCellOpt{}(SortK{}) : SortInstrsCellOpt{} [format{}("%cproject:InstrsCellOpt%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Int{}(SortK{}) : SortInt{} [format{}("%cproject:Int%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'K{}(SortK{}) : SortK{} [format{}("%cproject:K%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'KItem{}(SortK{}) : SortKItem{} [format{}("%cproject:KItem%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'List{}(SortK{}) : SortList{} [format{}("%cproject:List%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'LocalsCell{}(SortK{}) : SortLocalsCell{} [format{}("%cproject:LocalsCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'LocalsCellOpt{}(SortK{}) : SortLocalsCellOpt{} [format{}("%cproject:LocalsCellOpt%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Map{}(SortK{}) : SortMap{} [format{}("%cproject:Map%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'MapIntToVal{}(SortK{}) : SortMapIntToVal{} [format{}("%cproject:MapIntToVal%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Set{}(SortK{}) : SortSet{} [format{}("%cproject:Set%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'Val{}(SortK{}) : SortVal{} [format{}("%cproject:Val%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'WasmCell{}(SortK{}) : SortWasmCell{} [format{}("%cproject:WasmCell%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'WasmCellFragment{}(SortK{}) : SortWasmCellFragment{} [format{}("%cproject:WasmCellFragment%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'WasmCellOpt{}(SortK{}) : SortWasmCellOpt{} [format{}("%cproject:WasmCellOpt%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  symbol Lblproject'Coln'WrappedInt{}(SortK{}) : SortWrappedInt{} [format{}("%cproject:WrappedInt%r %c(%r %1 %c)%r"), function{}(), left{}(), priorities{}(), projection{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [format{}("%crandInt%r %c(%r %1 %c)%r"), function{}(), hook{}("INT.rand"), impure{}(), klabel{}("randInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1328,18,1328,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [format{}("%cremoveAll%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("MAP.removeAll"), klabel{}("removeAll"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,18,333,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [format{}("%csignExtendBitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}(), hook{}("INT.signExtendBitRange"), klabel{}("signExtendBitRangeInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1295,18,1295,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol Lblsize'LParUndsRParUnds'LIST'Unds'Int'Unds'List{}(SortList{}) : SortInt{} [format{}("%csize%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("LIST.size"), klabel{}("sizeList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1020,18,1020,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_len"), terminals{}("1101"), total{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'MAP'Unds'Int'Unds'Map{}(SortMap{}) : SortInt{} [format{}("%csize%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("MAP.size"), klabel{}("sizeMap"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(373,18,373,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(SortSet{}) : SortInt{} [format{}("%csize%r %c(%r %1 %c)%r"), function{}(), functional{}(), hook{}("SET.size"), klabel{}("size"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(794,18,794,76)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT-COMMON'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [format{}("%csrandInt%r %c(%r %1 %c)%r"), function{}(), hook{}("INT.srand"), impure{}(), klabel{}("srandInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1329,16,1329,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  symbol LblunwrapInt{}(SortWrappedInt{}) : SortInt{} [format{}("%cunwrap%r %c(%r %1 %c)%r"), function{}(), functional{}(), injective{}(), klabel{}("unwrapInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(82,18,82,93)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1101"), total{}()]
+  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [format{}("%cupdateList%r %c(... %r dest: %1 %c,%r index: %2 %c,%r src: %3 %c)%r"), function{}(), hook{}("LIST.updateAll"), klabel{}("updateList"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(984,19,984,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101")]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [format{}("%cupdateMap%r %c(%r %1 %c,%r %2 %c)%r"), function{}(), functional{}(), hook{}("MAP.updateAll"), klabel{}("updateMap"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(324,18,324,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), total{}()]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [format{}("%cvalues%r %c(%r %1 %c)%r"), function{}(), hook{}("MAP.values"), klabel{}("values"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(365,19,365,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101")]
+  symbol LblwrapInt{}(SortInt{}) : SortWrappedInt{} [constructor{}(), format{}("%cwrap%r %c(%r %1 %c)%r"), functional{}(), injective{}(), klabel{}("wrapInt"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(79,25,79,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), priorities{}(), right{}(), symbol'Kywd'{}(), terminals{}("1101")]
+  hooked-symbol Lbl'Tild'Int'Unds'{}(SortInt{}) : SortInt{} [format{}("%c~Int%r %1"), function{}(), functional{}(), hook{}("INT.not"), klabel{}("~Int_"), latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1228,18,1228,168)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsXor-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smtlib{}("notInt"), symbol'Kywd'{}(), terminals{}("10"), total{}()]
+
+// generated axioms
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortWasmCellFragment{}, SortKItem{}} (From:SortWasmCellFragment{}))) [subsort{SortWasmCellFragment{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInstr{}, SortKItem{}} (From:SortInstr{}))) [subsort{SortInstr{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (From:SortGeneratedCounterCellOpt{}))) [subsort{SortGeneratedCounterCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortWasmCell{}, SortKItem{}} (From:SortWasmCell{}))) [subsort{SortWasmCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortWasmCellOpt{}, SortKItem{}} (From:SortWasmCellOpt{}))) [subsort{SortWasmCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSet{}, SortKItem{}} (From:SortSet{}))) [subsort{SortSet{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInstrsCell{}, SortKItem{}} (From:SortInstrsCell{}))) [subsort{SortInstrsCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCell{}, SortKItem{}} (From:SortGeneratedTopCell{}))) [subsort{SortGeneratedTopCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortLocalsCellOpt{}, \equals{SortLocalsCellOpt{}, R} (Val:SortLocalsCellOpt{}, inj{SortLocalsCell{}, SortLocalsCellOpt{}} (From:SortLocalsCell{}))) [subsort{SortLocalsCell{}, SortLocalsCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInstrsCellOpt{}, SortKItem{}} (From:SortInstrsCellOpt{}))) [subsort{SortInstrsCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortInstrsCellOpt{}, \equals{SortInstrsCellOpt{}, R} (Val:SortInstrsCellOpt{}, inj{SortInstrsCell{}, SortInstrsCellOpt{}} (From:SortInstrsCell{}))) [subsort{SortInstrsCell{}, SortInstrsCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortList{}, SortKItem{}} (From:SortList{}))) [subsort{SortList{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBool{}, SortKItem{}} (From:SortBool{}))) [subsort{SortBool{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortVal{}, SortKItem{}} (From:SortVal{}))) [subsort{SortVal{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMapIntToVal{}, SortKItem{}} (From:SortMapIntToVal{}))) [subsort{SortMapIntToVal{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (From:SortGeneratedTopCellFragment{}))) [subsort{SortGeneratedTopCellFragment{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortLocalsCell{}, SortKItem{}} (From:SortLocalsCell{}))) [subsort{SortLocalsCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortWasmCellOpt{}, \equals{SortWasmCellOpt{}, R} (Val:SortWasmCellOpt{}, inj{SortWasmCell{}, SortWasmCellOpt{}} (From:SortWasmCell{}))) [subsort{SortWasmCell{}, SortWasmCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMap{}, SortKItem{}} (From:SortMap{}))) [subsort{SortMap{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortWrappedInt{}, SortKItem{}} (From:SortWrappedInt{}))) [subsort{SortWrappedInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortLocalsCellOpt{}, SortKItem{}} (From:SortLocalsCellOpt{}))) [subsort{SortLocalsCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKConfigVar{}, SortKItem{}} (From:SortKConfigVar{}))) [subsort{SortKConfigVar{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortVal{}, \equals{SortVal{}, R} (Val:SortVal{}, inj{SortWrappedInt{}, SortVal{}} (From:SortWrappedInt{}))) [subsort{SortWrappedInt{}, SortVal{}}()] // subsort
+  axiom{R, SortSort} \exists{R} (Val:SortSort, \equals{SortSort, R} (Val:SortSort, Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(K0:SortBool{}, K1:SortSort, K2:SortSort))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMapIntToVal{}, \equals{SortMapIntToVal{}, R} (Val:SortMapIntToVal{}, Lbl'Stop'MapIntToVal{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Stop'Set{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, Lbl'-LT-'generatedCounter'-GT-'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedCounterCell{}} (\and{SortGeneratedCounterCell{}} (Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{}), Lbl'-LT-'generatedCounter'-GT-'{}(Y0:SortInt{})), Lbl'-LT-'generatedCounter'-GT-'{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCell{}, \equals{SortGeneratedTopCell{}, R} (Val:SortGeneratedTopCell{}, Lbl'-LT-'generatedTop'-GT-'{}(K0:SortWasmCell{}, K1:SortGeneratedCounterCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCell{}} (\and{SortGeneratedTopCell{}} (Lbl'-LT-'generatedTop'-GT-'{}(X0:SortWasmCell{}, X1:SortGeneratedCounterCell{}), Lbl'-LT-'generatedTop'-GT-'{}(Y0:SortWasmCell{}, Y1:SortGeneratedCounterCell{})), Lbl'-LT-'generatedTop'-GT-'{}(\and{SortWasmCell{}} (X0:SortWasmCell{}, Y0:SortWasmCell{}), \and{SortGeneratedCounterCell{}} (X1:SortGeneratedCounterCell{}, Y1:SortGeneratedCounterCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCellFragment{}, \equals{SortGeneratedTopCellFragment{}, R} (Val:SortGeneratedTopCellFragment{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(K0:SortWasmCellOpt{}, K1:SortGeneratedCounterCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCellFragment{}} (\and{SortGeneratedTopCellFragment{}} (Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortWasmCellOpt{}, X1:SortGeneratedCounterCellOpt{}), Lbl'-LT-'generatedTop'-GT-'-fragment{}(Y0:SortWasmCellOpt{}, Y1:SortGeneratedCounterCellOpt{})), Lbl'-LT-'generatedTop'-GT-'-fragment{}(\and{SortWasmCellOpt{}} (X0:SortWasmCellOpt{}, Y0:SortWasmCellOpt{}), \and{SortGeneratedCounterCellOpt{}} (X1:SortGeneratedCounterCellOpt{}, Y1:SortGeneratedCounterCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortInstrsCell{}, \equals{SortInstrsCell{}, R} (Val:SortInstrsCell{}, Lbl'-LT-'instrs'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortInstrsCell{}} (\and{SortInstrsCell{}} (Lbl'-LT-'instrs'-GT-'{}(X0:SortK{}), Lbl'-LT-'instrs'-GT-'{}(Y0:SortK{})), Lbl'-LT-'instrs'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortLocalsCell{}, \equals{SortLocalsCell{}, R} (Val:SortLocalsCell{}, Lbl'-LT-'locals'-GT-'{}(K0:SortMapIntToVal{}))) [functional{}()] // functional
+  axiom{}\implies{SortLocalsCell{}} (\and{SortLocalsCell{}} (Lbl'-LT-'locals'-GT-'{}(X0:SortMapIntToVal{}), Lbl'-LT-'locals'-GT-'{}(Y0:SortMapIntToVal{})), Lbl'-LT-'locals'-GT-'{}(\and{SortMapIntToVal{}} (X0:SortMapIntToVal{}, Y0:SortMapIntToVal{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortWasmCell{}, \equals{SortWasmCell{}, R} (Val:SortWasmCell{}, Lbl'-LT-'wasm'-GT-'{}(K0:SortInstrsCell{}, K1:SortLocalsCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortWasmCell{}} (\and{SortWasmCell{}} (Lbl'-LT-'wasm'-GT-'{}(X0:SortInstrsCell{}, X1:SortLocalsCell{}), Lbl'-LT-'wasm'-GT-'{}(Y0:SortInstrsCell{}, Y1:SortLocalsCell{})), Lbl'-LT-'wasm'-GT-'{}(\and{SortInstrsCell{}} (X0:SortInstrsCell{}, Y0:SortInstrsCell{}), \and{SortLocalsCell{}} (X1:SortLocalsCell{}, Y1:SortLocalsCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortWasmCellFragment{}, \equals{SortWasmCellFragment{}, R} (Val:SortWasmCellFragment{}, Lbl'-LT-'wasm'-GT-'-fragment{}(K0:SortInstrsCellOpt{}, K1:SortLocalsCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortWasmCellFragment{}} (\and{SortWasmCellFragment{}} (Lbl'-LT-'wasm'-GT-'-fragment{}(X0:SortInstrsCellOpt{}, X1:SortLocalsCellOpt{}), Lbl'-LT-'wasm'-GT-'-fragment{}(Y0:SortInstrsCellOpt{}, Y1:SortLocalsCellOpt{})), Lbl'-LT-'wasm'-GT-'-fragment{}(\and{SortInstrsCellOpt{}} (X0:SortInstrsCellOpt{}, Y0:SortInstrsCellOpt{}), \and{SortLocalsCellOpt{}} (X1:SortLocalsCellOpt{}, Y1:SortLocalsCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblMap'Coln'update{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMapIntToVal{}, \equals{SortMapIntToVal{}, R} (Val:SortMapIntToVal{}, LblMapInt2Val'Coln'update{}(K0:SortMapIntToVal{}, K1:SortWrappedInt{}, K2:SortVal{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMapIntToVal{}, \equals{SortMapIntToVal{}, R} (Val:SortMapIntToVal{}, LblMapIntToVal'Coln'primitiveUpdate{}(K0:SortMapIntToVal{}, K1:SortInt{}, K2:SortVal{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortKItem{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMapIntToVal{}, \equals{SortMapIntToVal{}, R} (Val:SortMapIntToVal{}, Lbl'Unds'Int2Val'Pipe'-'-GT-Unds'{}(K0:SortWrappedInt{}, K1:SortVal{}))) [functional{}()] // functional
+  axiom{R} \equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:SortList{},K2:SortList{}),K3:SortList{}),Lbl'Unds'List'Unds'{}(K1:SortList{},Lbl'Unds'List'Unds'{}(K2:SortList{},K3:SortList{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(K:SortList{},Lbl'Stop'List{}()),K:SortList{}) [unit{}()] // right unit
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Stop'List{}(),K:SortList{}),K:SortList{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \equals{SortMapIntToVal{}, R} (Lbl'Unds'MapIntToVal'Unds'{}(Lbl'Unds'MapIntToVal'Unds'{}(K1:SortMapIntToVal{},K2:SortMapIntToVal{}),K3:SortMapIntToVal{}),Lbl'Unds'MapIntToVal'Unds'{}(K1:SortMapIntToVal{},Lbl'Unds'MapIntToVal'Unds'{}(K2:SortMapIntToVal{},K3:SortMapIntToVal{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortMapIntToVal{}, R} (Lbl'Unds'MapIntToVal'Unds'{}(K:SortMapIntToVal{},Lbl'Stop'MapIntToVal{}()),K:SortMapIntToVal{}) [unit{}()] // right unit
+  axiom{R}\equals{SortMapIntToVal{}, R} (Lbl'Unds'MapIntToVal'Unds'{}(Lbl'Stop'MapIntToVal{}(),K:SortMapIntToVal{}),K:SortMapIntToVal{}) [unit{}()] // left unit
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K:SortMap{},Lbl'Stop'Map{}()),K:SortMap{}) [unit{}()] // right unit
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),K:SortMap{}),K:SortMap{}) [unit{}()] // left unit
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},Lbl'Stop'Set{}()),K:SortSet{}) [unit{}()] // right unit
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Stop'Set{}(),K:SortSet{}),K:SortSet{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'Unds'KItem'Unds'Map'Unds'KItem'Unds'KItem{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(K0:SortKItem{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortKItem{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInstr{}, \equals{SortInstr{}, R} (Val:SortInstr{}, Lblinit'Unds'local'UndsUndsUnds'WASM-MAPS'Unds'Instr'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortInstr{}} (\and{SortInstr{}} (Lblinit'Unds'local'UndsUndsUnds'WASM-MAPS'Unds'Instr'Unds'Int'Unds'Int{}(X0:SortInt{}, X1:SortInt{}), Lblinit'Unds'local'UndsUndsUnds'WASM-MAPS'Unds'Instr'Unds'Int'Unds'Int{}(Y0:SortInt{}, Y1:SortInt{})), Lblinit'Unds'local'UndsUndsUnds'WASM-MAPS'Unds'Instr'Unds'Int'Unds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}), \and{SortInt{}} (X1:SortInt{}, Y1:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBool{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCellFragment{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInstr{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInstrsCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInstrsCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKConfigVar{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisList{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisLocalsCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisLocalsCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMap{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMapIntToVal{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisSet{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisVal{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisWasmCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisWasmCellFragment{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisWasmCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisWrappedInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, LblnoGeneratedCounterCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInstrsCellOpt{}, \equals{SortInstrsCellOpt{}, R} (Val:SortInstrsCellOpt{}, LblnoInstrsCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortLocalsCellOpt{}, \equals{SortLocalsCellOpt{}, R} (Val:SortLocalsCellOpt{}, LblnoLocalsCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortWasmCellOpt{}, \equals{SortWasmCellOpt{}, R} (Val:SortWasmCellOpt{}, LblnoWasmCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'LIST'Unds'Int'Unds'List{}(K0:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'MAP'Unds'Int'Unds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblunwrapInt{}(K0:SortWrappedInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortWrappedInt{}, \equals{SortWrappedInt{}, R} (Val:SortWrappedInt{}, LblwrapInt{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortWrappedInt{}} (\and{SortWrappedInt{}} (LblwrapInt{}(X0:SortInt{}), LblwrapInt{}(Y0:SortInt{})), LblwrapInt{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'Unds'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortLocalsCell{}, inj{SortLocalsCell{}, SortKItem{}} (Val:SortLocalsCell{})), \exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \exists{SortKItem{}} (Val:SortWasmCell{}, inj{SortWasmCell{}, SortKItem{}} (Val:SortWasmCell{})), \exists{SortKItem{}} (Val:SortWasmCellFragment{}, inj{SortWasmCellFragment{}, SortKItem{}} (Val:SortWasmCellFragment{})), \exists{SortKItem{}} (Val:SortKConfigVar{}, inj{SortKConfigVar{}, SortKItem{}} (Val:SortKConfigVar{})), \exists{SortKItem{}} (Val:SortInstr{}, inj{SortInstr{}, SortKItem{}} (Val:SortInstr{})), \exists{SortKItem{}} (Val:SortWrappedInt{}, inj{SortWrappedInt{}, SortKItem{}} (Val:SortWrappedInt{})), \exists{SortKItem{}} (Val:SortInstrsCell{}, inj{SortInstrsCell{}, SortKItem{}} (Val:SortInstrsCell{})), \exists{SortKItem{}} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (Val:SortGeneratedCounterCellOpt{})), \exists{SortKItem{}} (Val:SortInstrsCellOpt{}, inj{SortInstrsCellOpt{}, SortKItem{}} (Val:SortInstrsCellOpt{})), \exists{SortKItem{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (Val:SortGeneratedCounterCell{})), \exists{SortKItem{}} (Val:SortWasmCellOpt{}, inj{SortWasmCellOpt{}, SortKItem{}} (Val:SortWasmCellOpt{})), \exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \exists{SortKItem{}} (Val:SortMapIntToVal{}, inj{SortMapIntToVal{}, SortKItem{}} (Val:SortMapIntToVal{})), \exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \exists{SortKItem{}} (Val:SortLocalsCellOpt{}, inj{SortLocalsCellOpt{}, SortKItem{}} (Val:SortLocalsCellOpt{})), \exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \exists{SortKItem{}} (Val:SortVal{}, inj{SortVal{}, SortKItem{}} (Val:SortVal{})), \exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \bottom{SortKItem{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortLocalsCell{}} (\exists{SortLocalsCell{}} (X0:SortMapIntToVal{}, Lbl'-LT-'locals'-GT-'{}(X0:SortMapIntToVal{})), \bottom{SortLocalsCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortWasmCell{}} (\exists{SortWasmCell{}} (X0:SortInstrsCell{}, \exists{SortWasmCell{}} (X1:SortLocalsCell{}, Lbl'-LT-'wasm'-GT-'{}(X0:SortInstrsCell{}, X1:SortLocalsCell{}))), \bottom{SortWasmCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortWasmCellFragment{}} (\exists{SortWasmCellFragment{}} (X0:SortInstrsCellOpt{}, \exists{SortWasmCellFragment{}} (X1:SortLocalsCellOpt{}, Lbl'-LT-'wasm'-GT-'-fragment{}(X0:SortInstrsCellOpt{}, X1:SortLocalsCellOpt{}))), \bottom{SortWasmCellFragment{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortInstr{}} (\exists{SortInstr{}} (X0:SortInt{}, \exists{SortInstr{}} (X1:SortInt{}, Lblinit'Unds'local'UndsUndsUnds'WASM-MAPS'Unds'Instr'Unds'Int'Unds'Int{}(X0:SortInt{}, X1:SortInt{}))), \bottom{SortInstr{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortWrappedInt{}} (\exists{SortWrappedInt{}} (X0:SortInt{}, LblwrapInt{}(X0:SortInt{})), \bottom{SortWrappedInt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortInstrsCell{}} (\exists{SortInstrsCell{}} (X0:SortK{}, Lbl'-LT-'instrs'-GT-'{}(X0:SortK{})), \bottom{SortInstrsCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCellOpt{}} (LblnoGeneratedCounterCell{}(), \exists{SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{})), \bottom{SortGeneratedCounterCellOpt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortInstrsCellOpt{}} (LblnoInstrsCell{}(), \exists{SortInstrsCellOpt{}} (Val:SortInstrsCell{}, inj{SortInstrsCell{}, SortInstrsCellOpt{}} (Val:SortInstrsCell{})), \bottom{SortInstrsCellOpt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortWasmCellOpt{}} (LblnoWasmCell{}(), \exists{SortWasmCellOpt{}} (Val:SortWasmCell{}, inj{SortWasmCell{}, SortWasmCellOpt{}} (Val:SortWasmCell{})), \bottom{SortWasmCellOpt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortLocalsCellOpt{}} (LblnoLocalsCell{}(), \exists{SortLocalsCellOpt{}} (Val:SortLocalsCell{}, inj{SortLocalsCell{}, SortLocalsCellOpt{}} (Val:SortLocalsCell{})), \bottom{SortLocalsCellOpt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCell{}} (\exists{SortGeneratedTopCell{}} (X0:SortWasmCell{}, \exists{SortGeneratedTopCell{}} (X1:SortGeneratedCounterCell{}, Lbl'-LT-'generatedTop'-GT-'{}(X0:SortWasmCell{}, X1:SortGeneratedCounterCell{}))), \bottom{SortGeneratedTopCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortVal{}} (\exists{SortVal{}} (Val:SortWrappedInt{}, inj{SortWrappedInt{}, SortVal{}} (Val:SortWrappedInt{})), \bottom{SortVal{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCellFragment{}} (\exists{SortGeneratedTopCellFragment{}} (X0:SortWasmCellOpt{}, \exists{SortGeneratedTopCellFragment{}} (X1:SortGeneratedCounterCellOpt{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortWasmCellOpt{}, X1:SortGeneratedCounterCellOpt{}))), \bottom{SortGeneratedTopCellFragment{}}()) [constructor{}()] // no junk
+
+// rules
+// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,B1,_Gen0)=>B1 requires C ensures #token("true","Bool") [UNIQUE_ID(2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2), org.kframework.attributes.Location(Location(2304,8,2304,59)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        VarC:SortBool{},
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarB1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB1:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2304,8,2304,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,_Gen0,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [UNIQUE_ID(651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa), org.kframework.attributes.Location(Location(2305,8,2305,67)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        LblnotBool'Unds'{}(VarC:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            VarB2:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB2:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2305,8,2305,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `<generatedTop>`(`<wasm>`(`<instrs>`(inj{Instr,KItem}(`init_local___WASM-MAPS_Instr_Int_Int`(INDEX,VALUE))~>_DotVar2),`<locals>`(LOCALS)),_DotVar0)=>`<generatedTop>`(`<wasm>`(`<instrs>`(_DotVar2),`<locals>`(`MapIntToVal:primitiveUpdate`(LOCALS,INDEX,inj{WrappedInt,Val}(wrapInt(VALUE))))),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bdefee4f9a71fc27b05325e5c6dbc19bfbcfac0f5862067f1d8d630955a6f1ba), org.kframework.attributes.Location(Location(14,8,15,70)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'wasm'-GT-'{}(Lbl'-LT-'instrs'-GT-'{}(kseq{}(inj{SortInstr{}, SortKItem{}}(Lblinit'Unds'local'UndsUndsUnds'WASM-MAPS'Unds'Instr'Unds'Int'Unds'Int{}(VarINDEX:SortInt{},VarVALUE:SortInt{})),Var'Unds'DotVar2:SortK{})),Lbl'-LT-'locals'-GT-'{}(VarLOCALS:SortMapIntToVal{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'wasm'-GT-'{}(Lbl'-LT-'instrs'-GT-'{}(Var'Unds'DotVar2:SortK{}),Lbl'-LT-'locals'-GT-'{}(LblMapIntToVal'Coln'primitiveUpdate{}(VarLOCALS:SortMapIntToVal{},VarINDEX:SortInt{},inj{SortWrappedInt{}, SortVal{}}(LblwrapInt{}(VarVALUE:SortInt{}))))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("bdefee4f9a71fc27b05325e5c6dbc19bfbcfac0f5862067f1d8d630955a6f1ba"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(14,8,15,70)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `MapIntToVal:primitiveUpdate`(M,Key,Value)=>`MapInt2Val:update`(M,wrapInt(Key),Value) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5c16d2da61f238f8c597153890891bb4ca1b504bb2aa62847b44b91d03974c34), org.kframework.attributes.Location(Location(71,8,72,31)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMapIntToVal{}, R} (
+            X0:SortMapIntToVal{},
+            VarM:SortMapIntToVal{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarKey:SortInt{}
+          ),\and{R} (
+          \in{SortVal{}, R} (
+            X2:SortVal{},
+            VarValue:SortVal{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortMapIntToVal{},R} (
+      LblMapIntToVal'Coln'primitiveUpdate{}(X0:SortMapIntToVal{},X1:SortInt{},X2:SortVal{}),
+     \and{SortMapIntToVal{}} (
+       LblMapInt2Val'Coln'update{}(VarM:SortMapIntToVal{},LblwrapInt{}(VarKey:SortInt{}),VarValue:SortVal{}),
+        \top{SortMapIntToVal{}}())))
+  [UNIQUE'Unds'ID{}("5c16d2da61f238f8c597153890891bb4ca1b504bb2aa62847b44b91d03974c34"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(71,8,72,31)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_=/=Bool_`(B1,B2)=>`notBool_`(`_==Bool_`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f), org.kframework.attributes.Location(Location(1150,8,1150,57)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB1:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB2:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(VarB1:SortBool{},VarB2:SortBool{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1150,8,1150,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_=/=Int_`(I1,I2)=>`notBool_`(`_==Int_`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3), org.kframework.attributes.Location(Location(1429,8,1429,53)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Int'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1429,8,1429,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c), org.kframework.attributes.Location(Location(2302,8,2302,45)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarK2:SortK{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2302,8,2302,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497), org.kframework.attributes.Location(Location(1123,8,1123,37)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1123,8,1123,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98), org.kframework.attributes.Location(Location(1122,8,1122,37)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1122,8,1122,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}()]
+
+// rule `_andBool_`(_Gen0,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca), org.kframework.attributes.Location(Location(1124,8,1124,37)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1124,8,1124,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}()]
+
+// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f), org.kframework.attributes.Location(Location(1121,8,1121,37)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1121,8,1121,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andThenBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d), org.kframework.attributes.Location(Location(1128,8,1128,36)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1128,8,1128,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_andThenBool_`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c), org.kframework.attributes.Location(Location(1127,8,1127,37)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(VarK:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1127,8,1127,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}()]
+
+// rule `_andThenBool_`(_Gen0,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2), org.kframework.attributes.Location(Location(1129,8,1129,36)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1129,8,1129,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}()]
+
+// rule `_andThenBool_`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689), org.kframework.attributes.Location(Location(1126,8,1126,37)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1126,8,1126,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_divInt_`(I1,I2)=>`_/Int_`(`_-Int_`(I1,`_modInt_`(I1,I2)),I2) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4), org.kframework.attributes.Location(Location(1418,8,1419,23)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      Lbl'Unds'divInt'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsSlsh'Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1418,8,1419,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `_dividesInt__INT-COMMON_Bool_Int_Int`(I1,I2)=>`_==Int_`(`_%Int_`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5), org.kframework.attributes.Location(Location(1430,8,1430,58)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       Lbl'UndsEqlsEqls'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0")),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1430,8,1430,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_impliesBool_`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96), org.kframework.attributes.Location(Location(1148,8,1148,45)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(VarB:SortBool{}),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1148,8,1148,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}()]
+
+// rule `_impliesBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712), org.kframework.attributes.Location(Location(1147,8,1147,39)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1147,8,1147,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}()]
+
+// rule `_impliesBool_`(#token("false","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e), org.kframework.attributes.Location(Location(1146,8,1146,40)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1146,8,1146,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_impliesBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d), org.kframework.attributes.Location(Location(1145,8,1145,36)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1145,8,1145,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_modInt_`(I1,I2)=>`_%Int_`(`_+Int_`(`_%Int_`(I1,`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6), concrete, org.kframework.attributes.Location(Location(1421,5,1424,23)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \equals{SortInt{},R} (
+      Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsPerc'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1421,5,1424,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), simplification{}()]
+
+// rule `_orBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26), org.kframework.attributes.Location(Location(1138,8,1138,32)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1138,8,1138,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}()]
+
+// rule `_orBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3), org.kframework.attributes.Location(Location(1136,8,1136,34)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1136,8,1136,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}()]
+
+// rule `_orBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b), org.kframework.attributes.Location(Location(1137,8,1137,32)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1137,8,1137,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2), org.kframework.attributes.Location(Location(1135,8,1135,34)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1135,8,1135,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orElseBool_`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480), org.kframework.attributes.Location(Location(1143,8,1143,37)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(VarK:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1143,8,1143,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}()]
+
+// rule `_orElseBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14), org.kframework.attributes.Location(Location(1141,8,1141,33)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1141,8,1141,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}()]
+
+// rule `_orElseBool_`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf), org.kframework.attributes.Location(Location(1142,8,1142,37)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1142,8,1142,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_orElseBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6), org.kframework.attributes.Location(Location(1140,8,1140,33)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1140,8,1140,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_xorBool_`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f), org.kframework.attributes.Location(Location(1133,8,1133,38)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1133,8,1133,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_xorBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75), org.kframework.attributes.Location(Location(1132,8,1132,38)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1132,8,1132,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), simplification{}()]
+
+// rule `_xorBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf), org.kframework.attributes.Location(Location(1131,8,1131,38)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1131,8,1131,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `_|Set__SET_Set_Set_Set`(S1,S2)=>`_Set_`(S1,`Set:difference`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62), concrete, org.kframework.attributes.Location(Location(749,8,749,45)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortSet{}, R} (
+            X0:SortSet{},
+            VarS1:SortSet{}
+          ),\and{R} (
+          \in{SortSet{}, R} (
+            X1:SortSet{},
+            VarS2:SortSet{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortSet{},R} (
+      Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(X0:SortSet{},X1:SortSet{}),
+     \and{SortSet{}} (
+       Lbl'Unds'Set'Unds'{}(VarS1:SortSet{},LblSet'Coln'difference{}(VarS2:SortSet{},VarS1:SortSet{})),
+        \top{SortSet{}}())))
+  [UNIQUE'Unds'ID{}("e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(749,8,749,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_modInt_`(`_>>Int_`(I,IDX),`_<<Int_`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119), org.kframework.attributes.Location(Location(1414,8,1414,85)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'modInt'Unds'{}(Lbl'Unds-GT--GT-'Int'Unds'{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1414,8,1414,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `freshInt(_)_INT_Int_Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b), org.kframework.attributes.Location(Location(1433,8,1433,28)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       VarI:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1433,8,1433,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule getGeneratedCounterCell(`<generatedTop>`(_DotVar0,Cell))=>Cell requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortGeneratedTopCell{}, R} (
+            X0:SortGeneratedTopCell{},
+            Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'DotVar0:SortWasmCell{},VarCell:SortGeneratedCounterCell{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblgetGeneratedCounterCell{}(X0:SortGeneratedTopCell{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarCell:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3")]
+
+// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblinitGeneratedCounterCell{}(),
+     \and{SortGeneratedCounterCell{}} (
+       Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")),
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553"), initializer{}()]
+
+// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initWasmCell(Init),initGeneratedCounterCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f4cc6ece0fdc750cb8ed99cf359c32cb95a2f643fd8c8239554901781e2a87a6), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      LblinitGeneratedTopCell{}(X0:SortMap{}),
+     \and{SortGeneratedTopCell{}} (
+       Lbl'-LT-'generatedTop'-GT-'{}(LblinitWasmCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}()),
+        \top{SortGeneratedTopCell{}}())))
+  [UNIQUE'Unds'ID{}("f4cc6ece0fdc750cb8ed99cf359c32cb95a2f643fd8c8239554901781e2a87a6"), initializer{}()]
+
+// rule initInstrsCell(Init)=>`<instrs>`(`project:KItem`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar"))))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5c0f2673bdeeb7895002697ed273f3ec534b68605801775e1fcb8542f727cfe1), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInstrsCell{},R} (
+      LblinitInstrsCell{}(X0:SortMap{}),
+     \and{SortInstrsCell{}} (
+       Lbl'-LT-'instrs'-GT-'{}(kseq{}(Lblproject'Coln'KItem{}(kseq{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))),dotk{}())),dotk{}())),
+        \top{SortInstrsCell{}}())))
+  [UNIQUE'Unds'ID{}("5c0f2673bdeeb7895002697ed273f3ec534b68605801775e1fcb8542f727cfe1"), initializer{}()]
+
+// rule initLocalsCell(.KList)=>`<locals>`(`.MapIntToVal`(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4ae4708463b54a72beed101c27fc67b3a11fb1e5ec73b0f570cc18c85131a39b), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortLocalsCell{},R} (
+      LblinitLocalsCell{}(),
+     \and{SortLocalsCell{}} (
+       Lbl'-LT-'locals'-GT-'{}(Lbl'Stop'MapIntToVal{}()),
+        \top{SortLocalsCell{}}())))
+  [UNIQUE'Unds'ID{}("4ae4708463b54a72beed101c27fc67b3a11fb1e5ec73b0f570cc18c85131a39b"), initializer{}()]
+
+// rule initWasmCell(Init)=>`<wasm>`(initInstrsCell(Init),initLocalsCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2bc345752f61c0d1f0b7ed946fdb719ded3386cc7b1795bb1237670cf9f750de), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortWasmCell{},R} (
+      LblinitWasmCell{}(X0:SortMap{}),
+     \and{SortWasmCell{}} (
+       Lbl'-LT-'wasm'-GT-'{}(LblinitInstrsCell{}(VarInit:SortMap{}),LblinitLocalsCell{}()),
+        \top{SortWasmCell{}}())))
+  [UNIQUE'Unds'ID{}("2bc345752f61c0d1f0b7ed946fdb719ded3386cc7b1795bb1237670cf9f750de"), initializer{}()]
+
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7f8273ebd616814dbf1acdd96b9534fbaa5b0491bfd05a61916e5015ad4a37ab), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortBool{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'Gen0:SortBool{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7f8273ebd616814dbf1acdd96b9534fbaa5b0491bfd05a61916e5015ad4a37ab"), owise{}()]
+
+// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarBool:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77")]
+
+// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7d501e1637f26769ad3b9439efef0285daa79523b0d071b3a792972ce92e4fe2), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortGeneratedCounterCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(Var'Unds'Gen0:SortGeneratedCounterCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7d501e1637f26769ad3b9439efef0285daa79523b0d071b3a792972ce92e4fe2"), owise{}()]
+
+// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarGeneratedCounterCell:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c")]
+
+// rule isGeneratedCounterCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55e7759c7640aa41fef8271d53c6dd8668aa497704539a65577604ada709c5df), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedCounterCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedCounterCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("55e7759c7640aa41fef8271d53c6dd8668aa497704539a65577604ada709c5df"), owise{}()]
+
+// rule isGeneratedCounterCellOpt(inj{GeneratedCounterCellOpt,KItem}(GeneratedCounterCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarGeneratedCounterCellOpt:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12")]
+
+// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ec16314688c4b2d204af490e243a3e83a2e82fbc74988c3574b997cc9ca56816), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortGeneratedTopCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(Var'Unds'Gen0:SortGeneratedTopCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ec16314688c4b2d204af490e243a3e83a2e82fbc74988c3574b997cc9ca56816"), owise{}()]
+
+// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarGeneratedTopCell:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2")]
+
+// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1f022b25cc5a2adbe99fbae6b50007c803258a5749eb01e05c86096f7b35c0df), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortGeneratedTopCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(Var'Unds'Gen0:SortGeneratedTopCellFragment{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("1f022b25cc5a2adbe99fbae6b50007c803258a5749eb01e05c86096f7b35c0df"), owise{}()]
+
+// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271")]
+
+// rule isInstr(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(6452c8e115a18e500c5218c68af1198eaaeea7bc3fa612d29e1ceeb68e1733cc), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortInstr{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortInstr{}, SortKItem{}}(Var'Unds'Gen0:SortInstr{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisInstr{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("6452c8e115a18e500c5218c68af1198eaaeea7bc3fa612d29e1ceeb68e1733cc"), owise{}()]
+
+// rule isInstr(inj{Instr,KItem}(Instr))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(32d5e89928a2aebb8804d3fb80a3d8be72282b3682a4409df2f6c758e1ed3627)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInstr{}, SortKItem{}}(VarInstr:SortInstr{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisInstr{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("32d5e89928a2aebb8804d3fb80a3d8be72282b3682a4409df2f6c758e1ed3627")]
+
+// rule isInstrsCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(17c6ee106542f0e014f3a80ddbeedae42b1e97b465c2135c847a1886f819038f), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortInstrsCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortInstrsCell{}, SortKItem{}}(Var'Unds'Gen0:SortInstrsCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisInstrsCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("17c6ee106542f0e014f3a80ddbeedae42b1e97b465c2135c847a1886f819038f"), owise{}()]
+
+// rule isInstrsCell(inj{InstrsCell,KItem}(InstrsCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(86fc3bde458288aed9b72ccd7995163c70567d2a511f6c8b619f9ec7353327bc)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInstrsCell{}, SortKItem{}}(VarInstrsCell:SortInstrsCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisInstrsCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("86fc3bde458288aed9b72ccd7995163c70567d2a511f6c8b619f9ec7353327bc")]
+
+// rule isInstrsCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7a3bd88a6b17432614cfd5bc74fe961153cc90fb115081fea6a8237de70025c3), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortInstrsCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortInstrsCellOpt{}, SortKItem{}}(Var'Unds'Gen0:SortInstrsCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisInstrsCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7a3bd88a6b17432614cfd5bc74fe961153cc90fb115081fea6a8237de70025c3"), owise{}()]
+
+// rule isInstrsCellOpt(inj{InstrsCellOpt,KItem}(InstrsCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(235e07b2c47f87a9c87c0620ffdfaa91a427900190e916c6cabd37093791e2c1)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInstrsCellOpt{}, SortKItem{}}(VarInstrsCellOpt:SortInstrsCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisInstrsCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("235e07b2c47f87a9c87c0620ffdfaa91a427900190e916c6cabd37093791e2c1")]
+
+// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5c9850befff40cc79151dbc5a8999b5ffaad767f244ed97f9f29b56b7170bf24), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortInt{}, SortKItem{}}(Var'Unds'Gen0:SortInt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5c9850befff40cc79151dbc5a8999b5ffaad767f244ed97f9f29b56b7170bf24"), owise{}()]
+
+// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarInt:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5")]
+
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisK{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847")]
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f1c02853e001635e66a06d14d1cd322a996f4acbe38a7f9c88df6c97ea6a4677), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKConfigVar{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKConfigVar{}, SortKItem{}}(Var'Unds'Gen1:SortKConfigVar{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f1c02853e001635e66a06d14d1cd322a996f4acbe38a7f9c88df6c97ea6a4677"), owise{}()]
+
+// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKConfigVar{}, SortKItem{}}(VarKConfigVar:SortKConfigVar{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd")]
+
+// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f766beabd3e632a98e221201d003f26f45f1feef2aff6da0ab07edde06a5d99d), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKItem{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(Var'Unds'Gen1:SortKItem{},dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f766beabd3e632a98e221201d003f26f45f1feef2aff6da0ab07edde06a5d99d"), owise{}()]
+
+// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarKItem:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c")]
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0b6d1ffc254fbf57473abfe22e81bcfa646561c43d4e2cc175eab60cfb2b68aa), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortList{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortList{}, SortKItem{}}(Var'Unds'Gen0:SortList{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0b6d1ffc254fbf57473abfe22e81bcfa646561c43d4e2cc175eab60cfb2b68aa"), owise{}()]
+
+// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarList:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446")]
+
+// rule isLocalsCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9817d63d52a58461c855141734aa3d23f7ea1e76e194ee6e3ab2c2b0c33fa589), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortLocalsCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortLocalsCell{}, SortKItem{}}(Var'Unds'Gen0:SortLocalsCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisLocalsCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9817d63d52a58461c855141734aa3d23f7ea1e76e194ee6e3ab2c2b0c33fa589"), owise{}()]
+
+// rule isLocalsCell(inj{LocalsCell,KItem}(LocalsCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fa4650c091f5994506077b95884e38c47891b2345ed078999932e7b17c03c651)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortLocalsCell{}, SortKItem{}}(VarLocalsCell:SortLocalsCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisLocalsCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fa4650c091f5994506077b95884e38c47891b2345ed078999932e7b17c03c651")]
+
+// rule isLocalsCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(740d2e6544dd08f9f721106f3fe999d1791fa48b03202d7e1c469d28f9fedb3a), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortLocalsCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortLocalsCellOpt{}, SortKItem{}}(Var'Unds'Gen1:SortLocalsCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisLocalsCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("740d2e6544dd08f9f721106f3fe999d1791fa48b03202d7e1c469d28f9fedb3a"), owise{}()]
+
+// rule isLocalsCellOpt(inj{LocalsCellOpt,KItem}(LocalsCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(03493a2f3b67ad9f4e694bbb69bf110f4be25464d3e848f61b8d96d69f550965)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortLocalsCellOpt{}, SortKItem{}}(VarLocalsCellOpt:SortLocalsCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisLocalsCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("03493a2f3b67ad9f4e694bbb69bf110f4be25464d3e848f61b8d96d69f550965")]
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5da72349a323db3019243ab26f08b728d336c1a52aecaa0bcb7de4adae14bd71), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortMap{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMap{}, SortKItem{}}(Var'Unds'Gen1:SortMap{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5da72349a323db3019243ab26f08b728d336c1a52aecaa0bcb7de4adae14bd71"), owise{}()]
+
+// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarMap:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795")]
+
+// rule isMapIntToVal(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(df3c580a6ebcd5a1a5ea81d2fa25f9f57ab7d4597a6cbf3c8631b2c2e5b84ab0), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortMapIntToVal{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMapIntToVal{}, SortKItem{}}(Var'Unds'Gen0:SortMapIntToVal{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMapIntToVal{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("df3c580a6ebcd5a1a5ea81d2fa25f9f57ab7d4597a6cbf3c8631b2c2e5b84ab0"), owise{}()]
+
+// rule isMapIntToVal(inj{MapIntToVal,KItem}(MapIntToVal))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bcaf965ca6e2f12c37fe06cbbce333ed340b380a17571abfd953a3c2e7eec22d)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMapIntToVal{}, SortKItem{}}(VarMapIntToVal:SortMapIntToVal{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMapIntToVal{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("bcaf965ca6e2f12c37fe06cbbce333ed340b380a17571abfd953a3c2e7eec22d")]
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4bb33358689dc4ec69171f146dc69c169560a878b09ca872d2c4da9e2dbd0d5e), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortSet{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'Gen1:SortSet{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4bb33358689dc4ec69171f146dc69c169560a878b09ca872d2c4da9e2dbd0d5e"), owise{}()]
+
+// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarSet:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80")]
+
+// rule isVal(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4a97a3cdc97041f9c9ccf2aa7f3aae50aa8a477ddd2452cf26ea68d04ac2bdb8), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortVal{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortVal{}, SortKItem{}}(Var'Unds'Gen0:SortVal{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisVal{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4a97a3cdc97041f9c9ccf2aa7f3aae50aa8a477ddd2452cf26ea68d04ac2bdb8"), owise{}()]
+
+// rule isVal(inj{Val,KItem}(Val))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b5a0241c17a4586755b3028c3e3b0365371f29f68b2a247bb54c7837b5f7b8a3)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortVal{}, SortKItem{}}(VarVal:SortVal{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisVal{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b5a0241c17a4586755b3028c3e3b0365371f29f68b2a247bb54c7837b5f7b8a3")]
+
+// rule isWasmCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(684828e0d626a092811686ecd4d4abebc1f5553c595a367e6b6bde6d3b7f9e2c), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortWasmCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortWasmCell{}, SortKItem{}}(Var'Unds'Gen1:SortWasmCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisWasmCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("684828e0d626a092811686ecd4d4abebc1f5553c595a367e6b6bde6d3b7f9e2c"), owise{}()]
+
+// rule isWasmCell(inj{WasmCell,KItem}(WasmCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(04e780c80e8631b1ec9c8d093d6dc1e26b6b45d48b7ae3a51da0f1d582885edb)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortWasmCell{}, SortKItem{}}(VarWasmCell:SortWasmCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisWasmCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("04e780c80e8631b1ec9c8d093d6dc1e26b6b45d48b7ae3a51da0f1d582885edb")]
+
+// rule isWasmCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9fe9fb7eb8002b9f89f939b2ef76ca052d81ebb31550ac9e1f7144677d93a581), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortWasmCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortWasmCellFragment{}, SortKItem{}}(Var'Unds'Gen0:SortWasmCellFragment{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisWasmCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9fe9fb7eb8002b9f89f939b2ef76ca052d81ebb31550ac9e1f7144677d93a581"), owise{}()]
+
+// rule isWasmCellFragment(inj{WasmCellFragment,KItem}(WasmCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(37f6906de553efbc1184c8e53efbec82f68a725533c78d0d0964b65c2e703fdc)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortWasmCellFragment{}, SortKItem{}}(VarWasmCellFragment:SortWasmCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisWasmCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("37f6906de553efbc1184c8e53efbec82f68a725533c78d0d0964b65c2e703fdc")]
+
+// rule isWasmCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(601c4065f36c00ffb8c0612ad62a12d2e8e690b8000f87406c5f214cb448d667), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortWasmCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortWasmCellOpt{}, SortKItem{}}(Var'Unds'Gen1:SortWasmCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisWasmCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("601c4065f36c00ffb8c0612ad62a12d2e8e690b8000f87406c5f214cb448d667"), owise{}()]
+
+// rule isWasmCellOpt(inj{WasmCellOpt,KItem}(WasmCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(66023199290fe43c11e500707b339d2d90585ce949b70686c7eb72d8b112b6c1)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortWasmCellOpt{}, SortKItem{}}(VarWasmCellOpt:SortWasmCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisWasmCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("66023199290fe43c11e500707b339d2d90585ce949b70686c7eb72d8b112b6c1")]
+
+// rule isWrappedInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(60a97a1dbb59ec45780a1fe0b1cd7da841a8ec5c6ba175c9c5c4e3e70f9b5daf), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortWrappedInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortWrappedInt{}, SortKItem{}}(Var'Unds'Gen1:SortWrappedInt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisWrappedInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("60a97a1dbb59ec45780a1fe0b1cd7da841a8ec5c6ba175c9c5c4e3e70f9b5daf"), owise{}()]
+
+// rule isWrappedInt(inj{WrappedInt,KItem}(WrappedInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5fe9ceb2c66f9d1d14a134016b37f4f68c887afc92ac3027c23e10e07b803591)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortWrappedInt{}, SortKItem{}}(VarWrappedInt:SortWrappedInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisWrappedInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5fe9ceb2c66f9d1d14a134016b37f4f68c887afc92ac3027c23e10e07b803591")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I1 requires `_<=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6), org.kframework.attributes.Location(Location(1426,8,1426,57)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI1:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1426,8,1426,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I2 requires `_>=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3), org.kframework.attributes.Location(Location(1427,8,1427,57)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI2:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1427,8,1427,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]")]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415), org.kframework.attributes.Location(Location(1119,8,1119,29)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1119,8,1119,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c), org.kframework.attributes.Location(Location(1118,8,1118,29)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1118,8,1118,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule `project:Bool`(inj{Bool,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarK:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblproject'Coln'Bool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54"), projection{}()]
+
+// rule `project:GeneratedCounterCell`(inj{GeneratedCounterCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarK:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      Lblproject'Coln'GeneratedCounterCell{}(X0:SortK{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarK:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217"), projection{}()]
+
+// rule `project:GeneratedCounterCellOpt`(inj{GeneratedCounterCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarK:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCellOpt{},R} (
+      Lblproject'Coln'GeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortGeneratedCounterCellOpt{}} (
+       VarK:SortGeneratedCounterCellOpt{},
+        \top{SortGeneratedCounterCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca"), projection{}()]
+
+// rule `project:GeneratedTopCell`(inj{GeneratedTopCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarK:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      Lblproject'Coln'GeneratedTopCell{}(X0:SortK{}),
+     \and{SortGeneratedTopCell{}} (
+       VarK:SortGeneratedTopCell{},
+        \top{SortGeneratedTopCell{}}())))
+  [UNIQUE'Unds'ID{}("b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e"), projection{}()]
+
+// rule `project:GeneratedTopCellFragment`(inj{GeneratedTopCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarK:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCellFragment{},R} (
+      Lblproject'Coln'GeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortGeneratedTopCellFragment{}} (
+       VarK:SortGeneratedTopCellFragment{},
+        \top{SortGeneratedTopCellFragment{}}())))
+  [UNIQUE'Unds'ID{}("2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42"), projection{}()]
+
+// rule `project:Instr`(inj{Instr,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fa58df1e977e9f298aec05bfddf25c51189227bca5c8d9de9e7cba893ada4126), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInstr{}, SortKItem{}}(VarK:SortInstr{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInstr{},R} (
+      Lblproject'Coln'Instr{}(X0:SortK{}),
+     \and{SortInstr{}} (
+       VarK:SortInstr{},
+        \top{SortInstr{}}())))
+  [UNIQUE'Unds'ID{}("fa58df1e977e9f298aec05bfddf25c51189227bca5c8d9de9e7cba893ada4126"), projection{}()]
+
+// rule `project:InstrsCell`(inj{InstrsCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(69b2d0074d3900e0f34ae269cfadb89d7438fd9a1948a89cdab40464b648f24f), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInstrsCell{}, SortKItem{}}(VarK:SortInstrsCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInstrsCell{},R} (
+      Lblproject'Coln'InstrsCell{}(X0:SortK{}),
+     \and{SortInstrsCell{}} (
+       VarK:SortInstrsCell{},
+        \top{SortInstrsCell{}}())))
+  [UNIQUE'Unds'ID{}("69b2d0074d3900e0f34ae269cfadb89d7438fd9a1948a89cdab40464b648f24f"), projection{}()]
+
+// rule `project:InstrsCellOpt`(inj{InstrsCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2eeb2003e0d62164b5b54205b8b17c2c4f71f68ee2d28b48bc129a4f01dd880c), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInstrsCellOpt{}, SortKItem{}}(VarK:SortInstrsCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInstrsCellOpt{},R} (
+      Lblproject'Coln'InstrsCellOpt{}(X0:SortK{}),
+     \and{SortInstrsCellOpt{}} (
+       VarK:SortInstrsCellOpt{},
+        \top{SortInstrsCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("2eeb2003e0d62164b5b54205b8b17c2c4f71f68ee2d28b48bc129a4f01dd880c"), projection{}()]
+
+// rule `project:Int`(inj{Int,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarK:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'Coln'Int{}(X0:SortK{}),
+     \and{SortInt{}} (
+       VarK:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b"), projection{}()]
+
+// rule `project:K`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortK{},R} (
+      Lblproject'Coln'K{}(X0:SortK{}),
+     \and{SortK{}} (
+       VarK:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a"), projection{}()]
+
+// rule `project:KItem`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarK:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKItem{},R} (
+      Lblproject'Coln'KItem{}(X0:SortK{}),
+     \and{SortKItem{}} (
+       VarK:SortKItem{},
+        \top{SortKItem{}}())))
+  [UNIQUE'Unds'ID{}("1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29"), projection{}()]
+
+// rule `project:List`(inj{List,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarK:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortList{},R} (
+      Lblproject'Coln'List{}(X0:SortK{}),
+     \and{SortList{}} (
+       VarK:SortList{},
+        \top{SortList{}}())))
+  [UNIQUE'Unds'ID{}("2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5"), projection{}()]
+
+// rule `project:LocalsCell`(inj{LocalsCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a2bb9f2597d138c2a40bff0dcec4a0c8ded0598fdd7d5a96012a055862fece9d), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortLocalsCell{}, SortKItem{}}(VarK:SortLocalsCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortLocalsCell{},R} (
+      Lblproject'Coln'LocalsCell{}(X0:SortK{}),
+     \and{SortLocalsCell{}} (
+       VarK:SortLocalsCell{},
+        \top{SortLocalsCell{}}())))
+  [UNIQUE'Unds'ID{}("a2bb9f2597d138c2a40bff0dcec4a0c8ded0598fdd7d5a96012a055862fece9d"), projection{}()]
+
+// rule `project:LocalsCellOpt`(inj{LocalsCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(247782334383b7712a30d8a628d216ace6dac45c9a49cfc3bc1efeb70483d07d), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortLocalsCellOpt{}, SortKItem{}}(VarK:SortLocalsCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortLocalsCellOpt{},R} (
+      Lblproject'Coln'LocalsCellOpt{}(X0:SortK{}),
+     \and{SortLocalsCellOpt{}} (
+       VarK:SortLocalsCellOpt{},
+        \top{SortLocalsCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("247782334383b7712a30d8a628d216ace6dac45c9a49cfc3bc1efeb70483d07d"), projection{}()]
+
+// rule `project:Map`(inj{Map,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarK:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMap{},R} (
+      Lblproject'Coln'Map{}(X0:SortK{}),
+     \and{SortMap{}} (
+       VarK:SortMap{},
+        \top{SortMap{}}())))
+  [UNIQUE'Unds'ID{}("031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598"), projection{}()]
+
+// rule `project:MapIntToVal`(inj{MapIntToVal,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b72cf3465bb9ad09eb690c0e4895cf7fdf93674c087f8db4087fe86cc7d6b68e), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMapIntToVal{}, SortKItem{}}(VarK:SortMapIntToVal{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMapIntToVal{},R} (
+      Lblproject'Coln'MapIntToVal{}(X0:SortK{}),
+     \and{SortMapIntToVal{}} (
+       VarK:SortMapIntToVal{},
+        \top{SortMapIntToVal{}}())))
+  [UNIQUE'Unds'ID{}("b72cf3465bb9ad09eb690c0e4895cf7fdf93674c087f8db4087fe86cc7d6b68e"), projection{}()]
+
+// rule `project:Set`(inj{Set,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarK:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortSet{},R} (
+      Lblproject'Coln'Set{}(X0:SortK{}),
+     \and{SortSet{}} (
+       VarK:SortSet{},
+        \top{SortSet{}}())))
+  [UNIQUE'Unds'ID{}("0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0"), projection{}()]
+
+// rule `project:Val`(inj{Val,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(150c95b45e4aa067c3d3df9777c501a0c0693c6b14033fddfccc142e4e37cda8), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortVal{}, SortKItem{}}(VarK:SortVal{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortVal{},R} (
+      Lblproject'Coln'Val{}(X0:SortK{}),
+     \and{SortVal{}} (
+       VarK:SortVal{},
+        \top{SortVal{}}())))
+  [UNIQUE'Unds'ID{}("150c95b45e4aa067c3d3df9777c501a0c0693c6b14033fddfccc142e4e37cda8"), projection{}()]
+
+// rule `project:WasmCell`(inj{WasmCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e8d2f7fcba64d4c79eaa21a004d9057512e5345378a3ffa2fd003a84607c1208), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortWasmCell{}, SortKItem{}}(VarK:SortWasmCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortWasmCell{},R} (
+      Lblproject'Coln'WasmCell{}(X0:SortK{}),
+     \and{SortWasmCell{}} (
+       VarK:SortWasmCell{},
+        \top{SortWasmCell{}}())))
+  [UNIQUE'Unds'ID{}("e8d2f7fcba64d4c79eaa21a004d9057512e5345378a3ffa2fd003a84607c1208"), projection{}()]
+
+// rule `project:WasmCellFragment`(inj{WasmCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fda760717310a00745279e843cf585c2659cc2292346aa8b5430302690c02b41), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortWasmCellFragment{}, SortKItem{}}(VarK:SortWasmCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortWasmCellFragment{},R} (
+      Lblproject'Coln'WasmCellFragment{}(X0:SortK{}),
+     \and{SortWasmCellFragment{}} (
+       VarK:SortWasmCellFragment{},
+        \top{SortWasmCellFragment{}}())))
+  [UNIQUE'Unds'ID{}("fda760717310a00745279e843cf585c2659cc2292346aa8b5430302690c02b41"), projection{}()]
+
+// rule `project:WasmCellOpt`(inj{WasmCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(23bac6c9368fa88332238c7305f6c9e1bd7136f0da83eb2b290fd093faa8abb2), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortWasmCellOpt{}, SortKItem{}}(VarK:SortWasmCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortWasmCellOpt{},R} (
+      Lblproject'Coln'WasmCellOpt{}(X0:SortK{}),
+     \and{SortWasmCellOpt{}} (
+       VarK:SortWasmCellOpt{},
+        \top{SortWasmCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("23bac6c9368fa88332238c7305f6c9e1bd7136f0da83eb2b290fd093faa8abb2"), projection{}()]
+
+// rule `project:WrappedInt`(inj{WrappedInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(92182fd4d6bed16593c0259a27534fdd529b0d355b69c5c1917fbf20a59c7ff7), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortWrappedInt{}, SortKItem{}}(VarK:SortWrappedInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortWrappedInt{},R} (
+      Lblproject'Coln'WrappedInt{}(X0:SortK{}),
+     \and{SortWrappedInt{}} (
+       VarK:SortWrappedInt{},
+        \top{SortWrappedInt{}}())))
+  [UNIQUE'Unds'ID{}("92182fd4d6bed16593c0259a27534fdd529b0d355b69c5c1917fbf20a59c7ff7"), projection{}()]
+
+// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_-Int_`(`_modInt_`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))),`_<<Int_`(#token("1","Int"),LEN)),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f), org.kframework.attributes.Location(Location(1416,8,1416,164)), org.kframework.attributes.Source(Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds'modInt'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1416,8,1416,164)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/nix/store/fdlxg28vyq2il4m7nw52fa88vz0132gk-k-6.1.35-549dc1e2e6a5fa1dc6ea40c35c42ebce47bf4587/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+// rule unwrapInt(wrapInt(A))=>A requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e601dca4586587600919d3f89b5766227014f59d58ef7551baa4bcdf5d9ac03b), org.kframework.attributes.Location(Location(84,8,84,32)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortWrappedInt{}, R} (
+            X0:SortWrappedInt{},
+            LblwrapInt{}(VarA:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblunwrapInt{}(X0:SortWrappedInt{}),
+     \and{SortInt{}} (
+       VarA:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("e601dca4586587600919d3f89b5766227014f59d58ef7551baa4bcdf5d9ac03b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(84,8,84,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]")]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1,1,17,10)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/defn/k-files/wasm-maps.k)")]

--- a/test/input/wasm-maps.in
+++ b/test/input/wasm-maps.in
@@ -1,0 +1,1 @@
+LblinitGeneratedTopCell{}(Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortInstr{}, SortKItem{}}(Lblinit'Unds'local'UndsUndsUnds'WASM-MAPS'Unds'Instr'Unds'Int'Unds'Int{}(\dv{SortInt{}}("1"),\dv{SortInt{}}("2"))))))

--- a/test/output/wasm-maps.out.diff
+++ b/test/output/wasm-maps.out.diff
@@ -1,0 +1,1 @@
+Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'wasm'-GT-'{}(Lbl'-LT-'instrs'-GT-'{}(dotk{}()),Lbl'-LT-'locals'-GT-'{}(\left-assoc{}(Lbl'Unds'MapIntToVal'Unds'{}(Lbl'Unds'Int2Val'Pipe'-'-GT-Unds'{}(LblwrapInt{}(\dv{SortInt{}}("1")),inj{SortWrappedInt{}, SortVal{}}(LblwrapInt{}(\dv{SortInt{}}("2")))))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))

--- a/unittests/runtime-collections/lists.cpp
+++ b/unittests/runtime-collections/lists.cpp
@@ -33,6 +33,10 @@ void *koreAllocToken(size_t requested) {
 }
 const size_t BLOCK_SIZE = -1;
 
+const char **getArgumentSortsForTag(uint32_t tag) {
+  return nullptr;
+}
+
 void printConfigurationInternal(
     writer *file, block *subject, const char *sort, bool, void *) { }
 void sfprintf(writer *, const char *, ...) { }

--- a/unittests/runtime-ffi/ffi.cpp
+++ b/unittests/runtime-ffi/ffi.cpp
@@ -38,6 +38,10 @@ const char *symbols[NUM_SYMBOLS]
        "inj{SortBytes{}, SortKItem{}}",
        "inj{SortFFIType{}, SortKItem{}}"};
 
+const char **getArgumentSortsForTag(uint32_t tag) {
+  return nullptr;
+}
+
 const uint32_t first_inj_tag = 4;
 const uint32_t last_inj_tag = 5;
 

--- a/unittests/runtime-ffi/ffi.cpp
+++ b/unittests/runtime-ffi/ffi.cpp
@@ -14,8 +14,6 @@
 #define KCHAR char
 #define TYPETAG(type) "Lbl'Hash'ffi'Unds'" #type "{}"
 
-char *return_sort_table = nullptr;
-
 void *constructCompositePattern(uint32_t tag, std::vector<void *> &arguments) {
   return nullptr;
 }

--- a/unittests/runtime-io/io.cpp
+++ b/unittests/runtime-io/io.cpp
@@ -14,8 +14,6 @@
 
 #define KCHAR char
 
-char *return_sort_table = nullptr;
-
 void *constructCompositePattern(uint32_t tag, std::vector<void *> &arguments) {
   return nullptr;
 }

--- a/unittests/runtime-strings/bytestest.cpp
+++ b/unittests/runtime-strings/bytestest.cpp
@@ -9,8 +9,6 @@
 #define KCHAR char
 extern "C" {
 
-char *return_sort_table = nullptr;
-
 uint32_t getTagForSymbolName(const char *s) {
   return 0;
 }


### PR DESCRIPTION
This PR changes the way that we print and serialize collection elements. Previously, we assumed that the elements of collections were uniformly of sort `KItem`. This is indeed the case for the built-in `Map`, `Set` and `List` sorts, but the assumption breaks down in the presence of custom collection sorts that sort their elements differently (for example, defining a custom `Map` that requires its keys to only be integers). Terms of these custom sorts are printed incorrectly, with spurious injections into `KItem` rather than their actual element sorts.

The solution to the problem is to look up the argument sorts of the element constructor when printing and serializing collections; the required information is already present in the binary and just requires a bit of refactoring to access.

This PR makes the following changes:
* Adds @geo2a's minimised test case from #886 as a new integration test.
* Refactors the generation of argument and return sort tables when the configuration parser is emitted; previously these did not use the `emitDataTable` infrastructure and so required custom C functions to be written to index into them.
* Look up element sorts using the newly-accessible table when printing collections.

Fixes #886