### PR TITLE
Enable clang-tidy modernization checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@ Checks:
   clang-analyzer-*
   -clang-analyzer-cplusplus.PlacementNew
   modernize-*
-  -modernize-avoid-c-arrays
   -modernize-use-trailing-return-type
 
 WarningsAsErrors:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,7 +3,6 @@ Checks:
   -clang-analyzer-cplusplus.PlacementNew
   modernize-*
   -modernize-avoid-c-arrays
-  -modernize-concat-nested-namespaces
   -modernize-use-trailing-return-type
 
 WarningsAsErrors:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,6 @@ Checks:
   -modernize-raw-string-literal
   -modernize-redundant-void-arg
   -modernize-return-braced-init-list
-  -modernize-use-auto
   -modernize-use-default-member-init
   -modernize-use-trailing-return-type
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,6 @@ Checks:
   -modernize-raw-string-literal
   -modernize-redundant-void-arg
   -modernize-return-braced-init-list
-  -modernize-use-default-member-init
   -modernize-use-trailing-return-type
 
 WarningsAsErrors:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,7 +5,6 @@ Checks:
   -modernize-avoid-c-arrays
   -modernize-concat-nested-namespaces
   -modernize-deprecated-headers
-  -modernize-loop-convert
   -modernize-use-trailing-return-type
 
 WarningsAsErrors:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,6 @@ Checks:
   -modernize-deprecated-headers
   -modernize-loop-convert
   -modernize-macro-to-enum
-  -modernize-raw-string-literal
   -modernize-use-trailing-return-type
 
 WarningsAsErrors:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,6 @@ Checks:
   -modernize-return-braced-init-list
   -modernize-use-auto
   -modernize-use-default-member-init
-  -modernize-use-emplace
   -modernize-use-trailing-return-type
 
 WarningsAsErrors:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,7 +8,6 @@ Checks:
   -modernize-loop-convert
   -modernize-macro-to-enum
   -modernize-raw-string-literal
-  -modernize-redundant-void-arg
   -modernize-use-trailing-return-type
 
 WarningsAsErrors:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,21 @@
 Checks:
   clang-analyzer-*
   -clang-analyzer-cplusplus.PlacementNew
+  modernize-*
+  -modernize-avoid-c-arrays
+  -modernize-concat-nested-namespaces
+  -modernize-deprecated-headers
+  -modernize-loop-convert
+  -modernize-macro-to-enum
+  -modernize-raw-string-literal
+  -modernize-redundant-void-arg
+  -modernize-return-braced-init-list
+  -modernize-use-auto
+  -modernize-use-default-member-init
+  -modernize-use-emplace
+  -modernize-use-nullptr
+  -modernize-use-trailing-return-type
+  -modernize-use-using
 
 WarningsAsErrors:
   '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,7 +15,6 @@ Checks:
   -modernize-use-emplace
   -modernize-use-nullptr
   -modernize-use-trailing-return-type
-  -modernize-use-using
 
 WarningsAsErrors:
   '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,7 +6,6 @@ Checks:
   -modernize-concat-nested-namespaces
   -modernize-deprecated-headers
   -modernize-loop-convert
-  -modernize-macro-to-enum
   -modernize-use-trailing-return-type
 
 WarningsAsErrors:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ Checks:
   -modernize-use-auto
   -modernize-use-default-member-init
   -modernize-use-emplace
-  -modernize-use-nullptr
   -modernize-use-trailing-return-type
 
 WarningsAsErrors:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,6 @@ Checks:
   modernize-*
   -modernize-avoid-c-arrays
   -modernize-concat-nested-namespaces
-  -modernize-deprecated-headers
   -modernize-use-trailing-return-type
 
 WarningsAsErrors:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,6 @@ Checks:
   -modernize-macro-to-enum
   -modernize-raw-string-literal
   -modernize-redundant-void-arg
-  -modernize-return-braced-init-list
   -modernize-use-trailing-return-type
 
 WarningsAsErrors:

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -4,8 +4,9 @@
 #include "kllvm/binary/serializer.h"
 #include "kllvm/parser/KOREParser.h"
 
+#include <fmt/format.h>
+
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <cctype>
 #include <cstdio>
@@ -661,11 +662,7 @@ std::string enquote(std::string str) {
       if ((unsigned char)c >= 32 && (unsigned char)c < 127) {
         result.push_back(c);
       } else {
-        auto buf = std::array<char, 3>{};
-        buf[2] = 0;
-        snprintf(buf.data(), 3, "%02x", (unsigned char)c);
-        result.append("\\x");
-        result.append(buf.data());
+        fmt::format_to(std::back_inserter(result), "\\x{:02x}", c);
       }
       break;
     }
@@ -1886,19 +1883,16 @@ void KORECompositePattern::print(std::ostream &Out, unsigned indent) const {
 }
 
 static std::string escapeString(const std::string &str) {
-  std::string result;
+  auto result = std::string{};
+
   for (char c : str) {
     if (c == '"' || c == '\\' || !isprint(c)) {
-      result.push_back('\\');
-      result.push_back('x');
-      auto code = std::array<char, 3>{};
-      snprintf(code.data(), 3, "%02x", (unsigned char)c);
-      result.push_back(code[0]);
-      result.push_back(code[1]);
+      fmt::format_to(std::back_inserter(result), "\\x{:02x}", c);
     } else {
       result.push_back(c);
     }
   }
+
   return result;
 }
 

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -703,7 +703,7 @@ void KORECompositePattern::prettyPrint(
     std::ostream &out, PrettyPrintData const &data) const {
   std::string name = getConstructor()->getName();
   if (name == "\\dv") {
-    KORECompositeSort *s = dynamic_cast<KORECompositeSort *>(
+    auto *s = dynamic_cast<KORECompositeSort *>(
         getConstructor()->getFormalArguments()[0].get());
     bool hasHook = data.hook.count(s->getName());
     auto str = dynamic_cast<KOREStringPattern *>(arguments[0].get());
@@ -1657,7 +1657,7 @@ KOREAliasDeclaration::getSubstitution(KORECompositePattern *subject) {
   int i = 0;
   KOREPattern::substitution result;
   for (auto &arg : boundVariables->getArguments()) {
-    KOREVariablePattern *var = dynamic_cast<KOREVariablePattern *>(arg.get());
+    auto *var = dynamic_cast<KOREVariablePattern *>(arg.get());
     if (!var) {
       abort();
     }
@@ -1750,7 +1750,7 @@ void KOREDefinition::preprocess() {
   for (auto moditer = modules.begin(); moditer != modules.end(); ++moditer) {
     auto &declarations = (*moditer)->getDeclarations();
     for (auto iter = declarations.begin(); iter != declarations.end(); ++iter) {
-      KORESymbolDeclaration *decl
+      auto *decl
           = dynamic_cast<KORESymbolDeclaration *>(iter->get());
       if (decl == nullptr) {
         continue;

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -407,16 +407,16 @@ sptr<KOREPattern> KORECompositePattern::expandAliases(KOREDefinition *def) {
 static int indent = 0;
 static bool atNewLine = true;
 
-#define INDENT_SIZE 2
-
 static void newline(std::ostream &out) {
   out << std::endl;
   atNewLine = true;
 }
 
 static void printIndent(std::ostream &out) {
+  constexpr auto indent_size = 2;
+
   if (atNewLine) {
-    for (int i = 0; i < INDENT_SIZE * indent; i++) {
+    for (int i = 0; i < indent_size * indent; i++) {
       out << ' ';
     }
     atNewLine = false;
@@ -1750,8 +1750,7 @@ void KOREDefinition::preprocess() {
   for (auto moditer = modules.begin(); moditer != modules.end(); ++moditer) {
     auto &declarations = (*moditer)->getDeclarations();
     for (auto iter = declarations.begin(); iter != declarations.end(); ++iter) {
-      auto *decl
-          = dynamic_cast<KORESymbolDeclaration *>(iter->get());
+      auto *decl = dynamic_cast<KORESymbolDeclaration *>(iter->get());
       if (decl == nullptr) {
         continue;
       }

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -647,7 +647,7 @@ static void color(
 
 #define RESET_COLOR "\x1b[0m"
 
-std::string enquote(std::string str) {
+std::string enquote(const std::string &str) {
   std::string result;
   result.push_back('"');
   for (char c : str) {
@@ -1721,7 +1721,7 @@ void KOREDefinition::preprocess() {
   }
   auto symbols = std::map<std::string, std::vector<KORESymbol *>>{};
   unsigned nextOrdinal = 0;
-  for (auto decl : symbolDeclarations) {
+  for (const auto &decl : symbolDeclarations) {
     if (decl.second->getAttributes().count("freshGenerator")) {
       auto sort = decl.second->getSymbol()->getSort();
       if (sort->isConcrete()) {
@@ -1754,7 +1754,7 @@ void KOREDefinition::preprocess() {
       }
     }
   }
-  for (auto entry : symbols) {
+  for (const auto &entry : symbols) {
     for (auto symbol : entry.second) {
       auto decl = symbolDeclarations.at(symbol->getName());
       symbol->instantiateSymbol(decl);
@@ -1766,7 +1766,7 @@ void KOREDefinition::preprocess() {
   auto layouts = std::unordered_map<std::string, uint16_t>{};
   auto variables
       = std::unordered_map<std::string, std::pair<uint32_t, uint32_t>>{};
-  for (auto entry : symbols) {
+  for (const auto &entry : symbols) {
     uint32_t firstTag = nextSymbol;
     for (auto symbol : entry.second) {
       if (symbol->isConcrete()) {
@@ -1789,7 +1789,7 @@ void KOREDefinition::preprocess() {
           entry.first, std::pair<uint32_t, uint32_t>{firstTag, lastTag});
     }
   }
-  for (auto entry : symbols) {
+  for (const auto &entry : symbols) {
     auto range = variables.at(entry.first);
     for (auto symbol : entry.second) {
       for (auto &sort : symbol->getArguments()) {

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -940,7 +940,7 @@ KORECompositePattern::sortCollections(PrettyPrintData const &data) {
   return result;
 }
 
-std::set<std::string> KOREPattern::gatherSingletonVars(void) {
+std::set<std::string> KOREPattern::gatherSingletonVars() {
   auto counts = gatherVarCounts();
   std::set<std::string> result;
   for (auto entry : counts) {
@@ -951,7 +951,7 @@ std::set<std::string> KOREPattern::gatherSingletonVars(void) {
   return result;
 }
 
-std::map<std::string, int> KORECompositePattern::gatherVarCounts(void) {
+std::map<std::string, int> KORECompositePattern::gatherVarCounts() {
   std::map<std::string, int> result;
   for (auto &arg : arguments) {
     auto childResult = arg->gatherVarCounts();
@@ -962,7 +962,7 @@ std::map<std::string, int> KORECompositePattern::gatherVarCounts(void) {
   return result;
 }
 
-sptr<KOREPattern> KORECompositePattern::dedupeDisjuncts(void) {
+sptr<KOREPattern> KORECompositePattern::dedupeDisjuncts() {
   if (constructor->getName() != "\\or") {
     return shared_from_this();
   }

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -5,6 +5,7 @@
 #include "kllvm/parser/KOREParser.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cctype>
 #include <cstdio>
@@ -660,11 +661,11 @@ std::string enquote(std::string str) {
       if ((unsigned char)c >= 32 && (unsigned char)c < 127) {
         result.push_back(c);
       } else {
-        char buf[3];
+        auto buf = std::array<char, 3>{};
         buf[2] = 0;
-        snprintf(buf, 3, "%02x", (unsigned char)c);
+        snprintf(buf.data(), 3, "%02x", (unsigned char)c);
         result.append("\\x");
-        result.append(buf);
+        result.append(buf.data());
       }
       break;
     }
@@ -1743,9 +1744,9 @@ void KOREDefinition::preprocess() {
       ++iter;
     }
   }
-  for (auto & module : modules) {
+  for (auto &module : modules) {
     auto &declarations = module->getDeclarations();
-    for (const auto & declaration : declarations) {
+    for (const auto &declaration : declarations) {
       auto *decl = dynamic_cast<KORESymbolDeclaration *>(declaration.get());
       if (decl == nullptr) {
         continue;
@@ -1890,8 +1891,8 @@ static std::string escapeString(const std::string &str) {
     if (c == '"' || c == '\\' || !isprint(c)) {
       result.push_back('\\');
       result.push_back('x');
-      char code[3];
-      snprintf(code, 3, "%02x", (unsigned char)c);
+      auto code = std::array<char, 3>{};
+      snprintf(code.data(), 3, "%02x", (unsigned char)c);
       result.push_back(code[0]);
       result.push_back(code[1]);
     } else {

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -648,8 +648,7 @@ color(std::ostream &out, std::string color, PrettyPrintData const &data) {
 std::string enquote(std::string str) {
   std::string result;
   result.push_back('"');
-  for (size_t i = 0; i < str.length(); ++i) {
-    char c = str[i];
+  for (char c : str) {
     switch (c) {
     case '\\': result.append("\\\\"); break;
     case '"': result.append("\\\""); break;
@@ -1719,15 +1718,12 @@ void KOREDefinition::insertReservedSymbols() {
 void KOREDefinition::preprocess() {
   insertReservedSymbols();
 
-  for (auto iter = axioms.begin(); iter != axioms.end(); ++iter) {
-    auto axiom = *iter;
+  for (auto axiom : axioms) {
     axiom->pattern = axiom->pattern->expandAliases(this);
   }
   auto symbols = std::map<std::string, std::vector<KORESymbol *>>{};
   unsigned nextOrdinal = 0;
-  for (auto iter = symbolDeclarations.begin(); iter != symbolDeclarations.end();
-       ++iter) {
-    auto decl = *iter;
+  for (auto decl : symbolDeclarations) {
     if (decl.second->getAttributes().count("freshGenerator")) {
       auto sort = decl.second->getSymbol()->getSort();
       if (sort->isConcrete()) {
@@ -1747,10 +1743,10 @@ void KOREDefinition::preprocess() {
       ++iter;
     }
   }
-  for (auto moditer = modules.begin(); moditer != modules.end(); ++moditer) {
-    auto &declarations = (*moditer)->getDeclarations();
-    for (auto iter = declarations.begin(); iter != declarations.end(); ++iter) {
-      auto *decl = dynamic_cast<KORESymbolDeclaration *>(iter->get());
+  for (auto & module : modules) {
+    auto &declarations = module->getDeclarations();
+    for (const auto & declaration : declarations) {
+      auto *decl = dynamic_cast<KORESymbolDeclaration *>(declaration.get());
       if (decl == nullptr) {
         continue;
       }
@@ -1760,10 +1756,8 @@ void KOREDefinition::preprocess() {
       }
     }
   }
-  for (auto iter = symbols.begin(); iter != symbols.end(); ++iter) {
-    auto entry = *iter;
-    for (auto iter = entry.second.begin(); iter != entry.second.end(); ++iter) {
-      KORESymbol *symbol = *iter;
+  for (auto entry : symbols) {
+    for (auto symbol : entry.second) {
       auto decl = symbolDeclarations.at(symbol->getName());
       symbol->instantiateSymbol(decl);
     }
@@ -1774,11 +1768,9 @@ void KOREDefinition::preprocess() {
   auto layouts = std::unordered_map<std::string, uint16_t>{};
   auto variables
       = std::unordered_map<std::string, std::pair<uint32_t, uint32_t>>{};
-  for (auto iter = symbols.begin(); iter != symbols.end(); ++iter) {
-    auto entry = *iter;
+  for (auto entry : symbols) {
     uint32_t firstTag = nextSymbol;
-    for (auto iter = entry.second.begin(); iter != entry.second.end(); ++iter) {
-      KORESymbol *symbol = *iter;
+    for (auto symbol : entry.second) {
       if (symbol->isConcrete()) {
         if (!instantiations.count(*symbol)) {
           instantiations.emplace(*symbol, nextSymbol++);
@@ -1799,11 +1791,9 @@ void KOREDefinition::preprocess() {
           entry.first, std::pair<uint32_t, uint32_t>{firstTag, lastTag});
     }
   }
-  for (auto iter = symbols.begin(); iter != symbols.end(); ++iter) {
-    auto entry = *iter;
+  for (auto entry : symbols) {
     auto range = variables.at(entry.first);
-    for (auto iter = entry.second.begin(); iter != entry.second.end(); ++iter) {
-      KORESymbol *symbol = *iter;
+    for (auto symbol : entry.second) {
       for (auto &sort : symbol->getArguments()) {
         if (sort->isConcrete()) {
           hookedSorts[dynamic_cast<KORECompositeSort *>(sort.get())

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -913,7 +913,7 @@ KORECompositePattern::sortCollections(PrettyPrintData const &data) {
       std::ostringstream Out;
       item = item->sortCollections(data);
       item->prettyPrint(Out, newData);
-      printed.push_back({Out.str(), item});
+      printed.emplace_back(Out.str(), item);
     }
     indent = oldIndent;
     atNewLine = oldAtNewLine;

--- a/lib/ast/CMakeLists.txt
+++ b/lib/ast/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(AST
 )
 
 target_link_libraries(AST
-  PUBLIC Parser BinaryKore)
+  PUBLIC fmt::fmt-header-only Parser BinaryKore)
 
 install(
   TARGETS AST

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -7,7 +7,7 @@ namespace detail {
 
 bool is_big_endian() {
   uint32_t i = 1;
-  uint8_t *c = reinterpret_cast<uint8_t *>(&i);
+  auto *c = reinterpret_cast<uint8_t *>(&i);
   return *c == 0x00;
 }
 

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -32,7 +32,7 @@ serializer::serializer(flags f)
 
 std::string serializer::byte_string() const {
   auto *ptr = reinterpret_cast<unsigned char const *>(buffer_.data());
-  return std::string(ptr, ptr + buffer_.size());
+  return {ptr, ptr + buffer_.size()};
 }
 
 void serializer::reset() {

--- a/lib/codegen/CreateStaticTerm.cpp
+++ b/lib/codegen/CreateStaticTerm.cpp
@@ -148,8 +148,7 @@ CreateStaticTerm::createToken(ValueType sort, std::string contents) {
     llvm::Constant *global = Module->getOrInsertGlobal(
         "int_" + contents, llvm::StructType::getTypeByName(
                                Module->getContext(), INT_WRAPPER_STRUCT));
-    auto *globalVar
-        = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    auto *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       mpz_t value;
       const char *dataStart
@@ -161,8 +160,7 @@ CreateStaticTerm::createToken(ValueType sort, std::string contents) {
           = llvm::ArrayType::get(llvm::Type::getInt64Ty(Ctx), size);
       llvm::Constant *limbs
           = Module->getOrInsertGlobal("int_" + contents + "_limbs", limbsType);
-      auto *limbsVar
-          = llvm::dyn_cast<llvm::GlobalVariable>(limbs);
+      auto *limbsVar = llvm::dyn_cast<llvm::GlobalVariable>(limbs);
       std::vector<llvm::Constant *> allocdLimbs;
       for (size_t i = 0; i < size; i++) {
         allocdLimbs.push_back(llvm::ConstantInt::get(
@@ -204,8 +202,7 @@ CreateStaticTerm::createToken(ValueType sort, std::string contents) {
     llvm::Constant *global = Module->getOrInsertGlobal(
         "float_" + contents, llvm::StructType::getTypeByName(
                                  Module->getContext(), FLOAT_WRAPPER_STRUCT));
-    auto *globalVar
-        = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    auto *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       size_t prec, exp;
       const char last = contents.back();
@@ -245,8 +242,7 @@ CreateStaticTerm::createToken(ValueType sort, std::string contents) {
           = llvm::ArrayType::get(llvm::Type::getInt64Ty(Ctx), size);
       llvm::Constant *limbs = Module->getOrInsertGlobal(
           "float_" + contents + "_limbs", limbsType);
-      auto *limbsVar
-          = llvm::dyn_cast<llvm::GlobalVariable>(limbs);
+      auto *limbsVar = llvm::dyn_cast<llvm::GlobalVariable>(limbs);
       std::vector<llvm::Constant *> allocdLimbs;
       for (size_t i = 0; i < size; i++) {
         allocdLimbs.push_back(llvm::ConstantInt::get(
@@ -318,8 +314,7 @@ CreateStaticTerm::createToken(ValueType sort, std::string contents) {
          llvm::ArrayType::get(llvm::Type::getInt8Ty(Ctx), contents.size())});
     llvm::Constant *global
         = Module->getOrInsertGlobal("token_" + escape(contents), StringType);
-    auto *globalVar
-        = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    auto *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       llvm::StructType *BlockHeaderType = llvm::StructType::getTypeByName(
           Module->getContext(), BLOCKHEADER_STRUCT);

--- a/lib/codegen/CreateStaticTerm.cpp
+++ b/lib/codegen/CreateStaticTerm.cpp
@@ -40,7 +40,7 @@ llvm::Constant *CreateStaticTerm::notInjectionCase(
   constructor->print(koreString);
   llvm::Constant *Block
       = Module->getOrInsertGlobal(koreString.str().c_str(), BlockType);
-  llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(Block);
+  auto *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(Block);
 
   if (!globalVar->hasInitializer()) {
     std::vector<llvm::Constant *> blockVals;
@@ -148,7 +148,7 @@ CreateStaticTerm::createToken(ValueType sort, std::string contents) {
     llvm::Constant *global = Module->getOrInsertGlobal(
         "int_" + contents, llvm::StructType::getTypeByName(
                                Module->getContext(), INT_WRAPPER_STRUCT));
-    llvm::GlobalVariable *globalVar
+    auto *globalVar
         = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       mpz_t value;
@@ -161,7 +161,7 @@ CreateStaticTerm::createToken(ValueType sort, std::string contents) {
           = llvm::ArrayType::get(llvm::Type::getInt64Ty(Ctx), size);
       llvm::Constant *limbs
           = Module->getOrInsertGlobal("int_" + contents + "_limbs", limbsType);
-      llvm::GlobalVariable *limbsVar
+      auto *limbsVar
           = llvm::dyn_cast<llvm::GlobalVariable>(limbs);
       std::vector<llvm::Constant *> allocdLimbs;
       for (size_t i = 0; i < size; i++) {
@@ -204,7 +204,7 @@ CreateStaticTerm::createToken(ValueType sort, std::string contents) {
     llvm::Constant *global = Module->getOrInsertGlobal(
         "float_" + contents, llvm::StructType::getTypeByName(
                                  Module->getContext(), FLOAT_WRAPPER_STRUCT));
-    llvm::GlobalVariable *globalVar
+    auto *globalVar
         = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       size_t prec, exp;
@@ -245,7 +245,7 @@ CreateStaticTerm::createToken(ValueType sort, std::string contents) {
           = llvm::ArrayType::get(llvm::Type::getInt64Ty(Ctx), size);
       llvm::Constant *limbs = Module->getOrInsertGlobal(
           "float_" + contents + "_limbs", limbsType);
-      llvm::GlobalVariable *limbsVar
+      auto *limbsVar
           = llvm::dyn_cast<llvm::GlobalVariable>(limbs);
       std::vector<llvm::Constant *> allocdLimbs;
       for (size_t i = 0; i < size; i++) {
@@ -318,7 +318,7 @@ CreateStaticTerm::createToken(ValueType sort, std::string contents) {
          llvm::ArrayType::get(llvm::Type::getInt8Ty(Ctx), contents.size())});
     llvm::Constant *global
         = Module->getOrInsertGlobal("token_" + escape(contents), StringType);
-    llvm::GlobalVariable *globalVar
+    auto *globalVar
         = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       llvm::StructType *BlockHeaderType = llvm::StructType::getTypeByName(

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -995,7 +995,7 @@ bool makeFunction(
   std::vector<llvm::Type *> paramTypes;
   std::vector<std::string> paramNames;
   std::vector<llvm::Metadata *> debugArgs;
-  for (auto & entry : vars) {
+  for (auto &entry : vars) {
     auto sort
         = dynamic_cast<KORECompositeSort *>(entry.second->getSort().get());
     if (!sort) {
@@ -1113,7 +1113,7 @@ std::string makeApplyRuleFunction(
   std::vector<llvm::Type *> paramTypes;
   std::vector<std::string> paramNames;
   std::vector<llvm::Metadata *> debugArgs;
-  for (auto & entry : vars) {
+  for (auto &entry : vars) {
     auto sort
         = dynamic_cast<KORECompositeSort *>(entry.second->getSort().get());
     if (!sort) {

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -136,7 +136,7 @@ void addKompiledDirSymbol(
     bool debug) {
   auto Str = llvm::ConstantDataArray::getString(Context, dir, true);
   auto global = mod->getOrInsertGlobal(KOMPILED_DIR, Str->getType());
-  llvm::GlobalVariable *globalVar = llvm::cast<llvm::GlobalVariable>(global);
+  auto *globalVar = llvm::cast<llvm::GlobalVariable>(global);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(Str);
   }
@@ -411,7 +411,7 @@ llvm::Value *CreateTerm::createHook(
     assert(pattern->getArguments().size() == 2);
     llvm::Value *firstArg = alloc_arg(pattern, 0, locationStack);
     llvm::Value *secondArg = alloc_arg(pattern, 1, locationStack);
-    llvm::ICmpInst *Eq = new llvm::ICmpInst(
+    auto *Eq = new llvm::ICmpInst(
         *CurrentBlock, llvm::CmpInst::ICMP_EQ, firstArg, secondArg,
         "hook_BOOL_eq");
     return Eq;
@@ -432,14 +432,14 @@ llvm::Value *CreateTerm::createHook(
     llvm::Value *falseArg = alloc_arg(pattern, 2, locationStack);
     if (trueArg->getType()->isPointerTy()
         && !falseArg->getType()->isPointerTy()) {
-      llvm::AllocaInst *AllocCollection
+      auto *AllocCollection
           = new llvm::AllocaInst(falseArg->getType(), 0, "", CurrentBlock);
       new llvm::StoreInst(falseArg, AllocCollection, CurrentBlock);
       falseArg = AllocCollection;
     } else if (
         !trueArg->getType()->isPointerTy()
         && falseArg->getType()->isPointerTy()) {
-      llvm::AllocaInst *AllocCollection
+      auto *AllocCollection
           = new llvm::AllocaInst(trueArg->getType(), 0, "", NewTrueBlock);
       new llvm::StoreInst(trueArg, AllocCollection, NewTrueBlock);
       trueArg = AllocCollection;
@@ -686,7 +686,7 @@ llvm::Value *CreateTerm::createFunctionCall(
     case SortCategory::List:
     case SortCategory::Set: {
       if (!arg->getType()->isPointerTy()) {
-        llvm::AllocaInst *AllocCollection
+        auto *AllocCollection
             = new llvm::AllocaInst(arg->getType(), 0, "", CurrentBlock);
         new llvm::StoreInst(arg, AllocCollection, CurrentBlock);
         args.push_back(AllocCollection);

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -719,6 +719,7 @@ llvm::Value *CreateTerm::createFunctionCall(
   default: sret = false; break;
   }
   llvm::Value *AllocSret;
+  types.reserve(args.size());
   for (auto arg : args) {
     types.push_back(arg->getType());
   }

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -719,8 +719,7 @@ llvm::Value *CreateTerm::createFunctionCall(
   default: sret = false; break;
   }
   llvm::Value *AllocSret;
-  for (int i = 0; i < args.size(); i++) {
-    llvm::Value *arg = args[i];
+  for (auto arg : args) {
     types.push_back(arg->getType());
   }
   std::vector<llvm::Value *> realArgs = args;
@@ -996,8 +995,7 @@ bool makeFunction(
   std::vector<llvm::Type *> paramTypes;
   std::vector<std::string> paramNames;
   std::vector<llvm::Metadata *> debugArgs;
-  for (auto iter = vars.begin(); iter != vars.end(); ++iter) {
-    auto &entry = *iter;
+  for (auto & entry : vars) {
     auto sort
         = dynamic_cast<KORECompositeSort *>(entry.second->getSort().get());
     if (!sort) {
@@ -1115,8 +1113,7 @@ std::string makeApplyRuleFunction(
   std::vector<llvm::Type *> paramTypes;
   std::vector<std::string> paramNames;
   std::vector<llvm::Metadata *> debugArgs;
-  for (auto iter = vars.begin(); iter != vars.end(); ++iter) {
-    auto &entry = *iter;
+  for (auto & entry : vars) {
     auto sort
         = dynamic_cast<KORECompositeSort *>(entry.second->getSort().get());
     if (!sort) {

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -56,7 +56,7 @@ void initDebugInfo(llvm::Module *module, std::string filename) {
       llvm::DICompileUnit::DebugNameTableKind::None);
 }
 
-void finalizeDebugInfo(void) {
+void finalizeDebugInfo() {
   Dbg->finalize();
 }
 
@@ -128,7 +128,7 @@ void initDebugAxiom(
   DbgFile = Dbg->createFile(source, DbgFile->getDirectory());
 }
 
-void resetDebugLoc(void) {
+void resetDebugLoc() {
   if (!Dbg)
     return;
   DbgLine = 0;
@@ -209,29 +209,29 @@ llvm::DIType *getDebugType(ValueType type, std::string typeName) {
   }
 }
 
-llvm::DIType *getIntDebugType(void) {
+llvm::DIType *getIntDebugType() {
   if (!Dbg)
     return nullptr;
   return Dbg->createBasicType("uint32_t", 32, llvm::dwarf::DW_ATE_unsigned);
 }
 
-llvm::DIType *getLongDebugType(void) {
+llvm::DIType *getLongDebugType() {
   if (!Dbg)
     return nullptr;
   return Dbg->createBasicType("uint64_t", 64, llvm::dwarf::DW_ATE_unsigned);
 }
 
-llvm::DIType *getBoolDebugType(void) {
+llvm::DIType *getBoolDebugType() {
   if (!Dbg)
     return nullptr;
   return Dbg->createBasicType("bool", 8, llvm::dwarf::DW_ATE_boolean);
 }
 
-llvm::DIType *getVoidDebugType(void) {
+llvm::DIType *getVoidDebugType() {
   return nullptr;
 }
 
-llvm::DIType *getCharPtrDebugType(void) {
+llvm::DIType *getCharPtrDebugType() {
   if (!Dbg)
     return nullptr;
   return Dbg->createPointerType(
@@ -239,7 +239,7 @@ llvm::DIType *getCharPtrDebugType(void) {
       sizeof(size_t) * 8);
 }
 
-llvm::DIType *getCharDebugType(void) {
+llvm::DIType *getCharDebugType() {
   if (!Dbg)
     return nullptr;
   return Dbg->createBasicType("char", 8, llvm::dwarf::DW_ATE_signed_char);
@@ -261,7 +261,7 @@ getArrayDebugType(llvm::DIType *ty, size_t len, llvm::Align align) {
   return Dbg->createArrayType(len, align.value(), ty, arr);
 }
 
-llvm::DIType *getShortDebugType(void) {
+llvm::DIType *getShortDebugType() {
   if (!Dbg)
     return nullptr;
   return Dbg->createBasicType("uint16_t", 16, llvm::dwarf::DW_ATE_unsigned);

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -237,7 +237,7 @@ void SwitchNode::codegen(Decision *d) {
       int offset = 0;
       llvm::StructType *BlockType
           = getBlockType(d->Module, d->Definition, _case.getConstructor());
-      llvm::BitCastInst *Cast = new llvm::BitCastInst(
+      auto *Cast = new llvm::BitCastInst(
           val, llvm::PointerType::getUnqual(BlockType), "", d->CurrentBlock);
       KORESymbolDeclaration *symbolDecl
           = d->Definition->getSymbolDeclarations().at(
@@ -671,7 +671,7 @@ void Decision::store(var_type name, llvm::Value *val) {
 llvm::Constant *Decision::stringLiteral(std::string str) {
   auto Str = llvm::ConstantDataArray::getString(Ctx, str, true);
   auto global = Module->getOrInsertGlobal("str_lit_" + str, Str->getType());
-  llvm::GlobalVariable *globalVar = llvm::cast<llvm::GlobalVariable>(global);
+  auto *globalVar = llvm::cast<llvm::GlobalVariable>(global);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(Str);
   }
@@ -691,9 +691,9 @@ static void initChoiceBuffer(
   dt->preprocess(leaves);
   auto ty = llvm::ArrayType::get(
       llvm::Type::getInt8PtrTy(module->getContext()), dt->getChoiceDepth() + 1);
-  llvm::AllocaInst *choiceBuffer
+  auto *choiceBuffer
       = new llvm::AllocaInst(ty, 0, "choiceBuffer", block);
-  llvm::AllocaInst *choiceDepth = new llvm::AllocaInst(
+  auto *choiceDepth = new llvm::AllocaInst(
       llvm::Type::getInt64Ty(module->getContext()), 0, "choiceDepth", block);
   auto zero
       = llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 0);
@@ -703,11 +703,11 @@ static void initChoiceBuffer(
   new llvm::StoreInst(
       llvm::BlockAddress::get(block->getParent(), stuck), firstElt, block);
 
-  llvm::LoadInst *currDepth = new llvm::LoadInst(
+  auto *currDepth = new llvm::LoadInst(
       llvm::Type::getInt64Ty(module->getContext()), choiceDepth, "", fail);
   auto currentElt = llvm::GetElementPtrInst::CreateInBounds(
       ty, choiceBuffer, {zero, currDepth}, "", fail);
-  llvm::LoadInst *failAddress
+  auto *failAddress
       = new llvm::LoadInst(ty->getElementType(), currentElt, "", fail);
   auto newDepth = llvm::BinaryOperator::Create(
       llvm::Instruction::Sub, currDepth,
@@ -998,7 +998,7 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(
       elements);
   auto layout = module->getOrInsertGlobal(
       "layout_item_rule_" + std::to_string(ordinal), layoutArr->getType());
-  llvm::GlobalVariable *globalVar = llvm::cast<llvm::GlobalVariable>(layout);
+  auto *globalVar = llvm::cast<llvm::GlobalVariable>(layout);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(layoutArr);
   }

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -110,10 +110,8 @@ getFailPattern(DecisionCase const &_case, bool isInt) {
     auto result = fmt::format("{}(", ast_to_string(*_case.getConstructor()));
 
     std::string conn = "";
-    for (const auto & i : _case.getConstructor()->getArguments()) {
-      result += fmt::format(
-          "{}Var'Unds':{}", conn,
-          ast_to_string(*i));
+    for (const auto &i : _case.getConstructor()->getArguments()) {
+      result += fmt::format("{}Var'Unds':{}", conn, ast_to_string(*i));
       conn = ",";
     }
     result += ")";
@@ -691,8 +689,7 @@ static void initChoiceBuffer(
   dt->preprocess(leaves);
   auto ty = llvm::ArrayType::get(
       llvm::Type::getInt8PtrTy(module->getContext()), dt->getChoiceDepth() + 1);
-  auto *choiceBuffer
-      = new llvm::AllocaInst(ty, 0, "choiceBuffer", block);
+  auto *choiceBuffer = new llvm::AllocaInst(ty, 0, "choiceBuffer", block);
   auto *choiceDepth = new llvm::AllocaInst(
       llvm::Type::getInt64Ty(module->getContext()), 0, "choiceDepth", block);
   auto zero

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -171,7 +171,7 @@ void SwitchNode::codegen(Decision *d) {
     }
     if (auto sym = _case.getConstructor()) {
       isInt = isInt || sym->getName() == "\\dv";
-      caseData.push_back(std::make_pair(CaseBlock, &_case));
+      caseData.emplace_back(CaseBlock, &_case);
     } else {
       _default = CaseBlock;
       defaultCase = &_case;

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -110,10 +110,10 @@ getFailPattern(DecisionCase const &_case, bool isInt) {
     auto result = fmt::format("{}(", ast_to_string(*_case.getConstructor()));
 
     std::string conn = "";
-    for (int i = 0; i < _case.getConstructor()->getArguments().size(); i++) {
+    for (const auto & i : _case.getConstructor()->getArguments()) {
       result += fmt::format(
           "{}Var'Unds':{}", conn,
-          ast_to_string(*_case.getConstructor()->getArguments()[i]));
+          ast_to_string(*i));
       conn = ",";
     }
     result += ")";

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -83,8 +83,8 @@ public:
   }
 
   std::string str(yaml_node_t *node) {
-    return std::string(
-        (char *)node->data.scalar.value, node->data.scalar.length);
+    return {
+        (char *)node->data.scalar.value, node->data.scalar.length};
   }
 
   std::vector<std::string> vec(yaml_node_t *node) {

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -158,7 +158,7 @@ public:
         name = str(o);
       }
       ValueType hook = KORECompositeSort::getCategory(str(get(node, "hook")));
-      uses.push_back(std::make_pair(name, getParamType(hook, mod)));
+      uses.emplace_back(name, getParamType(hook, mod));
       return KOREVariablePattern::Create(name, sorts.at(hook));
     } else if (get(node, "literal")) {
       auto sym = KORESymbol::Create("\\dv");
@@ -264,9 +264,8 @@ public:
           newOccurrence.insert(newOccurrence.begin(), std::to_string(i));
           std::string binding = to_string(newOccurrence);
           std::string hook = str(get(get(_case, 2), i));
-          bindings.push_back(std::make_pair(
-              binding,
-              getParamType(KORECompositeSort::getCategory(hook), mod)));
+          bindings.emplace_back(
+              binding, getParamType(KORECompositeSort::getCategory(hook), mod));
         }
       }
       DecisionNode *child = (*this)(get(_case, 1));

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -83,8 +83,7 @@ public:
   }
 
   std::string str(yaml_node_t *node) {
-    return {
-        (char *)node->data.scalar.value, node->data.scalar.length};
+    return {(char *)node->data.scalar.value, node->data.scalar.length};
   }
 
   std::vector<std::string> vec(yaml_node_t *node) {

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -91,8 +91,7 @@ emitGetTagForSymbolName(KOREDefinition *definition, llvm::Module *module) {
       MergeBlock);
   auto &syms = definition->getAllSymbols();
   llvm::Function *Strcmp = getStrcmp(module);
-  for (auto iter = syms.begin(); iter != syms.end(); ++iter) {
-    auto &entry = *iter;
+  for (const auto & entry : syms) {
     uint32_t tag = entry.second->getTag();
     auto symbol = entry.second;
     CurrentBlock->insertInto(func);
@@ -153,8 +152,7 @@ static void emitDataTableForSymbol(
           dity, syms.size(), llvm::DataLayout(module).getABITypeAlign(ty)),
       globalVar);
   std::vector<llvm::Constant *> values;
-  for (auto iter = syms.begin(); iter != syms.end(); ++iter) {
-    auto entry = *iter;
+  for (auto entry : syms) {
     auto symbol = entry.second;
     auto val = getter(definition, module, symbol);
     values.push_back(val);
@@ -202,8 +200,7 @@ static void emitDataForSymbol(
       func->arg_begin(), stuck, syms.size(), EntryBlock);
   auto Phi = llvm::PHINode::Create(
       ty, definition->getSymbols().size(), "phi", MergeBlock);
-  for (auto iter = syms.begin(); iter != syms.end(); ++iter) {
-    auto entry = *iter;
+  for (auto entry : syms) {
     uint32_t tag = entry.first;
     auto symbol = entry.second;
     auto decl = definition->getSymbolDeclarations().at(symbol->getName());
@@ -429,8 +426,7 @@ emitGetTagForFreshSort(KOREDefinition *definition, llvm::Module *module) {
   llvm::Constant *zero32
       = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0);
   bool hasCase = false;
-  for (auto iter = sorts.begin(); iter != sorts.end(); ++iter) {
-    auto &entry = *iter;
+  for (const auto & entry : sorts) {
     std::string name = entry.first;
     if (!definition->getFreshFunctions().count(name)) {
       continue;
@@ -494,8 +490,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
   llvm::Constant *zero32
       = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0);
-  for (auto iter = sorts.begin(); iter != sorts.end(); ++iter) {
-    auto &entry = *iter;
+  for (const auto & entry : sorts) {
     std::string name = entry.first;
     if (!entry.second->getObjectSortVariables().empty()) {
       // TODO: MINT in initial configuration
@@ -817,8 +812,7 @@ static void emitTraversal(
   auto &syms = definition->getSymbols();
   auto Switch = llvm::SwitchInst::Create(Tag, stuck, syms.size(), EntryBlock);
 
-  for (auto iter = syms.begin(); iter != syms.end(); ++iter) {
-    auto entry = *iter;
+  for (auto entry : syms) {
     uint32_t tag = entry.first;
     auto symbol = entry.second;
     if (symbol->getArguments().empty()) {
@@ -1199,8 +1193,7 @@ static void emitLayouts(KOREDefinition *definition, llvm::Module *module) {
       llvm::PointerType::getUnqual(
           llvm::StructType::getTypeByName(module->getContext(), LAYOUT_STRUCT)),
       layouts.size(), "phi", MergeBlock);
-  for (auto iter = layouts.begin(); iter != layouts.end(); ++iter) {
-    auto entry = *iter;
+  for (auto entry : layouts) {
     uint16_t layout = entry.first;
     auto symbol = entry.second;
     auto CaseBlock = llvm::BasicBlock::Create(
@@ -1262,8 +1255,8 @@ static void emitSortTable(KOREDefinition *def, llvm::Module *mod) {
     auto indices = std::vector<llvm::Constant *>{zero, zero};
 
     std::vector<llvm::Constant *> subvalues;
-    for (size_t i = 0; i < symbol->getArguments().size(); ++i) {
-      auto arg_str = ast_to_string(*symbol->getArguments()[i]);
+    for (const auto & i : symbol->getArguments()) {
+      auto arg_str = ast_to_string(*i);
       auto strType = llvm::ArrayType::get(
           llvm::Type::getInt8Ty(ctx), arg_str.size() + 1);
       auto sortName = module->getOrInsertGlobal(

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -52,8 +52,7 @@ static llvm::Constant *getSymbolNamePtr(
   auto Str = llvm::ConstantDataArray::getString(Ctx, name, true);
   auto global = module->getOrInsertGlobal(
       fmt::format("sym_name_{}", name), Str->getType());
-  llvm::GlobalVariable *globalVar
-      = llvm::dyn_cast<llvm::GlobalVariable>(global);
+  auto *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(Str);
   }
@@ -147,7 +146,7 @@ static void emitDataTableForSymbol(
   llvm::BranchInst::Create(MergeBlock, stuck, icmp, EntryBlock);
   auto tableType = llvm::ArrayType::get(ty, syms.size());
   auto table = module->getOrInsertGlobal("table_" + name, tableType);
-  llvm::GlobalVariable *globalVar = llvm::cast<llvm::GlobalVariable>(table);
+  auto *globalVar = llvm::cast<llvm::GlobalVariable>(table);
   initDebugGlobal(
       "table_" + name,
       getArrayDebugType(
@@ -442,7 +441,7 @@ emitGetTagForFreshSort(KOREDefinition *definition, llvm::Module *module) {
     auto Str = llvm::ConstantDataArray::getString(Ctx, name, true);
     auto global
         = module->getOrInsertGlobal("sort_name_" + name, Str->getType());
-    llvm::GlobalVariable *globalVar = llvm::cast<llvm::GlobalVariable>(global);
+    auto *globalVar = llvm::cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       globalVar->setInitializer(Str);
     }
@@ -512,8 +511,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
     auto Str = llvm::ConstantDataArray::getString(Ctx, name, true);
     auto global
         = module->getOrInsertGlobal("sort_name_" + name, Str->getType());
-    llvm::GlobalVariable *globalVar
-        = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    auto *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       globalVar->setInitializer(Str);
     }
@@ -540,8 +538,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
     case SortCategory::Bool: {
       auto Str = llvm::ConstantDataArray::getString(Ctx, "true", false);
       auto global = module->getOrInsertGlobal("bool_true", Str->getType());
-      llvm::GlobalVariable *globalVar
-          = llvm::dyn_cast<llvm::GlobalVariable>(global);
+      auto *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
       if (!globalVar->hasInitializer()) {
         globalVar->setInitializer(Str);
       }
@@ -956,8 +953,7 @@ static void getVisitor(
     auto Str = llvm::ConstantDataArray::getString(Ctx, sort_name, true);
     auto global = module->getOrInsertGlobal(
         fmt::format("sort_name_{}", sort_name), Str->getType());
-    llvm::GlobalVariable *globalVar
-        = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    auto *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       globalVar->setInitializer(Str);
     }
@@ -1152,8 +1148,7 @@ static llvm::Constant *getLayoutData(
       elements);
   auto global = module->getOrInsertGlobal(
       "layout_item_" + std::to_string(layout), Arr->getType());
-  llvm::GlobalVariable *globalVar
-      = llvm::dyn_cast<llvm::GlobalVariable>(global);
+  auto *globalVar = llvm::cast<llvm::GlobalVariable>(global);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(Arr);
   }
@@ -1165,8 +1160,7 @@ static llvm::Constant *getLayoutData(
   auto global2 = module->getOrInsertGlobal(
       name,
       llvm::StructType::getTypeByName(module->getContext(), LAYOUT_STRUCT));
-  llvm::GlobalVariable *globalVar2
-      = llvm::dyn_cast<llvm::GlobalVariable>(global2);
+  auto *globalVar2 = llvm::cast<llvm::GlobalVariable>(global2);
   initDebugGlobal(name, getForwardDecl(LAYOUT_STRUCT), globalVar2);
   if (!globalVar2->hasInitializer()) {
     globalVar2->setInitializer(llvm::ConstantStruct::get(
@@ -1231,7 +1225,7 @@ static void emitInjTags(KOREDefinition *def, llvm::Module *mod) {
   llvm::LLVMContext &Ctx = mod->getContext();
   auto global
       = mod->getOrInsertGlobal("first_inj_tag", llvm::Type::getInt32Ty(Ctx));
-  llvm::GlobalVariable *globalVar = llvm::cast<llvm::GlobalVariable>(global);
+  auto *globalVar = llvm::cast<llvm::GlobalVariable>(global);
   globalVar->setConstant(true);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(llvm::ConstantInt::get(
@@ -1255,8 +1249,7 @@ static void emitSortTable(KOREDefinition *def, llvm::Module *mod) {
         llvm::Type::getInt8PtrTy(ctx), symbol->getArguments().size());
     auto subtable = module->getOrInsertGlobal(
         fmt::format("sorts_{}", ast_to_string(*symbol)), subtableType);
-    llvm::GlobalVariable *subtableVar
-        = llvm::dyn_cast<llvm::GlobalVariable>(subtable);
+    auto *subtableVar = llvm::dyn_cast<llvm::GlobalVariable>(subtable);
     initDebugGlobal(
         "sorts_" + symbol->getName(),
         getArrayDebugType(

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -91,7 +91,7 @@ emitGetTagForSymbolName(KOREDefinition *definition, llvm::Module *module) {
       MergeBlock);
   auto &syms = definition->getAllSymbols();
   llvm::Function *Strcmp = getStrcmp(module);
-  for (const auto & entry : syms) {
+  for (const auto &entry : syms) {
     uint32_t tag = entry.second->getTag();
     auto symbol = entry.second;
     CurrentBlock->insertInto(func);
@@ -426,7 +426,7 @@ emitGetTagForFreshSort(KOREDefinition *definition, llvm::Module *module) {
   llvm::Constant *zero32
       = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0);
   bool hasCase = false;
-  for (const auto & entry : sorts) {
+  for (const auto &entry : sorts) {
     std::string name = entry.first;
     if (!definition->getFreshFunctions().count(name)) {
       continue;
@@ -490,7 +490,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
   llvm::Constant *zero32
       = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0);
-  for (const auto & entry : sorts) {
+  for (const auto &entry : sorts) {
     std::string name = entry.first;
     if (!entry.second->getObjectSortVariables().empty()) {
       // TODO: MINT in initial configuration
@@ -1255,7 +1255,7 @@ static void emitSortTable(KOREDefinition *def, llvm::Module *mod) {
     auto indices = std::vector<llvm::Constant *>{zero, zero};
 
     std::vector<llvm::Constant *> subvalues;
-    for (const auto & i : symbol->getArguments()) {
+    for (const auto &i : symbol->getArguments()) {
       auto arg_str = ast_to_string(*i);
       auto strType = llvm::ArrayType::get(
           llvm::Type::getInt8Ty(ctx), arg_str.size() + 1);

--- a/lib/parser/KOREParser.cpp
+++ b/lib/parser/KOREParser.cpp
@@ -70,7 +70,7 @@ std::string KOREParser::consume(token next) {
   error(loc, "Expected: " + str(next) + " Actual: " + str(actual));
 }
 
-token KOREParser::peek(void) {
+token KOREParser::peek() {
   std::string data;
   if (buffer.tok == token::EMPTY) {
     buffer.tok = scanner.yylex(&data, &loc);
@@ -141,7 +141,7 @@ void KOREParser::sentences(KOREModule *node) {
   }
 }
 
-std::vector<ptr<KOREDeclaration>> KOREParser::declarations(void) {
+std::vector<ptr<KOREDeclaration>> KOREParser::declarations() {
   std::vector<ptr<KOREDeclaration>> decls;
   while (peek() != token::TOKEN_EOF) {
     auto decl = sentence();

--- a/lib/parser/KOREParser.cpp
+++ b/lib/parser/KOREParser.cpp
@@ -444,4 +444,4 @@ void KOREParser::patternsNE(std::vector<sptr<KOREPattern>> &node) {
   }
 }
 
-} // namespace kllvm
+} // namespace kllvm::parser

--- a/lib/parser/KOREParser.cpp
+++ b/lib/parser/KOREParser.cpp
@@ -9,8 +9,7 @@
 #include <iostream>
 #include <unistd.h>
 
-namespace kllvm {
-namespace parser {
+namespace kllvm::parser {
 
 std::unique_ptr<KOREParser> KOREParser::from_string(std::string text) {
   auto temp_file = temporary_file("tmp.parse.XXXXXX");
@@ -445,5 +444,4 @@ void KOREParser::patternsNE(std::vector<sptr<KOREPattern>> &node) {
   }
 }
 
-} // namespace parser
 } // namespace kllvm

--- a/lib/printer/printer.cpp
+++ b/lib/printer/printer.cpp
@@ -367,10 +367,8 @@ std::ostream &printKORE(
     axiom->getPattern()->markSymbols(symbols);
   }
 
-  for (auto iter = symbols.begin(); iter != symbols.end(); ++iter) {
-    auto &entry = *iter;
-    for (auto iter = entry.second.begin(); iter != entry.second.end(); ++iter) {
-      KORESymbol *symbol = *iter;
+  for (auto & entry : symbols) {
+    for (auto symbol : entry.second) {
       auto decl = def->getSymbolDeclarations().at(symbol->getName());
       symbol->instantiateSymbol(decl);
     }

--- a/lib/printer/printer.cpp
+++ b/lib/printer/printer.cpp
@@ -367,7 +367,7 @@ std::ostream &printKORE(
     axiom->getPattern()->markSymbols(symbols);
   }
 
-  for (auto & entry : symbols) {
+  for (auto &entry : symbols) {
     for (auto symbol : entry.second) {
       auto decl = def->getSymbolDeclarations().at(symbol->getName());
       symbol->instantiateSymbol(decl);

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -110,13 +110,13 @@ void *koreResizeLastAlloc(void *oldptr, size_t newrequest, size_t last_size) {
 }
 
 void *koreAllocMP(size_t requested) {
-  string *_new = (string *)koreAllocToken(sizeof(string) + requested);
+  auto *_new = (string *)koreAllocToken(sizeof(string) + requested);
   init_with_len(_new, requested);
   return _new->data;
 }
 
 void *koreReallocMP(void *ptr, size_t old_size, size_t new_size) {
-  string *_new = (string *)koreAllocToken(sizeof(string) + new_size);
+  auto *_new = (string *)koreAllocToken(sizeof(string) + new_size);
   size_t min = old_size > new_size ? new_size : old_size;
   memcpy(_new->data, ptr, min);
   init_with_len(_new, new_size);
@@ -126,25 +126,25 @@ void *koreReallocMP(void *ptr, size_t old_size, size_t new_size) {
 void koreFree(void *ptr, size_t size) { }
 
 __attribute__((always_inline)) void *koreAllocInteger(size_t requested) {
-  mpz_hdr *result = (mpz_hdr *)koreAlloc(sizeof(mpz_hdr));
+  auto *result = (mpz_hdr *)koreAlloc(sizeof(mpz_hdr));
   init_with_len(result, sizeof(mpz_hdr) - sizeof(blockheader));
   return &result->i;
 }
 
 __attribute__((always_inline)) void *koreAllocFloating(size_t requested) {
-  floating_hdr *result = (floating_hdr *)koreAlloc(sizeof(floating_hdr));
+  auto *result = (floating_hdr *)koreAlloc(sizeof(floating_hdr));
   init_with_len(result, sizeof(floating_hdr) - sizeof(blockheader));
   return &result->f;
 }
 
 __attribute__((always_inline)) void *koreAllocIntegerOld(size_t requested) {
-  mpz_hdr *result = (mpz_hdr *)koreAllocOld(sizeof(mpz_hdr));
+  auto *result = (mpz_hdr *)koreAllocOld(sizeof(mpz_hdr));
   init_with_len(result, sizeof(mpz_hdr) - sizeof(blockheader));
   return &result->i;
 }
 
 __attribute__((always_inline)) void *koreAllocFloatingOld(size_t requested) {
-  floating_hdr *result = (floating_hdr *)koreAllocOld(sizeof(floating_hdr));
+  auto *result = (floating_hdr *)koreAllocOld(sizeof(floating_hdr));
   init_with_len(result, sizeof(floating_hdr) - sizeof(blockheader));
   return &result->f;
 }

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -1,9 +1,9 @@
 #include <gmp.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "runtime/alloc.h"
 #include "runtime/arena.h"

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -1,8 +1,8 @@
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "runtime/alloc.h"
 #include "runtime/arena.h"

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -61,7 +61,7 @@ static void *megabyte_malloc() {
     if (next_superblock_ptr) {
       *next_superblock_ptr = (char *)superblock_ptr;
     }
-    memory_block_header *hdr = (memory_block_header *)superblock_ptr;
+    auto *hdr = (memory_block_header *)superblock_ptr;
     next_superblock_ptr = &hdr->next_superblock;
     hdr->next_superblock = nullptr;
   }
@@ -76,7 +76,7 @@ static void freshBlock(struct arena *Arena) {
   if (Arena->block_start == nullptr) {
     nextBlock = (char *)megabyte_malloc();
     Arena->first_block = nextBlock;
-    memory_block_header *nextHeader = (memory_block_header *)nextBlock;
+    auto *nextHeader = (memory_block_header *)nextBlock;
     nextHeader->next_block = nullptr;
     nextHeader->semispace = Arena->allocation_semispace_id;
     Arena->num_blocks++;
@@ -97,7 +97,7 @@ static void freshBlock(struct arena *Arena) {
           Arena->allocation_semispace_id);
       nextBlock = (char *)megabyte_malloc();
       *(char **)Arena->block_start = nextBlock;
-      memory_block_header *nextHeader = (memory_block_header *)nextBlock;
+      auto *nextHeader = (memory_block_header *)nextBlock;
       nextHeader->next_block = nullptr;
       nextHeader->semispace = Arena->allocation_semispace_id;
       Arena->num_blocks++;
@@ -233,9 +233,9 @@ size_t arenaSize(const struct arena *Arena) {
 }
 
 void freeAllMemory() {
-  memory_block_header *superblock = (memory_block_header *)first_superblock_ptr;
+  auto *superblock = (memory_block_header *)first_superblock_ptr;
   while (superblock) {
-    memory_block_header *next_superblock
+    auto *next_superblock
         = (memory_block_header *)superblock->next_superblock;
     free(superblock);
     superblock = next_superblock;

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -18,11 +18,11 @@ __attribute__((always_inline)) void arenaReset(struct arena *Arena) {
   if (id < 0) {
     id = ~Arena->allocation_semispace_id;
   }
-  Arena->first_block = 0;
-  Arena->block = 0;
-  Arena->block_start = 0;
-  Arena->block_end = 0;
-  Arena->first_collection_block = 0;
+  Arena->first_block = nullptr;
+  Arena->block = nullptr;
+  Arena->block_start = nullptr;
+  Arena->block_end = nullptr;
+  Arena->first_collection_block = nullptr;
   Arena->num_blocks = 0;
   Arena->num_collection_blocks = 0;
   Arena->allocation_semispace_id = id;
@@ -42,9 +42,9 @@ __attribute__((always_inline)) char getArenaSemispaceIDOfObject(void *ptr) {
   return mem_block_header(ptr)->semispace;
 }
 
-static void *first_superblock_ptr = 0;
-static void *superblock_ptr = 0;
-static char **next_superblock_ptr = 0;
+static void *first_superblock_ptr = nullptr;
+static void *superblock_ptr = nullptr;
+static char **next_superblock_ptr = nullptr;
 static unsigned blocks_left = 0;
 
 static void *megabyte_malloc() {
@@ -63,7 +63,7 @@ static void *megabyte_malloc() {
     }
     memory_block_header *hdr = (memory_block_header *)superblock_ptr;
     next_superblock_ptr = &hdr->next_superblock;
-    hdr->next_superblock = 0;
+    hdr->next_superblock = nullptr;
   }
   blocks_left--;
   void *result = superblock_ptr;
@@ -73,11 +73,11 @@ static void *megabyte_malloc() {
 
 static void freshBlock(struct arena *Arena) {
   char *nextBlock;
-  if (Arena->block_start == 0) {
+  if (Arena->block_start == nullptr) {
     nextBlock = (char *)megabyte_malloc();
     Arena->first_block = nextBlock;
     memory_block_header *nextHeader = (memory_block_header *)nextBlock;
-    nextHeader->next_block = 0;
+    nextHeader->next_block = nullptr;
     nextHeader->semispace = Arena->allocation_semispace_id;
     Arena->num_blocks++;
   } else {
@@ -98,7 +98,7 @@ static void freshBlock(struct arena *Arena) {
       nextBlock = (char *)megabyte_malloc();
       *(char **)Arena->block_start = nextBlock;
       memory_block_header *nextHeader = (memory_block_header *)nextBlock;
-      nextHeader->next_block = 0;
+      nextHeader->next_block = nullptr;
       nextHeader->semispace = Arena->allocation_semispace_id;
       Arena->num_blocks++;
     }
@@ -148,7 +148,7 @@ arenaResizeLastAlloc(struct arena *Arena, ssize_t increase) {
     Arena->block += increase;
     return Arena->block;
   }
-  return 0;
+  return nullptr;
 }
 
 __attribute__((always_inline)) void arenaSwapAndClear(struct arena *Arena) {
@@ -165,14 +165,15 @@ __attribute__((always_inline)) void arenaSwapAndClear(struct arena *Arena) {
 __attribute__((always_inline)) void arenaClear(struct arena *Arena) {
   Arena->block = Arena->first_block
                      ? Arena->first_block + sizeof(memory_block_header)
-                     : 0;
+                     : nullptr;
   Arena->block_start = Arena->first_block;
-  Arena->block_end = Arena->first_block ? Arena->first_block + BLOCK_SIZE : 0;
+  Arena->block_end
+      = Arena->first_block ? Arena->first_block + BLOCK_SIZE : nullptr;
 }
 
 __attribute__((always_inline)) char *arenaStartPtr(const struct arena *Arena) {
   return Arena->first_block ? Arena->first_block + sizeof(memory_block_header)
-                            : 0;
+                            : nullptr;
 }
 
 __attribute__((always_inline)) char **arenaEndPtr(struct arena *Arena) {
@@ -182,14 +183,14 @@ __attribute__((always_inline)) char **arenaEndPtr(struct arena *Arena) {
 char *movePtr(char *ptr, size_t size, const char *arena_end_ptr) {
   char *next_ptr = ptr + size;
   if (next_ptr == arena_end_ptr) {
-    return 0;
+    return nullptr;
   }
   if (next_ptr != mem_block_start(ptr) + BLOCK_SIZE) {
     return next_ptr;
   }
   char *next_block = *(char **)mem_block_start(ptr);
   if (!next_block) {
-    return 0;
+    return nullptr;
   }
   return next_block + sizeof(memory_block_header);
 }
@@ -203,7 +204,7 @@ ssize_t ptrDiff(char *ptr1, char *ptr2) {
   while (hdr != mem_block_header(ptr1) && hdr->next_block) {
     if (ptr2) {
       result += ((char *)hdr + BLOCK_SIZE) - ptr2;
-      ptr2 = NULL;
+      ptr2 = nullptr;
     } else {
       result += (BLOCK_SIZE - sizeof(memory_block_header));
     }
@@ -239,8 +240,8 @@ void freeAllMemory() {
     free(superblock);
     superblock = next_superblock;
   }
-  first_superblock_ptr = 0;
-  superblock_ptr = 0;
-  next_superblock_ptr = 0;
+  first_superblock_ptr = nullptr;
+  superblock_ptr = nullptr;
+  next_superblock_ptr = nullptr;
   blocks_left = 0;
 }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -235,8 +235,7 @@ size_t arenaSize(const struct arena *Arena) {
 void freeAllMemory() {
   auto *superblock = (memory_block_header *)first_superblock_ptr;
   while (superblock) {
-    auto *next_superblock
-        = (memory_block_header *)superblock->next_superblock;
+    auto *next_superblock = (memory_block_header *)superblock->next_superblock;
     free(superblock);
     superblock = next_superblock;
   }

--- a/runtime/arithmetic/int.cpp
+++ b/runtime/arithmetic/int.cpp
@@ -413,7 +413,7 @@ size_t *hook_MINT_export(mpz_t in, uint64_t bits) {
     count = 0;
   uint64_t alloccount = nwords > count ? nwords : count;
   size_t allocsize = alloccount * sizeof(size_t);
-  size_t *allocptr = (size_t *)koreAllocAlwaysGC(allocsize);
+  auto *allocptr = (size_t *)koreAllocAlwaysGC(allocsize);
   memset(allocptr, 0, allocsize);
   size_t *exportptr = nwords > count ? allocptr + nwords - count : allocptr;
   size_t actualcount;

--- a/runtime/arithmetic/int.cpp
+++ b/runtime/arithmetic/int.cpp
@@ -392,7 +392,7 @@ SortInt hook_INT_rand(SortInt upperBound) {
   mpz_init(result);
   if (!kllvm_randStateInitialized) {
     gmp_randinit_default(kllvm_randState);
-    mpz_set_si(result, time(NULL));
+    mpz_set_si(result, time(nullptr));
     gmp_randseed(kllvm_randState, result);
     kllvm_randStateInitialized = true;
   }

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -51,7 +51,7 @@ void migrate(block **blockPtr) {
   initialize_migrate();
   uint16_t layout = layout_hdr(hdr);
   size_t lenInBytes = get_size(hdr, layout);
-  block **forwardingAddress = (block **)(currBlock + 1);
+  auto **forwardingAddress = (block **)(currBlock + 1);
   if (!hasForwardingAddress) {
     block *newBlock;
     if (shouldPromote || (isInOldGen && collect_old)) {
@@ -221,7 +221,7 @@ migrate_child(void *currBlock, layoutitem *args, unsigned i, bool ptr) {
 }
 
 static char *evacuate(char *scan_ptr, char **alloc_ptr) {
-  block *currBlock = (block *)scan_ptr;
+  auto *currBlock = (block *)scan_ptr;
   const uint64_t hdr = currBlock->h.hdr;
   uint16_t layoutInt = layout_hdr(hdr);
   if (layoutInt) {

--- a/runtime/collect/migrate_roots.cpp
+++ b/runtime/collect/migrate_roots.cpp
@@ -33,10 +33,10 @@ void migrateRoots() {
   for (auto iter = blockEnumerators.begin(); iter != blockEnumerators.end();
        iter++) {
     auto BlockIteratorPair = (*(*iter))();
-    block_iterator BlockStartIt = BlockIteratorPair.first;
-    block_iterator BlockEndIt = BlockIteratorPair.second;
+    auto BlockStartIt = BlockIteratorPair.first;
+    auto BlockEndIt = BlockIteratorPair.second;
 
-    for (block_iterator it = BlockStartIt; it != BlockEndIt; ++it) {
+    for (auto it = BlockStartIt; it != BlockEndIt; ++it) {
       migrate(*it);
     }
   }

--- a/runtime/collect/migrate_roots.cpp
+++ b/runtime/collect/migrate_roots.cpp
@@ -30,7 +30,7 @@ void migrateRoots() {
     return;
   }
 
-  for (auto & blockEnumerator : blockEnumerators) {
+  for (auto &blockEnumerator : blockEnumerators) {
     auto BlockIteratorPair = (*blockEnumerator)();
     auto BlockStartIt = BlockIteratorPair.first;
     auto BlockEndIt = BlockIteratorPair.second;

--- a/runtime/collect/migrate_roots.cpp
+++ b/runtime/collect/migrate_roots.cpp
@@ -30,9 +30,8 @@ void migrateRoots() {
     return;
   }
 
-  for (auto iter = blockEnumerators.begin(); iter != blockEnumerators.end();
-       iter++) {
-    auto BlockIteratorPair = (*(*iter))();
+  for (auto & blockEnumerator : blockEnumerators) {
+    auto BlockIteratorPair = (*blockEnumerator)();
     auto BlockStartIt = BlockIteratorPair.first;
     auto BlockEndIt = BlockIteratorPair.second;
 

--- a/runtime/collections/hash.cpp
+++ b/runtime/collections/hash.cpp
@@ -14,13 +14,13 @@ static constexpr uint32_t HASH_THRESHOLD = 5;
 static constexpr uint32_t HASH_LENGTH_THRESHOLD = 1024;
 
 __attribute__((always_inline)) void add_hash8(void *h, uint8_t data) {
-  size_t *hash = (size_t *)h;
+  auto *hash = (size_t *)h;
   *hash = ((*hash) ^ ((size_t)data)) * 1099511628211UL;
   hash_length++;
 }
 
 __attribute__((always_inline)) void add_hash64(void *h, uint64_t data) {
-  uint8_t *buf = (uint8_t *)&data;
+  auto *buf = (uint8_t *)&data;
   add_hash8(h, buf[0]);
   add_hash8(h, buf[1]);
   add_hash8(h, buf[2]);
@@ -62,7 +62,7 @@ void hash_exit() {
 
 void k_hash(block *arg, void *h) {
   if (hash_enter()) {
-    uint64_t argintptr = (uint64_t)arg;
+    auto argintptr = (uint64_t)arg;
     if (is_leaf_block(arg)) {
       add_hash64(h, argintptr);
     } else {
@@ -81,7 +81,7 @@ void k_hash(block *arg, void *h) {
             break;
           }
           case RANGEMAP_LAYOUT: {
-            rangemap *rangemapptr = (rangemap *)(argintptr + offset);
+            auto *rangemapptr = (rangemap *)(argintptr + offset);
             rangemap_hash(rangemapptr, h);
             break;
           }
@@ -96,12 +96,12 @@ void k_hash(block *arg, void *h) {
             break;
           }
           case INT_LAYOUT: {
-            mpz_ptr *intptrptr = (mpz_ptr *)(argintptr + offset);
+            auto *intptrptr = (mpz_ptr *)(argintptr + offset);
             int_hash(*intptrptr, h);
             break;
           }
           case FLOAT_LAYOUT: {
-            floating **floatptrptr = (floating **)(argintptr + offset);
+            auto **floatptrptr = (floating **)(argintptr + offset);
             float_hash(*floatptrptr, h);
             break;
           }
@@ -112,7 +112,7 @@ void k_hash(block *arg, void *h) {
           }
           case SYMBOL_LAYOUT:
           case VARIABLE_LAYOUT: {
-            block **childptrptr = (block **)(argintptr + offset);
+            auto **childptrptr = (block **)(argintptr + offset);
             k_hash(*childptrptr, h);
             break;
           }
@@ -120,7 +120,7 @@ void k_hash(block *arg, void *h) {
           }
         }
       } else {
-        string *str = (string *)arg;
+        auto *str = (string *)arg;
         add_hash_str(h, str->data, len(arg));
       }
     }

--- a/runtime/collections/kelemle.cpp
+++ b/runtime/collections/kelemle.cpp
@@ -10,8 +10,8 @@ bool hook_FLOAT_trueeq(SortFloat, SortFloat);
 bool hook_STRING_lt(SortString, SortString);
 
 bool hook_KEQUAL_eq(block *arg1, block *arg2) {
-  uint64_t arg1intptr = (uint64_t)arg1;
-  uint64_t arg2intptr = (uint64_t)arg2;
+  auto arg1intptr = (uint64_t)arg1;
+  auto arg2intptr = (uint64_t)arg2;
   bool arg1lb = is_leaf_block(arg1);
   bool arg2lb = is_leaf_block(arg2);
   if (arg1lb == arg2lb) {
@@ -31,7 +31,7 @@ bool hook_KEQUAL_eq(block *arg1, block *arg2) {
           return hook_STRING_eq((string *)arg1, (string *)arg2);
         } else { // arglayout != 0
           // Both arg1 and arg2 are blocks.
-          uint16_t arglayoutshort = (uint16_t)arglayout;
+          auto arglayoutshort = (uint16_t)arglayout;
           layout *layoutPtr = getLayoutData(arglayoutshort);
           uint8_t length = layoutPtr->nargs;
           for (uint8_t i = 0; i < length; i++) {
@@ -50,8 +50,8 @@ bool hook_KEQUAL_eq(block *arg1, block *arg2) {
               break;
             }
             case RANGEMAP_LAYOUT: {
-              rangemap *rangemap1ptr = (rangemap *)(child1intptr);
-              rangemap *rangemap2ptr = (rangemap *)(child2intptr);
+              auto *rangemap1ptr = (rangemap *)(child1intptr);
+              auto *rangemap2ptr = (rangemap *)(child2intptr);
               bool cmp = hook_RANGEMAP_eq(rangemap1ptr, rangemap2ptr);
               if (!cmp) {
                 return false;
@@ -77,8 +77,8 @@ bool hook_KEQUAL_eq(block *arg1, block *arg2) {
               break;
             }
             case INT_LAYOUT: {
-              mpz_ptr *int1ptrptr = (mpz_ptr *)(child1intptr);
-              mpz_ptr *int2ptrptr = (mpz_ptr *)(child2intptr);
+              auto *int1ptrptr = (mpz_ptr *)(child1intptr);
+              auto *int2ptrptr = (mpz_ptr *)(child2intptr);
               bool cmp = hook_INT_eq(*int1ptrptr, *int2ptrptr);
               if (!cmp) {
                 return false;
@@ -86,8 +86,8 @@ bool hook_KEQUAL_eq(block *arg1, block *arg2) {
               break;
             }
             case FLOAT_LAYOUT: {
-              floating **float1ptrptr = (floating **)(child1intptr);
-              floating **float2ptrptr = (floating **)(child2intptr);
+              auto **float1ptrptr = (floating **)(child1intptr);
+              auto **float2ptrptr = (floating **)(child2intptr);
               bool cmp = hook_FLOAT_trueeq(*float1ptrptr, *float2ptrptr);
               if (!cmp) {
                 return false;
@@ -107,8 +107,8 @@ bool hook_KEQUAL_eq(block *arg1, block *arg2) {
               break;
             }
             case SYMBOL_LAYOUT: {
-              block **child1ptrptr = (block **)(child1intptr);
-              block **child2ptrptr = (block **)(child2intptr);
+              auto **child1ptrptr = (block **)(child1intptr);
+              auto **child2ptrptr = (block **)(child2intptr);
               bool cmp = hook_KEQUAL_eq(*child1ptrptr, *child2ptrptr);
               if (!cmp) {
                 return false;
@@ -116,8 +116,8 @@ bool hook_KEQUAL_eq(block *arg1, block *arg2) {
               break;
             }
             case VARIABLE_LAYOUT: {
-              block **var1ptrptr = (block **)(child1intptr);
-              block **var2ptrptr = (block **)(child2intptr);
+              auto **var1ptrptr = (block **)(child1intptr);
+              auto **var2ptrptr = (block **)(child2intptr);
               bool cmp = hook_STRING_eq(
                   (string *)*var1ptrptr, (string *)*var2ptrptr);
               if (!cmp) {
@@ -148,8 +148,8 @@ bool hook_KEQUAL_eq(block *arg1, block *arg2) {
 // - Symbols with same tags are ordered be lexicographically comparing their
 //   childen.
 bool hook_KEQUAL_lt(block *arg1, block *arg2) {
-  uint64_t arg1intptr = (uint64_t)arg1;
-  uint64_t arg2intptr = (uint64_t)arg2;
+  auto arg1intptr = (uint64_t)arg1;
+  auto arg2intptr = (uint64_t)arg2;
   bool isconstant1 = is_leaf_block(arg1);
   bool isconstant2 = is_leaf_block(arg2);
   if (isconstant1 != isconstant2) {
@@ -195,8 +195,8 @@ bool hook_KEQUAL_lt(block *arg1, block *arg2) {
             abort(); // Implement when needed.
           }
           case INT_LAYOUT: {
-            mpz_ptr *int1ptrptr = (mpz_ptr *)(arg1intptr + offset);
-            mpz_ptr *int2ptrptr = (mpz_ptr *)(arg2intptr + offset);
+            auto *int1ptrptr = (mpz_ptr *)(arg1intptr + offset);
+            auto *int2ptrptr = (mpz_ptr *)(arg2intptr + offset);
             int cmp = mpz_cmp(*int1ptrptr, *int2ptrptr);
             if (cmp != 0) {
               return cmp < 0;

--- a/runtime/collections/lists.cpp
+++ b/runtime/collections/lists.cpp
@@ -6,7 +6,7 @@
 
 extern "C" {
 list hook_LIST_unit() {
-  return list();
+  return {};
 }
 
 list hook_LIST_element(SortKItem value) {
@@ -107,7 +107,7 @@ list hook_LIST_make(SortInt len, SortKItem value) {
   }
 
   size_t length = mpz_get_ui(len);
-  return list(length, value);
+  return {length, value};
 }
 
 list hook_LIST_update(SortList list, SortInt index, SortKItem value) {

--- a/runtime/collections/maps.cpp
+++ b/runtime/collections/maps.cpp
@@ -19,7 +19,7 @@ map hook_MAP_element(SortKItem key, SortKItem value) {
 }
 
 map hook_MAP_unit() {
-  return map();
+  return {};
 }
 
 map hook_MAP_concat(SortMap m1, SortMap m2) {

--- a/runtime/collections/rangemaps.cpp
+++ b/runtime/collections/rangemaps.cpp
@@ -27,7 +27,7 @@ rangemap hook_RANGEMAP_elementRng(SortRange rng, SortKItem value) {
 }
 
 rangemap hook_RANGEMAP_unit() {
-  return rangemap();
+  return {};
 }
 
 rangemap hook_RANGEMAP_concat(SortRangeMap m1, SortRangeMap m2) {

--- a/runtime/collections/rangemaps.cpp
+++ b/runtime/collections/rangemaps.cpp
@@ -22,7 +22,7 @@ static struct blockheader range_header() {
   return hdr;
 }
 rangemap hook_RANGEMAP_elementRng(SortRange rng, SortKItem value) {
-  range *ptr = (range *)rng;
+  auto *ptr = (range *)rng;
   return hook_RANGEMAP_element(ptr->start, ptr->end, value);
 }
 
@@ -64,7 +64,7 @@ SortKItem hook_RANGEMAP_lookupOrDefault(
 SortRange hook_RANGEMAP_find_range(SortRangeMap m, SortKItem key) {
   auto val = m->get_key_value(key);
   if (val.has_value()) {
-    range *ptr = (range *)koreAlloc(sizeof(range));
+    auto *ptr = (range *)koreAlloc(sizeof(range));
     ptr->h = range_header();
     ptr->start = val.value().first.start();
     ptr->end = val.value().first.end();
@@ -81,7 +81,7 @@ rangemap hook_RANGEMAP_update(
 
 rangemap
 hook_RANGEMAP_updateRng(SortRangeMap m, SortRange rng, SortKItem value) {
-  range *ptr = (range *)rng;
+  auto *ptr = (range *)rng;
   return hook_RANGEMAP_update(m, ptr->start, ptr->end, value);
 }
 
@@ -90,7 +90,7 @@ rangemap hook_RANGEMAP_remove(SortRangeMap m, SortKItem start, SortKItem end) {
 }
 
 rangemap hook_RANGEMAP_removeRng(SortRangeMap m, SortRange rng) {
-  range *ptr = (range *)rng;
+  auto *ptr = (range *)rng;
   return hook_RANGEMAP_remove(m, ptr->start, ptr->end);
 }
 
@@ -118,11 +118,11 @@ set hook_RANGEMAP_keys(SortRangeMap m) {
   auto tmp = hook_SET_unit();
   for (auto iter = rng_map::ConstRangeMapIterator<KElem, KElem>(*m);
        iter.has_next(); ++iter) {
-    range *ptr = (range *)koreAlloc(sizeof(range));
+    auto *ptr = (range *)koreAlloc(sizeof(range));
     ptr->h = range_header();
     ptr->start = iter->first.start();
     ptr->end = iter->first.end();
-    inj_range2kitem *inj_ptr
+    auto *inj_ptr
         = (inj_range2kitem *)koreAlloc(sizeof(inj_range2kitem));
     inj_ptr->h = inj_range2kitem_header();
     inj_ptr->child = ptr;
@@ -136,11 +136,11 @@ list hook_RANGEMAP_keys_list(SortRangeMap m) {
   auto tmp = list().transient();
   for (auto iter = rng_map::ConstRangeMapIterator<KElem, KElem>(*m);
        iter.has_next(); ++iter) {
-    range *ptr = (range *)koreAlloc(sizeof(range));
+    auto *ptr = (range *)koreAlloc(sizeof(range));
     ptr->h = range_header();
     ptr->start = iter->first.start();
     ptr->end = iter->first.end();
-    inj_range2kitem *inj_ptr
+    auto *inj_ptr
         = (inj_range2kitem *)koreAlloc(sizeof(inj_range2kitem));
     inj_ptr->h = inj_range2kitem_header();
     inj_ptr->child = ptr;
@@ -175,7 +175,7 @@ SortRange hook_RANGEMAP_choiceRng(SortRangeMap m) {
     KLLVM_HOOK_INVALID_ARGUMENT("Cannot choose from an empty range map");
   }
   auto pair = m->treemap().root_data();
-  range *ptr = (range *)koreAlloc(sizeof(range));
+  auto *ptr = (range *)koreAlloc(sizeof(range));
   ptr->h = range_header();
   ptr->start = pair.first.start();
   ptr->end = pair.first.end();
@@ -210,8 +210,8 @@ rangemap hook_RANGEMAP_updateAll(SortRangeMap m1, SortRangeMap m2) {
 rangemap hook_RANGEMAP_removeAll(SortRangeMap map, SortSet set) {
   auto tmp = *map;
   for (auto iter = set->begin(); iter != set->end(); ++iter) {
-    block *b_ptr = (block *)iter->elem;
-    range *r_ptr = (range *)(b_ptr->children[0]);
+    auto *b_ptr = (block *)iter->elem;
+    auto *r_ptr = (range *)(b_ptr->children[0]);
     tmp = tmp.deleted(rng_map::Range<KElem>(r_ptr->start, r_ptr->end));
   }
   return tmp;

--- a/runtime/collections/rangemaps.cpp
+++ b/runtime/collections/rangemaps.cpp
@@ -122,8 +122,7 @@ set hook_RANGEMAP_keys(SortRangeMap m) {
     ptr->h = range_header();
     ptr->start = iter->first.start();
     ptr->end = iter->first.end();
-    auto *inj_ptr
-        = (inj_range2kitem *)koreAlloc(sizeof(inj_range2kitem));
+    auto *inj_ptr = (inj_range2kitem *)koreAlloc(sizeof(inj_range2kitem));
     inj_ptr->h = inj_range2kitem_header();
     inj_ptr->child = ptr;
     auto elem = hook_SET_element((SortKItem)inj_ptr);
@@ -140,8 +139,7 @@ list hook_RANGEMAP_keys_list(SortRangeMap m) {
     ptr->h = range_header();
     ptr->start = iter->first.start();
     ptr->end = iter->first.end();
-    auto *inj_ptr
-        = (inj_range2kitem *)koreAlloc(sizeof(inj_range2kitem));
+    auto *inj_ptr = (inj_range2kitem *)koreAlloc(sizeof(inj_range2kitem));
     inj_ptr->h = inj_range2kitem_header();
     inj_ptr->child = ptr;
     tmp.push_back((SortKItem)inj_ptr);

--- a/runtime/collections/sets.cpp
+++ b/runtime/collections/sets.cpp
@@ -19,7 +19,7 @@ set hook_SET_element(SortKItem elem) {
 }
 
 set hook_SET_unit() {
-  return set();
+  return {};
 }
 
 bool hook_SET_in(SortKItem elem, SortSet set) {

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -486,7 +486,7 @@ SortIOInt hook_IO_accept(SortInt sock) {
   }
 
   int fd = mpz_get_si(sock);
-  int clientsock = accept(fd, NULL, NULL);
+  int clientsock = accept(fd, nullptr, nullptr);
 
   if (clientsock == -1) {
     return getInjErrorBlock();
@@ -679,10 +679,10 @@ SortKItem hook_IO_system(SortString cmd) {
 
     if (len(cmd) > 0) {
       char *command = getTerminatedString(cmd);
-      ret = execl("/bin/sh", "/bin/sh", "-c", command, NULL);
+      ret = execl("/bin/sh", "/bin/sh", "-c", command, nullptr);
       ret == -1 ? exit(127) : exit(0);
     } else {
-      ret = system(NULL);
+      ret = system(nullptr);
       exit(ret);
     }
   }
@@ -699,7 +699,7 @@ SortKItem hook_IO_system(SortString cmd) {
 
   while (done < 2) {
     ready_fds = read_fds;
-    if (select(FD_SETSIZE, &ready_fds, NULL, NULL, NULL) == -1) {
+    if (select(FD_SETSIZE, &ready_fds, nullptr, nullptr, nullptr) == -1) {
       return getKSeqErrorBlock();
     }
     if (FD_ISSET(out[0], &ready_fds)) {
@@ -762,7 +762,7 @@ block *hook_IO_opendir(string *path) {
 
 SortInt hook_IO_time() {
   mpz_t result;
-  mpz_init_set_si(result, time(NULL));
+  mpz_init_set_si(result, time(nullptr));
   return move_int(result);
 }
 }

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -108,7 +108,7 @@ static block *block_errno() {
   case ELOOP: errStr = GETTAG(ELOOP); break;
   case EOVERFLOW: errStr = GETTAG(EOVERFLOW); break;
   default:
-    block *retBlock
+    auto *retBlock
         = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
     retBlock->h = getBlockHeaderForSymbol(
         (uint64_t)getTagForSymbolName("Lbl'Hash'unknownIOError{}"));
@@ -157,9 +157,9 @@ static blockheader header_string() {
 
 static inline block *getKSeqErrorBlock() {
   block *err = block_errno();
-  block *retBlock
+  auto *retBlock
       = static_cast<block *>(koreAlloc(sizeof(block) + 2 * sizeof(block *)));
-  block *inj = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
+  auto *inj = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
   retBlock->h = kseqHeader;
   inj->h = header_err();
   memcpy(inj->children, &err, sizeof(block *));
@@ -170,7 +170,7 @@ static inline block *getKSeqErrorBlock() {
 
 static inline block *getInjErrorBlock() {
   block *p = block_errno();
-  block *retBlock
+  auto *retBlock
       = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
   retBlock->h = header_err();
   memcpy(retBlock->children, &p, sizeof(block *));
@@ -255,7 +255,7 @@ SortIOInt hook_IO_open(SortString filename, SortString control) {
     return getInjErrorBlock();
   }
 
-  block *retBlock
+  auto *retBlock
       = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
   retBlock->h = header_int();
   mpz_init_set_si(result, fd);
@@ -276,7 +276,7 @@ SortIOInt hook_IO_tell(SortInt i) {
     return getInjErrorBlock();
   }
 
-  block *retBlock
+  auto *retBlock
       = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
   retBlock->h = header_int();
   mpz_t result;
@@ -297,7 +297,7 @@ SortIOInt hook_IO_getc(SortInt i) {
 
   if (0 == ret) {
     block *p = leaf_block(getTagForSymbolName(GETTAG(EOF)));
-    block *retBlock
+    auto *retBlock
         = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
     retBlock->h = header_err();
     memcpy(retBlock->children, &p, sizeof(block *));
@@ -306,7 +306,7 @@ SortIOInt hook_IO_getc(SortInt i) {
     return getInjErrorBlock();
   }
 
-  block *retBlock
+  auto *retBlock
       = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
   retBlock->h = header_int();
   mpz_t result;
@@ -334,7 +334,7 @@ SortIOString hook_IO_read(SortInt i, SortInt len) {
 
   result = static_cast<string *>(koreResizeLastAlloc(
       result, sizeof(string) + bytes, sizeof(string) + length));
-  block *retBlock
+  auto *retBlock
       = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
   retBlock->h = header_string();
   init_with_len(result, bytes);
@@ -492,7 +492,7 @@ SortIOInt hook_IO_accept(SortInt sock) {
     return getInjErrorBlock();
   }
 
-  block *retBlock
+  auto *retBlock
       = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
   retBlock->h = header_int();
 
@@ -621,7 +621,7 @@ list hook_KREFLECTION_argv() {
     buf = hook_BUFFER_concat_raw(
         buf, llvm_backend_argv[i], strlen(llvm_backend_argv[i]));
     SortString str = hook_BUFFER_toString(buf);
-    block *b = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(str)));
+    auto *b = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(str)));
     b->h = getBlockHeaderForSymbol(
         (uint64_t)getTagForSymbolName("inj{SortString{}, SortKItem{}}"));
     memcpy(b->children, &str, sizeof(str));
@@ -639,14 +639,14 @@ SortIOFile hook_IO_mkstemp(SortString filename) {
     return getInjErrorBlock();
   }
 
-  block *retBlock = static_cast<block *>(
+  auto *retBlock = static_cast<block *>(
       koreAlloc(sizeof(block) + sizeof(string *) + sizeof(mpz_ptr)));
 
   mpz_t result;
   mpz_init_set_si(result, ret);
   mpz_ptr p = move_int(result);
   size_t length = len(filename);
-  string *retString = static_cast<string *>(
+  auto *retString = static_cast<string *>(
       koreAllocToken(sizeof(string) + sizeof(char) * length));
   memcpy(retString->data, temp, sizeof(char) * length);
   init_with_len(retString, length);
@@ -729,7 +729,7 @@ SortKItem hook_IO_system(SortString cmd) {
   waitpid(pid, &ret, 0);
   ret = WEXITSTATUS(ret);
 
-  block *retBlock = static_cast<block *>(koreAlloc(
+  auto *retBlock = static_cast<block *>(koreAlloc(
       sizeof(block) + sizeof(mpz_ptr) + sizeof(string *) + sizeof(string *)));
 
   mpz_t result;

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -1,5 +1,6 @@
 #include <cerrno>
 #include <cstring>
+#include <ctime>
 #include <fcntl.h>
 #include <gmp.h>
 #include <iostream>
@@ -10,7 +11,6 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <time.h>
 #include <unistd.h>
 
 #include "runtime/alloc.h"

--- a/runtime/json/json.cpp
+++ b/runtime/json/json.cpp
@@ -120,7 +120,7 @@ get_header(boolHdr, "inj{SortBool{}, SortJSON{}}")
       return true;
     } else {
       mpz_clear(z);
-      floating f[1];
+      floating f[1]; // NOLINT(modernize-avoid-c-arrays)
       mpfr_init2(f->f, 53);
       f->exp = 11;
       mpfr_set_str(f->f, str, 9, MPFR_RNDN);

--- a/runtime/json/json.cpp
+++ b/runtime/json/json.cpp
@@ -100,7 +100,7 @@ get_header(boolHdr, "inj{SortBool{}, SortJSON{}}")
     return true;
   }
   bool Bool(bool b) {
-    boolinj *inj = (boolinj *)koreAlloc(sizeof(boolinj));
+    auto *inj = (boolinj *)koreAlloc(sizeof(boolinj));
     inj->h = boolHdr();
     inj->data = b;
     result = (block *)inj;
@@ -124,7 +124,7 @@ get_header(boolHdr, "inj{SortBool{}, SortJSON{}}")
       mpfr_init2(f->f, 53);
       f->exp = 11;
       mpfr_set_str(f->f, str, 9, MPFR_RNDN);
-      floatinj *inj = (floatinj *)koreAlloc(sizeof(floatinj));
+      auto *inj = (floatinj *)koreAlloc(sizeof(floatinj));
       inj->h = floatHdr();
       inj->data = move_float(f);
       result = (block *)inj;
@@ -134,9 +134,9 @@ get_header(boolHdr, "inj{SortBool{}, SortJSON{}}")
   }
 
   bool String(const char *str, SizeType len, bool copy) {
-    stringinj *inj = (stringinj *)koreAlloc(sizeof(stringinj));
+    auto *inj = (stringinj *)koreAlloc(sizeof(stringinj));
     inj->h = strHdr();
-    string *token = (string *)koreAllocToken(sizeof(string) + len);
+    auto *token = (string *)koreAllocToken(sizeof(string) + len);
     init_with_len(token, len);
     memcpy(token->data, str, len);
     inj->data = token;
@@ -154,13 +154,13 @@ get_header(boolHdr, "inj{SortBool{}, SortJSON{}}")
   bool EndObject(SizeType memberCount) {
     result = dotList();
     for (int i = 0; i < memberCount; i++) {
-      jsonmember *member = (jsonmember *)koreAlloc(sizeof(jsonmember));
+      auto *member = (jsonmember *)koreAlloc(sizeof(jsonmember));
       member->h = membHdr();
       member->val = stack.back();
       stack.pop_back();
       member->key = stack.back();
       stack.pop_back();
-      jsonlist *list = (jsonlist *)koreAlloc(sizeof(jsonlist));
+      auto *list = (jsonlist *)koreAlloc(sizeof(jsonlist));
       list->h = listHdr();
       list->hd = (block *)member;
       list->tl = (jsonlist *)result;
@@ -178,7 +178,7 @@ get_header(boolHdr, "inj{SortBool{}, SortJSON{}}")
   bool EndArray(SizeType elementCount) {
     result = dotList();
     for (int i = 0; i < elementCount; i++) {
-      jsonlist *list = (jsonlist *)koreAlloc(sizeof(jsonlist));
+      auto *list = (jsonlist *)koreAlloc(sizeof(jsonlist));
       list->h = listHdr();
       list->hd = stack.back();
       stack.pop_back();
@@ -214,18 +214,18 @@ static bool write_json(KoreWriter<Stream> &writer, block *data) {
     if (data == null()) {
       writer.Null();
     } else if (tag_hdr(data->h.hdr) == tag_hdr(boolHdr().hdr)) {
-      boolinj *inj = (boolinj *)data;
+      auto *inj = (boolinj *)data;
       writer.Bool(inj->data);
     } else if (tag_hdr(data->h.hdr) == tag_hdr(intHdr().hdr)) {
       zinj *inj = (zinj *)data;
       string *str = hook_STRING_int2string(inj->data);
       writer.RawNumber(str->data, len(str), false);
     } else if (tag_hdr(data->h.hdr) == tag_hdr(floatHdr().hdr)) {
-      floatinj *inj = (floatinj *)data;
+      auto *inj = (floatinj *)data;
       std::string str = floatToString(inj->data, "");
       writer.RawNumber(str.c_str(), str.length(), false);
     } else if (tag_hdr(data->h.hdr) == tag_hdr(strHdr().hdr)) {
-      stringinj *inj = (stringinj *)data;
+      auto *inj = (stringinj *)data;
       writer.String(inj->data->data, len(inj->data), false);
     } else if (tag_hdr(data->h.hdr) == tag_hdr(objHdr().hdr)) {
       writer.StartObject();
@@ -238,12 +238,12 @@ static bool write_json(KoreWriter<Stream> &writer, block *data) {
       return_value = write_json(writer, (block *)obj->data);
       writer.EndArray();
     } else if (tag_hdr(data->h.hdr) == tag_hdr(listHdr().hdr)) {
-      jsonlist *list = (jsonlist *)data;
+      auto *list = (jsonlist *)data;
       return_value = write_json(writer, list->hd)
                      && write_json(writer, (block *)list->tl);
     } else if (tag_hdr(data->h.hdr) == tag_hdr(membHdr().hdr)) {
-      jsonmember *memb = (jsonmember *)data;
-      stringinj *inj = (stringinj *)memb->key;
+      auto *memb = (jsonmember *)data;
+      auto *inj = (stringinj *)memb->key;
       writer.Key(inj->data->data, len(inj->data), false);
       return_value = write_json(writer, memb->val);
     } else {

--- a/runtime/json/json.cpp
+++ b/runtime/json/json.cpp
@@ -33,10 +33,10 @@ struct stringinj {
   string *data;
 };
 
-typedef struct boolinj {
+struct boolinj {
   struct blockheader h;
   bool data;
-} boolinj;
+};
 
 struct jsonlist {
   blockheader h;

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -180,13 +180,13 @@ string *ffiCall(
     block *ret) {
   ffi_cif cif;
   ffi_type **argtypes, *rtype;
-  void (*address)(void);
+  void (*address)();
 
   if (!mpz_fits_ulong_p(addr)) {
     KLLVM_HOOK_INVALID_ARGUMENT("Addr is too large: {}", intToString(addr));
   }
 
-  address = (void (*)(void))mpz_get_ui(addr);
+  address = (void (*)())mpz_get_ui(addr);
 
   size_t nargs = hook_LIST_size_long(args);
   size_t nfixtypes = hook_LIST_size_long(fixtypes);

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -425,7 +425,7 @@ block *hook_FFI_free(block *kitem) {
 }
 
 block *hook_FFI_freeAll(void) {
-  for (auto & allocatedKItemPtr : allocatedKItemPtrs) {
+  for (auto &allocatedKItemPtr : allocatedKItemPtrs) {
     hook_FFI_free(allocatedKItemPtr.first);
   }
 

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -86,7 +86,7 @@ static void *so_lib_handle() {
 
 static ffi_type *getTypeFromBlock(block *elem) {
   if (is_leaf_block(elem)) {
-    uint64_t symbol = (uint64_t)elem;
+    auto symbol = (uint64_t)elem;
 
     if (symbol == tag_type_void()) {
       return &ffi_type_void;
@@ -146,7 +146,7 @@ static ffi_type *getTypeFromBlock(block *elem) {
     size_t numFields = hook_LIST_size_long(elements);
     block *structField;
 
-    ffi_type *structType = (ffi_type *)malloc(sizeof(ffi_type));
+    auto *structType = (ffi_type *)malloc(sizeof(ffi_type));
     structType->size = 0;
     structType->alignment = 0;
     structType->type = FFI_TYPE_STRUCT;
@@ -261,7 +261,7 @@ string *ffiCall(
   default: KLLVM_HOOK_INVALID_ARGUMENT("Bad FFI argument type"); break;
   }
 
-  string *rvalue
+  auto *rvalue
       = static_cast<string *>(koreAllocToken(sizeof(string) + rtype->size));
   ffi_call(&cif, address, (void *)(rvalue->data), avalues);
 
@@ -455,7 +455,7 @@ bool hook_FFI_allocated(block *kitem) {
 
 SortK hook_FFI_read(SortInt addr, SortBytes mem) {
   unsigned long l = mpz_get_ui(addr);
-  uintptr_t intptr = (uintptr_t)l;
+  auto intptr = (uintptr_t)l;
   char *ptr = (char *)intptr;
   memcpy(mem->data, ptr, len(mem));
   return dotK;
@@ -463,7 +463,7 @@ SortK hook_FFI_read(SortInt addr, SortBytes mem) {
 
 SortK hook_FFI_write(SortInt addr, SortBytes mem) {
   unsigned long l = mpz_get_ui(addr);
-  uintptr_t intptr = (uintptr_t)l;
+  auto intptr = (uintptr_t)l;
   char *ptr = (char *)intptr;
   for (size_t i = 0; i < len(mem); ++i) {
     if (ptr[i] != mem->data[i]) {

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -425,9 +425,8 @@ block *hook_FFI_free(block *kitem) {
 }
 
 block *hook_FFI_freeAll(void) {
-  for (auto iter = allocatedKItemPtrs.begin(); iter != allocatedKItemPtrs.end();
-       ++iter) {
-    hook_FFI_free(iter->first);
+  for (auto & allocatedKItemPtr : allocatedKItemPtrs) {
+    hook_FFI_free(allocatedKItemPtr.first);
   }
 
   return dotK;

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -71,13 +71,13 @@ size_t hook_LIST_size_long(list *l);
 block *hook_LIST_get_long(list *l, ssize_t idx);
 
 static void *so_lib_handle() {
-  static void *handle = NULL;
+  static void *handle = nullptr;
 
-  if (handle == NULL) {
-    handle = dlopen(NULL, RTLD_LAZY);
+  if (handle == nullptr) {
+    handle = dlopen(nullptr, RTLD_LAZY);
 
-    if (handle == NULL) {
-      KLLVM_HOOK_INVALID_ARGUMENT("dlopen returned NULL");
+    if (handle == nullptr) {
+      KLLVM_HOOK_INVALID_ARGUMENT("dlopen returned nullptr");
     }
   }
 
@@ -165,7 +165,7 @@ static ffi_type *getTypeFromBlock(block *elem) {
           = getTypeFromBlock((block *)*(structField->children));
     }
 
-    structType->elements[numFields] = NULL;
+    structType->elements[numFields] = nullptr;
 
     structTypes.push_back(structType);
 
@@ -281,7 +281,7 @@ string *ffiCall(
 
 SortBytes
 hook_FFI_call(SortInt addr, SortList args, SortList types, SortFFIType ret) {
-  return ffiCall(false, addr, args, types, NULL, ret);
+  return ffiCall(false, addr, args, types, nullptr, ret);
 }
 
 SortBytes hook_FFI_call_variadic(

--- a/runtime/meta/substitution.cpp
+++ b/runtime/meta/substitution.cpp
@@ -23,7 +23,7 @@ template <class New>
 void makeDirty(bool &dirty, uint64_t offset, New newArg, block *&newBlock) {
   if (!dirty) {
     dirty = true;
-    block *alloc = (block *)koreAlloc(size_hdr(newBlock->h.hdr));
+    auto *alloc = (block *)koreAlloc(size_hdr(newBlock->h.hdr));
     alloc->h = newBlock->h;
     reset_gc(alloc);
     memcpy(alloc->children, newBlock->children, offset - 8);
@@ -261,7 +261,7 @@ block *substituteInternal(block *currBlock) {
       block *to_replace_stack = to_replace;
       block *replacement_stack = replacement;
       block *replacementInj_stack = replacementInj;
-      block *result = (block *)evaluateFunctionSymbol(tag, &arguments[0]);
+      auto *result = (block *)evaluateFunctionSymbol(tag, &arguments[0]);
       to_replace = to_replace_stack;
       replacement = replacement_stack;
       replacementInj = replacementInj_stack;
@@ -373,7 +373,7 @@ block *incrementDebruijn(block *currBlock) {
 }
 
 block *alphaRename(block *term) {
-  string *var = (string *)term;
+  auto *var = (string *)term;
   size_t var_len = len(var);
   auto newToken = (string *)koreAllocToken(sizeof(string) + var_len);
   memcpy(newToken->data, var->data, var_len);

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -27,7 +27,7 @@ uint32_t getTagForSymbolName(const char *);
 // bytes2int and int2bytes expect constructors of sort Endianness, which become
 // a uint64_t constant value in the K term representation
 uint64_t tag_big_endian() {
-  static uint64_t tag = (uint64_t)-1;
+  static auto tag = (uint64_t)-1;
   if (tag == -1) {
     tag = (uint64_t)leaf_block(getTagForSymbolName("LblbigEndianBytes{}"));
   }
@@ -37,7 +37,7 @@ uint64_t tag_big_endian() {
 // bytes2int expects constructors of sort Signedness, which become a uint64_t
 // constant value in the K term representation
 uint64_t tag_unsigned() {
-  static uint64_t tag = (uint64_t)-1;
+  static auto tag = (uint64_t)-1;
   if (tag == -1) {
     tag = (uint64_t)leaf_block(getTagForSymbolName("LblunsignedBytes{}"));
   }
@@ -47,8 +47,8 @@ uint64_t tag_unsigned() {
 // syntax Int ::= Bytes2Int(Bytes, Endianness, Signedness)
 SortInt hook_BYTES_bytes2int(
     SortBytes b, SortEndianness endianness_ptr, SortSignedness signedness_ptr) {
-  uint64_t endianness = (uint64_t)endianness_ptr;
-  uint64_t signedness = (uint64_t)signedness_ptr;
+  auto endianness = (uint64_t)endianness_ptr;
+  auto signedness = (uint64_t)signedness_ptr;
   mpz_t result;
   mpz_init(result);
   int order = endianness == tag_big_endian() ? 1 : -1;
@@ -84,13 +84,13 @@ void extract(mpz_t, mpz_t, size_t, size_t);
 // syntax Bytes ::= Int2Bytes(Int, Int, Endianness)
 SortBytes
 hook_BYTES_int2bytes(SortInt len, SortInt i, SortEndianness endianness_ptr) {
-  uint64_t endianness = (uint64_t)endianness_ptr;
+  auto endianness = (uint64_t)endianness_ptr;
   unsigned long len_long = mpz_get_ui(len);
   if (len_long == 0) {
     return hook_BYTES_empty();
   }
   bool neg = mpz_sgn(i) < 0;
-  string *result
+  auto *result
       = static_cast<string *>(koreAllocToken(sizeof(string) + len_long));
   init_with_len(result, len_long);
   memset(result->data, neg ? 0xff : 0x00, len_long);
@@ -107,7 +107,7 @@ hook_BYTES_int2bytes(SortInt len, SortInt i, SortEndianness endianness_ptr) {
 }
 
 string *bytes2string(string *b, size_t len) {
-  string *result = static_cast<string *>(koreAllocToken(sizeof(string) + len));
+  auto *result = static_cast<string *>(koreAllocToken(sizeof(string) + len));
   memcpy(result->data, b->data, len);
   init_with_len(result, len);
   return result;
@@ -224,7 +224,7 @@ SortBytes hook_BYTES_padRight(SortBytes b, SortInt length, SortInt v) {
   if (uv > 255) {
     KLLVM_HOOK_INVALID_ARGUMENT("Integer overflow on value: {}", uv);
   }
-  string *result = static_cast<string *>(koreAllocToken(sizeof(string) + ulen));
+  auto *result = static_cast<string *>(koreAllocToken(sizeof(string) + ulen));
   init_with_len(result, ulen);
   memcpy(result->data, b->data, len(b));
   memset(result->data + len(b), uv, ulen - len(b));
@@ -240,7 +240,7 @@ SortBytes hook_BYTES_padLeft(SortBytes b, SortInt length, SortInt v) {
   if (uv > 255) {
     KLLVM_HOOK_INVALID_ARGUMENT("Integer overflow on value: {}", uv);
   }
-  string *result = static_cast<string *>(koreAllocToken(sizeof(string) + ulen));
+  auto *result = static_cast<string *>(koreAllocToken(sizeof(string) + ulen));
   init_with_len(result, ulen);
   memset(result->data, uv, ulen - len(b));
   memcpy(result->data + ulen - len(b), b->data, len(b));

--- a/runtime/strings/numeric.cpp
+++ b/runtime/strings/numeric.cpp
@@ -17,7 +17,7 @@ std::string floatToString(const floating *f, const char *suffix) {
     }
   } else {
     mpfr_exp_t printed_exp;
-    char *str = mpfr_get_str(NULL, &printed_exp, 10, 0, f->f, MPFR_RNDN);
+    char *str = mpfr_get_str(nullptr, &printed_exp, 10, 0, f->f, MPFR_RNDN);
     size_t len = strlen(str);
     string *newstr = (string *)koreAllocToken(sizeof(string) + len + 2);
     init_with_len(newstr, len + 2);
@@ -51,11 +51,11 @@ std::string floatToString(const floating *f) {
 }
 
 std::string intToStringInBase(mpz_t i, uint64_t base) {
-  char *tmp = mpz_get_str(NULL, base, i);
+  char *tmp = mpz_get_str(nullptr, base, i);
   auto ret = std::string(tmp);
 
   void (*mpz_free)(void *, size_t);
-  mp_get_memory_functions(NULL, NULL, &mpz_free);
+  mp_get_memory_functions(nullptr, nullptr, &mpz_free);
   mpz_free(tmp, strlen(tmp) + 1);
 
   return ret;

--- a/runtime/strings/numeric.cpp
+++ b/runtime/strings/numeric.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>
@@ -38,16 +39,17 @@ std::string floatToString(const floating *f, const char *suffix) {
 std::string floatToString(const floating *f) {
   uint64_t prec = mpfr_get_prec(f->f);
   uint64_t exp = f->exp;
-  char suffix[41]; // 19 chars per long + p and x and null byte
+  auto suffix
+      = std::array<char, 41>{}; // 19 chars per long + p and x and null byte
   if (prec == 53 && exp == 11) {
     suffix[0] = 0;
   } else if (prec == 24 && exp == 8) {
     suffix[0] = 'f';
     suffix[1] = 0;
   } else {
-    snprintf(suffix, sizeof(suffix), "p%" PRIu64 "x%" PRIu64, prec, exp);
+    snprintf(suffix.data(), sizeof(suffix), "p%" PRIu64 "x%" PRIu64, prec, exp);
   }
-  return floatToString(f, suffix);
+  return floatToString(f, suffix.data());
 }
 
 std::string intToStringInBase(mpz_t i, uint64_t base) {

--- a/runtime/strings/numeric.cpp
+++ b/runtime/strings/numeric.cpp
@@ -19,7 +19,7 @@ std::string floatToString(const floating *f, const char *suffix) {
     mpfr_exp_t printed_exp;
     char *str = mpfr_get_str(nullptr, &printed_exp, 10, 0, f->f, MPFR_RNDN);
     size_t len = strlen(str);
-    string *newstr = (string *)koreAllocToken(sizeof(string) + len + 2);
+    auto *newstr = (string *)koreAllocToken(sizeof(string) + len + 2);
     init_with_len(newstr, len + 2);
     size_t idx = 0;
     if (str[0] == '-') {

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -192,7 +192,7 @@ string *makeString(const KCHAR *input, ssize_t len = -1) {
 
 char *getTerminatedString(string *str) {
   int length = len(str);
-  string *buf
+  auto *buf
       = static_cast<string *>(koreAllocToken(sizeof(string) + (length + 1)));
   memcpy(buf->data, str->data, length);
   init_with_len(buf, length + 1);

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -27,7 +27,7 @@ void init_float(floating *result, const char *c_str) {
 uint32_t getTagForSymbolName(const char *name) {
   std::string s = name;
   // https://stackoverflow.com/a/101980/6209703
-  Cache::iterator lb = cache.lower_bound(s);
+  auto lb = cache.lower_bound(s);
   // key exists
   if (lb != cache.end() && !(cache.key_comp()(s, lb->first))) {
     return lb->second;
@@ -60,7 +60,7 @@ void *constructCompositePattern(uint32_t tag, std::vector<void *> &arguments) {
     uint16_t layout_code = layout_hdr(headerVal.hdr);
     layout *data = getLayoutData(layout_code);
     if (data->args[0].cat == SYMBOL_LAYOUT) {
-      block *child = (block *)arguments[0];
+      auto *child = (block *)arguments[0];
       if (!is_leaf_block(child) && get_layout(child) != 0) {
         uint32_t tag = tag_hdr(child->h.hdr);
         if (tag >= first_inj_tag && tag <= last_inj_tag) {
@@ -70,7 +70,7 @@ void *constructCompositePattern(uint32_t tag, std::vector<void *> &arguments) {
     }
   }
 
-  block *Block = (block *)koreAlloc(size);
+  auto *Block = (block *)koreAlloc(size);
   Block->h = headerVal;
 
   storeSymbolChildren(Block, &arguments[0]);

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -126,9 +126,9 @@ extern "C" void *constructInitialConfiguration(const KOREPattern *initial) {
       }
 
       construction term{tag, constructor->getArguments().size()};
-      workList.push_back(term);
+      workList.emplace_back(term);
       for (const auto &child : constructor->getArguments()) {
-        workList.push_back(child.get());
+        workList.emplace_back(child.get());
       }
     } else {
       uint32_t tag = std::get_if<construction>(&current)->tag;

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -119,7 +119,7 @@ void sfprintf(writer *file, const char *fmt, ...) {
       }
     }
     va_end(args_copy);
-    string *str = (string *)finalBuf;
+    auto *str = (string *)finalBuf;
     init_with_len(str, res);
     hook_BUFFER_concat(file->buffer, str);
   }
@@ -151,7 +151,7 @@ void printConfigurationInternal(
   }
   uint16_t layout = get_layout(subject);
   if (!layout) {
-    string *str = (string *)subject;
+    auto *str = (string *)subject;
     size_t subject_len = len(subject);
     sfprintf(file, "\\dv{%s}(\"", sort);
     for (size_t i = 0; i < subject_len; ++i) {

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -37,8 +37,7 @@ struct print_state {
   print_state()
       : boundVariables{}
       , varNames{}
-      , usedVarNames{}
-       { }
+      , usedVarNames{} { }
 
   // We never want to copy the state; it should only ever get passed around by
   // reference.

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -38,7 +38,7 @@ struct print_state {
       : boundVariables{}
       , varNames{}
       , usedVarNames{}
-      , varCounter(0) { }
+       { }
 
   // We never want to copy the state; it should only ever get passed around by
   // reference.
@@ -47,7 +47,7 @@ struct print_state {
   std::vector<block *> boundVariables;
   std::unordered_map<string *, std::string, StringHash, StringEq> varNames;
   std::set<std::string> usedVarNames;
-  uint64_t varCounter;
+  uint64_t varCounter{0};
 };
 
 void printInt(writer *file, mpz_t i, const char *sort, void *state) {

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -52,33 +52,33 @@ struct print_state {
 
 void printInt(writer *file, mpz_t i, const char *sort, void *state) {
   auto str = intToString(i);
-  sfprintf(file, "\\dv{%s}(\"%s\")", sort, str.c_str());
+  sfprintf(file, R"(\dv{%s}("%s"))", sort, str.c_str());
 }
 
 void printFloat(writer *file, floating *f, const char *sort, void *state) {
   std::string str = floatToString(f);
-  sfprintf(file, "\\dv{%s}(\"%s\")", sort, str.c_str());
+  sfprintf(file, R"(\dv{%s}("%s"))", sort, str.c_str());
 }
 
 void printBool(writer *file, bool b, const char *sort, void *state) {
   const char *str = b ? "true" : "false";
-  sfprintf(file, "\\dv{%s}(\"%s\")", sort, str);
+  sfprintf(file, R"(\dv{%s}("%s"))", sort, str);
 }
 
 void printStringBuffer(
     writer *file, stringbuffer *b, const char *sort, void *state) {
   std::string str(b->contents->data, b->strlen);
-  sfprintf(file, "\\dv{%s}(\"%s\")", sort, str.c_str());
+  sfprintf(file, R"(\dv{%s}("%s"))", sort, str.c_str());
 }
 
 void printMInt(
     writer *file, size_t *i, size_t bits, const char *sort, void *state) {
   if (i == nullptr) {
-    sfprintf(file, "\\dv{%s}(\"0p%zd\")", sort, bits);
+    sfprintf(file, R"(\dv{%s}("0p%zd"))", sort, bits);
   } else {
     mpz_ptr z = hook_MINT_import(i, bits, false);
     auto str = intToString(z);
-    sfprintf(file, "\\dv{%s}(\"%sp%zd\")", sort, str.c_str(), bits);
+    sfprintf(file, R"(\dv{%s}("%sp%zd"))", sort, str.c_str(), bits);
   }
 }
 

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -254,7 +254,7 @@ void serializeMInt(
     str = intToString(z);
   }
 
-  auto buf_len = snprintf(NULL, 0, fmt, str.c_str(), bits);
+  auto buf_len = snprintf(nullptr, 0, fmt, str.c_str(), bits);
   auto buffer = std::make_unique<char[]>(buf_len + 1);
 
   snprintf(buffer.get(), buf_len + 1, fmt, str.c_str(), bits);

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -32,7 +32,7 @@ struct serialization_state {
       , boundVariables{}
       , varNames{}
       , usedVarNames{}
-      , varCounter(0) { }
+       { }
 
   // We never want to copy the state; it should only ever get passed around by
   // reference.
@@ -42,7 +42,7 @@ struct serialization_state {
   std::vector<block *> boundVariables;
   std::unordered_map<string *, std::string, StringHash, StringEq> varNames;
   std::set<std::string> usedVarNames;
-  uint64_t varCounter;
+  uint64_t varCounter{0};
 };
 
 static std::string drop_back(std::string s, int n) {

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -31,8 +31,7 @@ struct serialization_state {
       : instance()
       , boundVariables{}
       , varNames{}
-      , usedVarNames{}
-       { }
+      , usedVarNames{} { }
 
   // We never want to copy the state; it should only ever get passed around by
   // reference.
@@ -255,10 +254,10 @@ void serializeMInt(
   }
 
   auto buf_len = snprintf(nullptr, 0, fmt, str.c_str(), bits);
-  auto buffer = std::make_unique<char[]>(buf_len + 1);
+  auto buffer = std::vector<char>(buf_len + 1);
 
-  snprintf(buffer.get(), buf_len + 1, fmt, str.c_str(), bits);
-  emitToken(instance, sort, buffer.get());
+  snprintf(buffer.data(), buf_len + 1, fmt, str.c_str(), bits);
+  emitToken(instance, sort, buffer.data());
 }
 
 void serializeComma(writer *file, void *state) { }

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -299,7 +299,7 @@ void serializeConfigurationInternal(
 
   uint16_t layout = get_layout(subject);
   if (!layout) {
-    string *str = (string *)subject;
+    auto *str = (string *)subject;
     size_t subject_len = len(subject);
 
     if (isVar && !state.varNames.count(str)) {

--- a/runtime/util/match_log.cpp
+++ b/runtime/util/match_log.cpp
@@ -30,12 +30,19 @@ size_t getMatchLogSize(void) {
 
 void addMatchSuccess(void) {
   matchLog.push_back(
-      {MatchLog::SUCCESS, NULL, NULL, NULL, {}, NULL, NULL, NULL});
+      {MatchLog::SUCCESS,
+       nullptr,
+       nullptr,
+       nullptr,
+       {},
+       nullptr,
+       nullptr,
+       nullptr});
 }
 
 void addMatchFailReason(void *subject, char *pattern, char *sort) {
   matchLog.push_back(
-      {MatchLog::FAIL, NULL, NULL, NULL, {}, pattern, subject, sort});
+      {MatchLog::FAIL, nullptr, nullptr, nullptr, {}, pattern, subject, sort});
 }
 
 void addMatchFunction(char *debugName, char *function, void *result, ...) {
@@ -51,8 +58,8 @@ void addMatchFunction(char *debugName, char *function, void *result, ...) {
   }
 
   matchLog.push_back(
-      {MatchLog::FUNCTION, function, debugName, result, args, NULL, NULL,
-       NULL});
+      {MatchLog::FUNCTION, function, debugName, result, args, nullptr, nullptr,
+       nullptr});
 
   va_end(ap);
 }

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -27,4 +27,4 @@ mapfile -t inputs < <(find "${source_dirs[@]}" -name '*.cpp' -or -name '*.h')
   "${inputs[@]}"                      \
   -clang-tidy-binary "${clang_tidy}"  \
   -j "$(nproc)"                       \
-  -p "${BUILD_DIR}"
+  -p "${BUILD_DIR}" "$@"

--- a/tools/k-rule-apply/main.cpp
+++ b/tools/k-rule-apply/main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
   // Get util function from the shared lib, cast it to its right type, and call
   // with its appropriate argument if any.
   void *match_function_ptr = dlsym(handle, match_function_name->c_str());
-  if (match_function_ptr == NULL) {
+  if (match_function_ptr == nullptr) {
     std::cerr << "Error: " << dlerror() << "\n";
     dlclose(handle);
     return EXIT_FAILURE;
@@ -81,14 +81,14 @@ int main(int argc, char **argv) {
   resetMatchReason(handle);
   initStaticObjects(handle);
   auto b = constructInitialConfiguration(InitialConfiguration.get(), handle);
-  if (b == NULL) {
+  if (b == nullptr) {
     std::cerr << "Error: " << dlerror() << "\n";
     return EXIT_FAILURE;
   }
 
   match_function((block *)b);
   auto log = getMatchLog(handle);
-  if (log == NULL) {
+  if (log == nullptr) {
     std::cerr << "Error: " << dlerror() << "\n";
     return EXIT_FAILURE;
   }

--- a/tools/kore-expand-macros/main.cpp
+++ b/tools/kore-expand-macros/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
     axiom->getPattern()->markSymbols(symbols);
   }
 
-  for (auto & entry : symbols) {
+  for (auto &entry : symbols) {
     for (auto symbol : entry.second) {
       auto decl = def->getSymbolDeclarations().at(symbol->getName());
       symbol->instantiateSymbol(decl);

--- a/tools/kore-expand-macros/main.cpp
+++ b/tools/kore-expand-macros/main.cpp
@@ -73,10 +73,8 @@ int main(int argc, char **argv) {
     axiom->getPattern()->markSymbols(symbols);
   }
 
-  for (auto iter = symbols.begin(); iter != symbols.end(); ++iter) {
-    auto &entry = *iter;
-    for (auto iter = entry.second.begin(); iter != entry.second.end(); ++iter) {
-      KORESymbol *symbol = *iter;
+  for (auto & entry : symbols) {
+    for (auto symbol : entry.second) {
       auto decl = def->getSymbolDeclarations().at(symbol->getName());
       symbol->instantiateSymbol(decl);
     }

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -63,7 +63,7 @@ cl::alias OutputFileAlias(
 namespace {
 
 fs::path dt_dir() {
-  return fs::path(Directory.getValue());
+  return Directory.getValue();
 }
 
 fs::path get_indexed_filename(

--- a/tools/llvm-kompile-gc-stats/main.cpp
+++ b/tools/llvm-kompile-gc-stats/main.cpp
@@ -34,8 +34,8 @@ int main(int argc, char **argv) {
   // over time.
   bool alloc = strcmp(argv[1], "alloc") == 0;
   if (analyze) {
-    for (int i = 0; i < 2048; i++) {
-      mpz_init(total[i]);
+    for (auto & i : total) {
+      mpz_init(i);
     }
   }
   int lowerBound;

--- a/tools/llvm-kompile-gc-stats/main.cpp
+++ b/tools/llvm-kompile-gc-stats/main.cpp
@@ -1,8 +1,10 @@
+#include <gmp.h>
+
+#include <array>
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <gmp.h>
 
 int main(int argc, char **argv) {
   const char *usage = "usage: %s [dump|analyze|generation|count] <file>"
@@ -12,8 +14,8 @@ int main(int argc, char **argv) {
     return 1;
   }
   FILE *f = fopen(argv[2], "rb");
-  size_t frame[2049];
-  mpz_t total[2048];
+  auto frame = std::array<size_t, 2049>{};
+  auto total = std::array<mpz_t, 2048>{};
   size_t step = 0;
   // `llvm-kompile-gc-stats dump` dumps the raw log to stdout. useful for
   // debugging, less useful as information
@@ -34,7 +36,7 @@ int main(int argc, char **argv) {
   // over time.
   bool alloc = strcmp(argv[1], "alloc") == 0;
   if (analyze) {
-    for (auto & i : total) {
+    for (auto &i : total) {
       mpz_init(i);
     }
   }
@@ -47,7 +49,7 @@ int main(int argc, char **argv) {
     mpz_init(size);
   }
   while (true) {
-    int ret = fread(frame, sizeof(size_t), 2049, f);
+    int ret = fread(frame.data(), sizeof(size_t), 2049, f);
     // the frame contains 2049 integers:
     //
     // frame[0] contains the total number of bytes allocated since the last


### PR DESCRIPTION
This follows up on #924 by enabling the modernization set of `clang-tidy` checks. As in the original PR, each individual commit largely mechanically fixes simple issues related to a single check. The changes here are stylistic ones that ensure we are using modern C++ features appropriately in the backend's code, and aren't leaning on legacy / C-style practices.

There are a couple of commits that are not directly mechanical changes:
- https://github.com/runtimeverification/llvm-backend/pull/933/commits/ed23fddbd90898e7c54e1ed37d4352689b294fef allows the script that drives `clang-tidy` to receive additional CLI args; doing so enables the use of the auto-fixer.
- https://github.com/runtimeverification/llvm-backend/pull/933/commits/b74fe6ac4456c0025975d4aed6ba9216dec01051 refactors some formatting code to use FMT rather than legacy printing functions.
- https://github.com/runtimeverification/llvm-backend/pull/933/commits/e13d666f501856d0b38bd77a2ad307b7fd1f2b50 corrects the formatting of code generated by the auto-fixer.

As ever, I'm open to bikeshedding the specific changes introduced here - it's really easy to change whether a specific check is enabled or disabled. For instance, I have left the [trailing return type](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-trailing-return-type.html) check disabled as it's not the code style we're using.