### PR TITLE
Enable clang-tidy miscellaneous checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,9 +3,8 @@ Checks:
   -clang-analyzer-cplusplus.PlacementNew
   misc-*
   -misc-no-recursion
-  -misc-non-private-member-variables-in-classes
   -misc-unused-parameters
-  -misc-throw-by-value-catch-by-reference
+  -misc-non-private-member-variables-in-classes
 
 WarningsAsErrors:
   '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,15 @@
 Checks:
   clang-analyzer-*
   -clang-analyzer-cplusplus.PlacementNew
+  misc-*
+  -misc-no-recursion
+  -misc-non-private-member-variables-in-classes
+  -misc-unused-parameters
+  -misc-throw-by-value-catch-by-reference
 
 WarningsAsErrors:
   '*'
+
+CheckOptions:
+  - key: 'misc-const-correctness.AnalyzeValues'
+    value: false

--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -222,6 +222,10 @@ void bind_ast(py::module_ &m) {
 
   /* Sorts */
 
+  // The "redundant" expressions here are used by Pybind's metaprogramming to
+  // generate equality functions over the bound classes.
+  // NOLINTBEGIN(misc-redundant-expression)
+
   auto sort_base
       = py::class_<KORESort, std::shared_ptr<KORESort>>(ast, "Sort")
             .def_property_readonly("is_concrete", &KORESort::isConcrete)
@@ -270,6 +274,8 @@ void bind_ast(py::module_ &m) {
       .def(py::init(&KOREVariable::Create))
       .def("__repr__", print_repr_adapter<KOREVariable>())
       .def_property_readonly("name", &KOREVariable::getName);
+
+  // NOLINTEND(misc-redundant-expression)
 
   /* Patterns */
 

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -62,7 +62,7 @@ private:
       return Leaf;
     if (get(node, "function"))
       return Function;
-    throw node;
+    throw *node;
   }
 
 public:


### PR DESCRIPTION
This PR enables the "miscellaneous" set of `clang-tidy` checks. Adopting these checks requires basically no changes to our code, but I've left the following checks disabled:
- Disallowing recursion
- Disallowing unused parameters with names (e.g. this check prefers `T f(A, B)` to `T f(A a, B b)` when `a` and `b` are unused).
- Using public data members in classes; we do this in a few places and I think it's an acceptable decision.

As ever, happy to bikeshed but this shouldn't be a controversial one at all.