### PR TITLE
Enable clang-tidy bugprone checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ Checks:
   -bugprone-easily-swappable-parameters
   -bugprone-narrowing-conversions
   -bugprone-exception-escape
-  -bugprone-branch-clone
   -bugprone-sizeof-expression
   -bugprone-implicit-widening-of-multiplication-result
   -bugprone-unchecked-optional-access # false positives

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,16 @@ Checks:
   -modernize-use-trailing-return-type
   performance-*
   -performance-no-int-to-ptr
+  bugprone-*
+  -bugprone-easily-swappable-parameters
+  -bugprone-narrowing-conversions
+  -bugprone-exception-escape
+  -bugprone-unused-return-value
+  -bugprone-assignment-in-if-condition
+  -bugprone-branch-clone
+  -bugprone-unchecked-optional-access
+  -bugprone-sizeof-expression
+  -bugprone-implicit-widening-of-multiplication-result
 
 WarningsAsErrors:
   '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,7 +16,6 @@ Checks:
   -bugprone-unused-return-value
   -bugprone-assignment-in-if-condition
   -bugprone-branch-clone
-  -bugprone-unchecked-optional-access
   -bugprone-sizeof-expression
   -bugprone-implicit-widening-of-multiplication-result
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,11 +13,11 @@ Checks:
   -bugprone-easily-swappable-parameters
   -bugprone-narrowing-conversions
   -bugprone-exception-escape
-  -bugprone-unused-return-value
   -bugprone-assignment-in-if-condition
   -bugprone-branch-clone
   -bugprone-sizeof-expression
   -bugprone-implicit-widening-of-multiplication-result
+  -bugprone-unchecked-optional-access # false positives
 
 WarningsAsErrors:
   '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ Checks:
   -bugprone-easily-swappable-parameters
   -bugprone-narrowing-conversions
   -bugprone-exception-escape
-  -bugprone-sizeof-expression
   -bugprone-implicit-widening-of-multiplication-result
   -bugprone-unchecked-optional-access # false positives
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ Checks:
   -bugprone-easily-swappable-parameters
   -bugprone-narrowing-conversions
   -bugprone-exception-escape
-  -bugprone-assignment-in-if-condition
   -bugprone-branch-clone
   -bugprone-sizeof-expression
   -bugprone-implicit-widening-of-multiplication-result

--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -364,10 +364,12 @@ void bind_proof_trace(py::module_ &m) {
             .def_property_readonly(
                 "substitution", &LLVMRewriteEvent::getSubstitution);
 
-  py::class_<LLVMRuleEvent, std::shared_ptr<LLVMRuleEvent>>(
-      proof_trace, "LLVMRuleEvent", llvm_rewrite_event);
+  [[maybe_unused]] auto llvm_rule_event
+      = py::class_<LLVMRuleEvent, std::shared_ptr<LLVMRuleEvent>>(
+          proof_trace, "LLVMRuleEvent", llvm_rewrite_event);
 
-  py::class_<LLVMSideConditionEvent, std::shared_ptr<LLVMSideConditionEvent>>(
+  [[maybe_unused]] auto llvm_side_condition_event = py::class_<
+      LLVMSideConditionEvent, std::shared_ptr<LLVMSideConditionEvent>>(
       proof_trace, "LLVMSideConditionEvent", llvm_rewrite_event);
 
   py::class_<LLVMFunctionEvent, std::shared_ptr<LLVMFunctionEvent>>(

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -200,8 +200,6 @@ ValueType KORECompositeSort::getCategory(std::string const &name) {
     category = SortCategory::List;
   else if (name == "SET.Set")
     category = SortCategory::Set;
-  else if (name == "ARRAY.Array")
-    category = SortCategory::Symbol; // ARRAY is implemented in K
   else if (name == "INT.Int")
     category = SortCategory::Int;
   else if (name == "FLOAT.Float")
@@ -217,8 +215,12 @@ ValueType KORECompositeSort::getCategory(std::string const &name) {
   else if (name.substr(0, 10) == "MINT.MInt ") {
     category = SortCategory::MInt;
     bits = std::stoi(name.substr(10));
-  } else
+  } else {
+    // ARRAY.Array is implemented in K and therefore should fall through to the
+    // default category. Should it one day be implemented as a fully hooked
+    // sort, a check needs to be added to the list above.
     category = SortCategory::Symbol;
+  }
   return {category, bits};
 }
 
@@ -1324,15 +1326,13 @@ bool KOREAxiomDeclaration::isTopAxiom() const {
       }
       return false;
     } else if (
-        top->getConstructor()->getName() == "\\rewrites"
-        && top->getArguments().size() == 2) {
-      return true;
-    } else if (
-        top->getConstructor()->getName() == "\\and"
+        (top->getConstructor()->getName() == "\\rewrites"
+         || top->getConstructor()->getName() == "\\and")
         && top->getArguments().size() == 2) {
       return true;
     }
   }
+
   return false;
 }
 

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -524,7 +524,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
     case SortCategory::Map:
     case SortCategory::RangeMap:
     case SortCategory::List:
-    case SortCategory::Set: addAbort(CaseBlock, module); break;
+    case SortCategory::Set:
     case SortCategory::StringBuffer:
     case SortCategory::MInt:
       // TODO: tokens

--- a/runtime/collections/kelemle.cpp
+++ b/runtime/collections/kelemle.cpp
@@ -182,18 +182,15 @@ bool hook_KEQUAL_lt(block *arg1, block *arg2) {
           uint64_t offset = layoutPtr->args[i].offset;
           uint16_t cat = layoutPtr->args[i].cat;
           switch (cat) {
-          case MAP_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case RANGEMAP_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case LIST_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case SET_LAYOUT: {
-            abort(); // Implement when needed.
-          }
+          case MAP_LAYOUT:
+          case RANGEMAP_LAYOUT:
+          case LIST_LAYOUT:
+          case SET_LAYOUT:
+          case FLOAT_LAYOUT:
+          case STRINGBUFFER_LAYOUT:
+          case BOOL_LAYOUT:
+          case SYMBOL_LAYOUT:
+          case VARIABLE_LAYOUT: abort(); // Implement when needed.
           case INT_LAYOUT: {
             auto *int1ptrptr = (mpz_ptr *)(arg1intptr + offset);
             auto *int2ptrptr = (mpz_ptr *)(arg2intptr + offset);
@@ -202,21 +199,6 @@ bool hook_KEQUAL_lt(block *arg1, block *arg2) {
               return cmp < 0;
             }
             break;
-          }
-          case FLOAT_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case STRINGBUFFER_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case BOOL_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case SYMBOL_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case VARIABLE_LAYOUT: {
-            abort(); // Implement when needed.
           }
           default: abort();
           }

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -617,6 +617,7 @@ list hook_KREFLECTION_argv() {
 
   list l{};
 
+  // NOLINTBEGIN(*-sizeof-expression)
   for (int i = 0; i < llvm_backend_argc; i++) {
     stringbuffer *buf = hook_BUFFER_empty();
     buf = hook_BUFFER_concat_raw(
@@ -628,6 +629,7 @@ list hook_KREFLECTION_argv() {
     memcpy(b->children, &str, sizeof(str));
     l = l.push_back(KElem(b));
   }
+  // NOLINTEND(*-sizeof-expression)
 
   return l;
 }

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -666,6 +666,7 @@ SortKItem hook_IO_system(SortString cmd) {
   stringbuffer *errBuffer = hook_BUFFER_empty();
   char buf[IOBUFSIZE];
 
+  // NOLINTNEXTLINE(*-assignment-in-if-condition)
   if (pipe(out) == -1 || pipe(err) == -1 || (pid = fork()) == -1) {
     return getKSeqErrorBlock();
   }

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -617,19 +617,18 @@ list hook_KREFLECTION_argv() {
 
   list l{};
 
-  // NOLINTBEGIN(*-sizeof-expression)
   for (int i = 0; i < llvm_backend_argc; i++) {
     stringbuffer *buf = hook_BUFFER_empty();
     buf = hook_BUFFER_concat_raw(
         buf, llvm_backend_argv[i], strlen(llvm_backend_argv[i]));
     SortString str = hook_BUFFER_toString(buf);
-    auto *b = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(str)));
+    auto *b
+        = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(SortString)));
     b->h = getBlockHeaderForSymbol(
         (uint64_t)getTagForSymbolName("inj{SortString{}, SortKItem{}}"));
-    memcpy(b->children, &str, sizeof(str));
+    memcpy(b->children, &str, sizeof(SortString));
     l = l.push_back(KElem(b));
   }
-  // NOLINTEND(*-sizeof-expression)
 
   return l;
 }

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -88,6 +88,9 @@ static ffi_type *getTypeFromBlock(block *elem) {
   if (is_leaf_block(elem)) {
     auto symbol = (uint64_t)elem;
 
+    // Some of these types are aliased to each other and so the branch clone
+    // check produces false positives; it's clearer to keep it this way.
+    // NOLINTBEGIN(*-branch-clone)
     if (symbol == tag_type_void()) {
       return &ffi_type_void;
     } else if (symbol == tag_type_uint8()) {
@@ -171,6 +174,7 @@ static ffi_type *getTypeFromBlock(block *elem) {
 
     return structType;
   }
+  // NOLINTEND(*-branch-clone)
 
   KLLVM_HOOK_INVALID_ARGUMENT("Arg is not a supported type");
 }

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -17,8 +17,6 @@
 
 extern "C" {
 
-#define KCHAR char
-
 mpz_ptr move_int(mpz_t);
 floating *move_float(floating *);
 
@@ -85,9 +83,9 @@ SortString hook_STRING_chr(SortInt ord) {
     KLLVM_HOOK_INVALID_ARGUMENT("Ord must be <= 255: {}", uord);
   }
   auto ret
-      = static_cast<string *>(koreAllocToken(sizeof(string) + sizeof(KCHAR)));
+      = static_cast<string *>(koreAllocToken(sizeof(string) + sizeof(char)));
   init_with_len(ret, 1);
-  ret->data[0] = static_cast<KCHAR>(uord);
+  ret->data[0] = static_cast<char>(uord);
   return ret;
 }
 
@@ -113,10 +111,9 @@ SortInt hook_STRING_find(SortString haystack, SortString needle, SortInt pos) {
     return move_int(result);
   }
   auto out = std::search(
-      haystack->data + upos * sizeof(KCHAR),
-      haystack->data + len(haystack) * sizeof(KCHAR), needle->data,
-      needle->data + len(needle) * sizeof(KCHAR));
-  int64_t ret = (out - haystack->data) / sizeof(KCHAR);
+      haystack->data + upos, haystack->data + len(haystack), needle->data,
+      needle->data + len(needle));
+  int64_t ret = out - haystack->data;
   // search returns the end of the range if it is not found, but we want -1 in
   // such a case.
   auto res = (ret < len(haystack)) ? ret : -1;
@@ -150,10 +147,9 @@ hook_STRING_findChar(SortString haystack, SortString needle, SortInt pos) {
     return move_int(result);
   }
   auto out = std::find_first_of(
-      haystack->data + upos * sizeof(KCHAR),
-      haystack->data + len(haystack) * sizeof(KCHAR), needle->data,
-      needle->data + len(needle) * sizeof(KCHAR));
-  int64_t ret = (out - haystack->data) / sizeof(KCHAR);
+      haystack->data + upos, haystack->data + len(haystack), needle->data,
+      needle->data + len(needle));
+  int64_t ret = out - haystack->data;
   // search returns the end of the range if it is not found, but we want -1 in
   // such a case.
   auto res = (ret < len(haystack)) ? ret : -1;
@@ -180,7 +176,7 @@ hook_STRING_rfindChar(SortString haystack, SortString needle, SortInt pos) {
   return move_int(result);
 }
 
-string *makeString(const KCHAR *input, ssize_t len = -1) {
+string *makeString(const char *input, ssize_t len = -1) {
   if (len == -1) {
     len = strlen(input);
   }
@@ -308,8 +304,7 @@ inline SortString hook_STRING_replace(
   }
   auto diff = len(needle) - len(replacer);
   size_t new_len = len(haystack) - i * diff;
-  auto ret = static_cast<string *>(
-      koreAllocToken(sizeof(string) + new_len * sizeof(KCHAR)));
+  auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + new_len));
   init_with_len(ret, new_len);
   int m = 0;
   for (size_t r = 0, h = 0; r < new_len;) {

--- a/tools/k-rule-apply/main.cpp
+++ b/tools/k-rule-apply/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
   auto InitialConfiguration = parser.pattern();
 
   auto match_function_name = getMatchFunctionName();
-  if (match_function_name == std::nullopt) {
+  if (!match_function_name.has_value()) {
     std::cerr << "Rule with label " << RuleLabel << " does not exist.\n";
     return EXIT_FAILURE;
   }

--- a/tools/kore-expand-macros/main.cpp
+++ b/tools/kore-expand-macros/main.cpp
@@ -88,5 +88,6 @@ int main(int argc, char **argv) {
   expanded->print(std::cout);
   std::cout << std::endl;
 
+  // NOLINTNEXTLINE(*-unused-return-value)
   def.release(); // so we don't waste time calling delete a bunch of times
 }


### PR DESCRIPTION
This is another PR in my ongoing series to enable more clang-tidy checks for the codebase. As previously, each commit in this PR fixes the issues flagged by a single check, and can / should be reviewed independently.