### PR TITLE
Enable clang-tidy readability checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ Checks:
   -readability-magic-numbers
   -readability-identifier-length
   -readability-implicit-bool-conversion
-  -readability-else-after-return
   -readability-function-cognitive-complexity
   -readability-named-parameter
   -readability-suspicious-call-argument

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,7 +15,6 @@ Checks:
   -readability-implicit-bool-conversion
   -readability-redundant-member-init
   -readability-else-after-return
-  -readability-non-const-parameter
   -readability-function-cognitive-complexity
   -readability-named-parameter
   -readability-redundant-declaration

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,7 +15,6 @@ Checks:
   -readability-implicit-bool-conversion
   -readability-redundant-member-init
   -readability-uppercase-literal-suffix
-  -readability-convert-member-functions-to-static
   -readability-container-size-empty
   -readability-container-data-pointer
   -readability-else-after-return

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ Checks:
   -readability-magic-numbers
   -readability-identifier-length
   -readability-implicit-bool-conversion
-  -readability-redundant-member-init
   -readability-else-after-return
   -readability-function-cognitive-complexity
   -readability-named-parameter

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,7 +16,6 @@ Checks:
   -readability-else-after-return
   -readability-function-cognitive-complexity
   -readability-named-parameter
-  -readability-redundant-declaration
   -readability-simplify-boolean-expr
   -readability-suspicious-call-argument
   -readability-inconsistent-declaration-parameter-name

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,7 +18,6 @@ Checks:
   -readability-uppercase-literal-suffix
   -readability-convert-member-functions-to-static
   -readability-container-size-empty
-  -readability-braces-around-statements
   -readability-container-data-pointer
   -readability-else-after-return
   -readability-non-const-parameter

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,31 @@ Checks:
   -modernize-use-trailing-return-type
   performance-*
   -performance-no-int-to-ptr
+  readability-*
+  -readability-magic-numbers
+  -readability-identifier-length
+  -readability-implicit-bool-conversion
+  -readability-redundant-member-init
+  -readability-qualified-auto
+  -readability-uppercase-literal-suffix
+  -readability-convert-member-functions-to-static
+  -readability-container-size-empty
+  -readability-string-compare
+  -readability-braces-around-statements
+  -readability-container-data-pointer
+  -readability-else-after-return
+  -readability-non-const-parameter
+  -readability-function-cognitive-complexity
+  -readability-redundant-string-init
+  -readability-named-parameter
+  -readability-redundant-declaration
+  -readability-isolate-declaration
+  -readability-simplify-boolean-expr
+  -readability-suspicious-call-argument
+  -readability-inconsistent-declaration-parameter-name
+  -readability-redundant-string-cstr
+  -readability-make-member-function-const
+  -readability-use-anyofallof
 
 WarningsAsErrors:
   '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,7 +32,6 @@ Checks:
   -readability-suspicious-call-argument
   -readability-inconsistent-declaration-parameter-name
   -readability-redundant-string-cstr
-  -readability-make-member-function-const
 
 WarningsAsErrors:
   '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,7 +16,6 @@ Checks:
   -readability-function-cognitive-complexity
   -readability-named-parameter
   -readability-suspicious-call-argument
-  -readability-inconsistent-declaration-parameter-name
 
 WarningsAsErrors:
   '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ Checks:
   -readability-magic-numbers
   -readability-identifier-length
   -readability-implicit-bool-conversion
-  -readability-function-cognitive-complexity
   -readability-named-parameter
   -readability-suspicious-call-argument
 
@@ -23,3 +22,5 @@ WarningsAsErrors:
 CheckOptions:
   - key: 'misc-const-correctness.AnalyzeValues'
     value: false
+  - key: 'readability-function-cognitive-complexity.IgnoreMacros'
+    value: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,7 +18,6 @@ Checks:
   -readability-function-cognitive-complexity
   -readability-named-parameter
   -readability-redundant-declaration
-  -readability-isolate-declaration
   -readability-simplify-boolean-expr
   -readability-suspicious-call-argument
   -readability-inconsistent-declaration-parameter-name

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,6 @@ Checks:
   -readability-identifier-length
   -readability-implicit-bool-conversion
   -readability-named-parameter
-  -readability-suspicious-call-argument
 
 WarningsAsErrors:
   '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,7 +18,6 @@ Checks:
   -readability-uppercase-literal-suffix
   -readability-convert-member-functions-to-static
   -readability-container-size-empty
-  -readability-string-compare
   -readability-braces-around-statements
   -readability-container-data-pointer
   -readability-else-after-return

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,7 +33,6 @@ Checks:
   -readability-inconsistent-declaration-parameter-name
   -readability-redundant-string-cstr
   -readability-make-member-function-const
-  -readability-use-anyofallof
 
 WarningsAsErrors:
   '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,6 @@ Checks:
   -readability-identifier-length
   -readability-implicit-bool-conversion
   -readability-redundant-member-init
-  -readability-qualified-auto
   -readability-uppercase-literal-suffix
   -readability-convert-member-functions-to-static
   -readability-container-size-empty

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,7 +15,6 @@ Checks:
   -readability-implicit-bool-conversion
   -readability-redundant-member-init
   -readability-uppercase-literal-suffix
-  -readability-container-size-empty
   -readability-container-data-pointer
   -readability-else-after-return
   -readability-non-const-parameter

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,6 @@ Checks:
   -readability-identifier-length
   -readability-implicit-bool-conversion
   -readability-redundant-member-init
-  -readability-uppercase-literal-suffix
   -readability-else-after-return
   -readability-non-const-parameter
   -readability-function-cognitive-complexity

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,6 @@ Checks:
   -readability-else-after-return
   -readability-non-const-parameter
   -readability-function-cognitive-complexity
-  -readability-redundant-string-init
   -readability-named-parameter
   -readability-redundant-declaration
   -readability-isolate-declaration

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,7 +16,6 @@ Checks:
   -readability-else-after-return
   -readability-function-cognitive-complexity
   -readability-named-parameter
-  -readability-simplify-boolean-expr
   -readability-suspicious-call-argument
   -readability-inconsistent-declaration-parameter-name
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,7 +15,6 @@ Checks:
   -readability-implicit-bool-conversion
   -readability-redundant-member-init
   -readability-uppercase-literal-suffix
-  -readability-container-data-pointer
   -readability-else-after-return
   -readability-non-const-parameter
   -readability-function-cognitive-complexity

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,7 +31,6 @@ Checks:
   -readability-simplify-boolean-expr
   -readability-suspicious-call-argument
   -readability-inconsistent-declaration-parameter-name
-  -readability-redundant-string-cstr
 
 WarningsAsErrors:
   '*'

--- a/bindings/c/lib.cpp
+++ b/bindings/c/lib.cpp
@@ -49,7 +49,7 @@ std::optional<pretty_print_definition> get_print_data();
  */
 
 extern "C" {
-block *take_steps(int64_t, block *);
+
 void initStaticObjects(void);
 void freeAllKoreMem(void);
 }

--- a/bindings/c/lib.cpp
+++ b/bindings/c/lib.cpp
@@ -124,7 +124,7 @@ char *kore_pattern_pretty_print(kore_pattern const *pat) {
   fs::remove_all(temp_dir_name);
 
   auto pretty_str = ss.str();
-  auto data
+  auto *data
       = static_cast<char *>(malloc(sizeof(char) * (pretty_str.size() + 1)));
 
   std::copy(pretty_str.begin(), pretty_str.end(), data);
@@ -152,20 +152,20 @@ void kore_pattern_free(kore_pattern const *pat) {
 }
 
 kore_pattern *kore_pattern_parse(char const *kore_text) {
-  auto pat = new kore_pattern;
+  auto *pat = new kore_pattern;
   pat->ptr_ = kllvm::parser::KOREParser::from_string(kore_text)->pattern();
   return pat;
 }
 
 kore_pattern *kore_pattern_parse_file(char const *filename) {
-  auto pat = new kore_pattern;
+  auto *pat = new kore_pattern;
   pat->ptr_ = kllvm::parser::KOREParser(std::string(filename)).pattern();
   return pat;
 }
 
 kore_pattern *kore_pattern_new_token(char const *value, kore_sort const *sort) {
-  auto pat = kore_string_pattern_new(value);
-  auto ret = kore_pattern_new_token_internal(pat, sort);
+  auto *pat = kore_string_pattern_new(value);
+  auto *ret = kore_pattern_new_token_internal(pat, sort);
 
   kore_pattern_free(pat);
   return ret;
@@ -173,8 +173,8 @@ kore_pattern *kore_pattern_new_token(char const *value, kore_sort const *sort) {
 
 kore_pattern *kore_pattern_new_token_with_len(
     char const *value, size_t len, kore_sort const *sort) {
-  auto pat = kore_string_pattern_new_with_len(value, len);
-  auto ret = kore_pattern_new_token_internal(pat, sort);
+  auto *pat = kore_string_pattern_new_with_len(value, len);
+  auto *ret = kore_pattern_new_token_internal(pat, sort);
 
   kore_pattern_free(pat);
   return ret;
@@ -182,39 +182,39 @@ kore_pattern *kore_pattern_new_token_with_len(
 
 kore_pattern *kore_pattern_new_injection(
     kore_pattern const *term, kore_sort const *from, kore_sort const *to) {
-  auto inj = new kore_pattern;
+  auto *inj = new kore_pattern;
   inj->ptr_ = kllvm::bindings::make_injection(term->ptr_, from->ptr_, to->ptr_);
   return inj;
 }
 
 kore_pattern *kore_pattern_make_interpreter_input(
     kore_pattern const *pgm, kore_sort const *sort) {
-  auto config_sort = kore_composite_sort_new("SortKConfigVar");
-  auto kitem_sort = kore_composite_sort_new("SortKItem");
+  auto *config_sort = kore_composite_sort_new("SortKConfigVar");
+  auto *kitem_sort = kore_composite_sort_new("SortKItem");
 
-  auto pgm_token = kore_pattern_new_token("$PGM", config_sort);
-  auto key = kore_pattern_new_injection(pgm_token, config_sort, kitem_sort);
+  auto *pgm_token = kore_pattern_new_token("$PGM", config_sort);
+  auto *key = kore_pattern_new_injection(pgm_token, config_sort, kitem_sort);
   kore_pattern_free(pgm_token);
 
-  auto map_item = kore_composite_pattern_new("Lbl'UndsPipe'-'-GT-Unds'");
+  auto *map_item = kore_composite_pattern_new("Lbl'UndsPipe'-'-GT-Unds'");
   kore_composite_pattern_add_argument(map_item, key);
   kore_pattern_free(key);
 
   if (kore_sort_is_kitem(sort)) {
     kore_composite_pattern_add_argument(map_item, pgm);
   } else {
-    auto inj = kore_pattern_new_injection(pgm, sort, kitem_sort);
+    auto *inj = kore_pattern_new_injection(pgm, sort, kitem_sort);
     kore_composite_pattern_add_argument(map_item, inj);
     kore_pattern_free(inj);
   }
 
-  auto map_unit = kore_composite_pattern_new("Lbl'Stop'Map");
+  auto *map_unit = kore_composite_pattern_new("Lbl'Stop'Map");
 
-  auto map_concat = kore_composite_pattern_new("Lbl'Unds'Map'Unds'");
+  auto *map_concat = kore_composite_pattern_new("Lbl'Unds'Map'Unds'");
   kore_composite_pattern_add_argument(map_concat, map_unit);
   kore_composite_pattern_add_argument(map_concat, map_item);
 
-  auto top_cell = kore_composite_pattern_new("LblinitGeneratedTopCell");
+  auto *top_cell = kore_composite_pattern_new("LblinitGeneratedTopCell");
   kore_composite_pattern_add_argument(top_cell, map_concat);
 
   kore_sort_free(config_sort);
@@ -227,7 +227,7 @@ kore_pattern *kore_pattern_make_interpreter_input(
 }
 
 kore_pattern *kore_pattern_desugar_associative(kore_pattern const *pat) {
-  auto ret = new kore_pattern;
+  auto *ret = new kore_pattern;
   ret->ptr_ = pat->ptr_->desugarAssociative();
   return ret;
 }
@@ -237,10 +237,10 @@ block *kore_pattern_construct(kore_pattern const *pat) {
 }
 
 char *kore_block_dump(block *term) {
-  auto hooked_str = printConfigurationToString(term)->data;
+  auto *hooked_str = printConfigurationToString(term)->data;
   auto len = std::strlen(hooked_str);
 
-  auto new_str = static_cast<char *>(malloc((len + 1) * sizeof(char)));
+  auto *new_str = static_cast<char *>(malloc((len + 1) * sizeof(char)));
   std::strncpy(new_str, hooked_str, len);
   new_str[len] = '\0';
 
@@ -248,7 +248,7 @@ char *kore_block_dump(block *term) {
 }
 
 kore_pattern *kore_pattern_from_block(block *term) {
-  auto pat = new kore_pattern;
+  auto *pat = new kore_pattern;
   pat->ptr_ = kllvm::bindings::term_to_pattern(term);
   return pat;
 }
@@ -264,16 +264,16 @@ bool kore_simplify_bool(kore_pattern const *pattern) {
 void kore_simplify(
     kore_pattern const *pattern, kore_sort const *sort, char **data_out,
     size_t *size_out) {
-  auto block = kllvm::bindings::simplify_to_term(pattern->ptr_, sort->ptr_);
+  auto *block = kllvm::bindings::simplify_to_term(pattern->ptr_, sort->ptr_);
   serializeConfiguration(block, "SortKItem{}", data_out, size_out, true);
 }
 
 void kore_simplify_binary(
     char *data_in, size_t size_in, kore_sort const *sort, char **data_out,
     size_t *size_out) {
-  auto sort_str = kore_sort_dump(sort);
+  auto *sort_str = kore_sort_dump(sort);
 
-  auto block = deserializeConfiguration(data_in, size_in);
+  auto *block = deserializeConfiguration(data_in, size_in);
   serializeConfiguration(block, sort_str, data_out, size_out, true);
 
   free(sort_str);
@@ -282,20 +282,20 @@ void kore_simplify_binary(
 /* KORECompositePattern */
 
 kore_pattern *kore_composite_pattern_new(char const *name) {
-  auto pat = new kore_pattern;
+  auto *pat = new kore_pattern;
   pat->ptr_ = kllvm::KORECompositePattern::Create(std::string(name));
   return pat;
 }
 
 kore_pattern *kore_composite_pattern_from_symbol(kore_symbol *sym) {
-  auto pat = new kore_pattern;
+  auto *pat = new kore_pattern;
   pat->ptr_ = kllvm::KORECompositePattern::Create(sym->ptr_.get());
   return pat;
 }
 
 void kore_composite_pattern_add_argument(
     kore_pattern *pat, kore_pattern const *arg) {
-  if (auto cast_ptr
+  if (auto *cast_ptr
       = dynamic_cast<kllvm::KORECompositePattern *>(pat->ptr_.get())) {
     cast_ptr->addArgument(arg->ptr_);
   } else {
@@ -339,14 +339,14 @@ bool kore_sort_is_k(kore_sort const *sort) {
 /* KORECompositeSort */
 
 kore_sort *kore_composite_sort_new(char const *name) {
-  auto sort = new kore_sort;
+  auto *sort = new kore_sort;
   sort->ptr_ = kllvm::KORECompositeSort::Create(std::string(name));
   return sort;
 }
 
 void kore_composite_sort_add_argument(
     kore_sort const *sort, kore_sort const *arg) {
-  if (auto cast_ptr
+  if (auto *cast_ptr
       = dynamic_cast<kllvm::KORECompositeSort *>(sort->ptr_.get())) {
     cast_ptr->addArgument(arg->ptr_);
   } else {
@@ -357,7 +357,7 @@ void kore_composite_sort_add_argument(
 /* KORESymbol */
 
 kore_symbol *kore_symbol_new(char const *name) {
-  auto sym = new kore_symbol;
+  auto *sym = new kore_symbol;
   sym->ptr_ = kllvm::KORESymbol::Create(std::string(name));
   return sym;
 }
@@ -391,24 +391,24 @@ char *get_c_string(std::string const &str) {
   // Include null terminator
   auto total_length = str.length() + 1;
 
-  auto c_str = reinterpret_cast<char *>(malloc(total_length * sizeof(char)));
+  auto *c_str = reinterpret_cast<char *>(malloc(total_length * sizeof(char)));
   std::strncpy(c_str, str.c_str(), total_length);
 
   return c_str;
 }
 
 kore_pattern *kore_string_pattern_new_internal(std::string const &str) {
-  auto pat = new kore_pattern;
+  auto *pat = new kore_pattern;
   pat->ptr_ = kllvm::KOREStringPattern::Create(str);
   return pat;
 }
 
 kore_pattern *kore_pattern_new_token_internal(
     kore_pattern const *value, kore_sort const *sort) {
-  auto sym = kore_symbol_new("\\dv");
+  auto *sym = kore_symbol_new("\\dv");
   kore_symbol_add_formal_argument(sym, sort);
 
-  auto pat = kore_composite_pattern_from_symbol(sym);
+  auto *pat = kore_composite_pattern_from_symbol(sym);
   kore_composite_pattern_add_argument(pat, value);
 
   kore_symbol_free(sym);

--- a/bindings/core/src/core.cpp
+++ b/bindings/core/src/core.cpp
@@ -95,8 +95,8 @@ evaluate_function(std::shared_ptr<KORECompositePattern> const &term) {
 
   auto label = ast_to_string(*term->getConstructor());
   auto tag = getTagForSymbolName(label.c_str());
-  auto return_sort = getReturnSortForTag(tag);
-  auto result = evaluateFunctionSymbol(tag, term_args.data());
+  const auto *return_sort = getReturnSortForTag(tag);
+  auto *result = evaluateFunctionSymbol(tag, term_args.data());
 
   return sortedTermToKorePattern(static_cast<block *>(result), return_sort);
 }

--- a/bindings/core/src/core.cpp
+++ b/bindings/core/src/core.cpp
@@ -74,10 +74,9 @@ block *simplify_to_term(
 
   if (is_sort_kitem(sort) || is_sort_k(sort)) {
     return construct_term(pattern);
-  } else {
-    auto rawTerm = make_rawTerm(pattern, sort, kitem_sort);
+  }     auto rawTerm = make_rawTerm(pattern, sort, kitem_sort);
     return construct_term(rawTerm);
-  }
+ 
 }
 
 std::shared_ptr<KOREPattern> simplify(

--- a/bindings/core/src/core.cpp
+++ b/bindings/core/src/core.cpp
@@ -74,9 +74,9 @@ block *simplify_to_term(
 
   if (is_sort_kitem(sort) || is_sort_k(sort)) {
     return construct_term(pattern);
-  }     auto rawTerm = make_rawTerm(pattern, sort, kitem_sort);
-    return construct_term(rawTerm);
- 
+  }
+  auto rawTerm = make_rawTerm(pattern, sort, kitem_sort);
+  return construct_term(rawTerm);
 }
 
 std::shared_ptr<KOREPattern> simplify(

--- a/bindings/python/runtime.cpp
+++ b/bindings/python/runtime.cpp
@@ -73,7 +73,7 @@ void bind_runtime(py::module_ &m) {
       .def(
           "__str__",
           [](block *term) {
-            auto k_str = printConfigurationToString(term);
+            auto *k_str = printConfigurationToString(term);
             return std::string(k_str->data, len(k_str));
           })
       .def("step", [](block *term, int64_t n) { return take_steps(n, term); })

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -164,7 +164,7 @@ public:
   const std::string getName() const { return name; }
   ValueType getCategory(KOREDefinition *definition);
   std::string getHook(KOREDefinition *definition) const;
-  static ValueType getCategory(std::string const &hook);
+  static ValueType getCategory(std::string const &hookName);
 
   virtual bool isConcrete() const override;
   virtual sptr<KORESort> substitute(const substitution &subst) override;

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -163,7 +163,7 @@ public:
 
   const std::string getName() const { return name; }
   ValueType getCategory(KOREDefinition *definition);
-  std::string getHook(KOREDefinition *definition);
+  std::string getHook(KOREDefinition *definition) const;
   static ValueType getCategory(std::string const &hook);
 
   virtual bool isConcrete() const override;

--- a/include/kllvm/binary/serializer.h
+++ b/include/kllvm/binary/serializer.h
@@ -145,7 +145,7 @@ private:
    * Calculate the number of continued bytes required to serialize this value as
    * a length field, without actually doing so.
    */
-  int required_chunks(uint64_t len) const;
+  static int required_chunks(uint64_t len);
 };
 
 template <typename It>

--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -387,7 +387,7 @@ private:
 
   llvm::AllocaInst *decl(var_type const &name);
 
-  llvm::Constant *stringLiteral(std::string const &name);
+  llvm::Constant *stringLiteral(std::string const &str);
   llvm::Value *ptrTerm(llvm::Value *val);
 
 public:

--- a/include/kllvm/parser/KOREParser.h
+++ b/include/kllvm/parser/KOREParser.h
@@ -31,7 +31,8 @@ public:
 private:
   KOREScanner scanner;
   location loc;
-  [[noreturn]] void error(const location &loc, const std::string &err_message);
+  [[noreturn]] static void
+  error(const location &loc, const std::string &err_message);
 
   std::string consume(token next);
   token peek();

--- a/include/runtime/alloc.h
+++ b/include/runtime/alloc.h
@@ -38,7 +38,7 @@ void *koreAllocAlwaysGC(size_t requested);
 // generation
 void koreAllocSwap(bool swapOld);
 // resizes the last allocation into the young generation
-void *koreResizeLastAlloc(void *oldptr, size_t newrequest, size_t oldrequest);
+void *koreResizeLastAlloc(void *oldptr, size_t newrequest, size_t last_size);
 // allocator hook for the GMP library
 void *koreAllocMP(size_t);
 // reallocator hook for the GMP library

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -26,14 +26,14 @@
 struct MatchLog {
   enum { SUCCESS = 0, FUNCTION, FAIL } kind;
 
-  char *function;
-  char *debugName;
+  char const *function;
+  char const *debugName;
   void *result;
   std::vector<void *> args;
 
-  char *pattern;
+  char const *pattern;
   void *subject;
-  char *sort;
+  char const *sort;
 };
 
 // the actual length is equal to the block header with the gc bits masked out.

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -190,34 +190,34 @@ std::string KORECompositeSort::getHook(KOREDefinition *definition) const {
   return strPattern->getContents();
 }
 
-ValueType KORECompositeSort::getCategory(std::string const &name) {
+ValueType KORECompositeSort::getCategory(std::string const &hookName) {
   SortCategory category;
   uint64_t bits = 0;
-  if (name == "MAP.Map") {
+  if (hookName == "MAP.Map") {
     category = SortCategory::Map;
-  } else if (name == "RANGEMAP.RangeMap") {
+  } else if (hookName == "RANGEMAP.RangeMap") {
     category = SortCategory::RangeMap;
-  } else if (name == "LIST.List") {
+  } else if (hookName == "LIST.List") {
     category = SortCategory::List;
-  } else if (name == "SET.Set") {
+  } else if (hookName == "SET.Set") {
     category = SortCategory::Set;
-  } else if (name == "ARRAY.Array") {
+  } else if (hookName == "ARRAY.Array") {
     category = SortCategory::Symbol; // ARRAY is implemented in K
-  } else if (name == "INT.Int") {
+  } else if (hookName == "INT.Int") {
     category = SortCategory::Int;
-  } else if (name == "FLOAT.Float") {
+  } else if (hookName == "FLOAT.Float") {
     category = SortCategory::Float;
-  } else if (name == "BUFFER.StringBuffer") {
+  } else if (hookName == "BUFFER.StringBuffer") {
     category = SortCategory::StringBuffer;
-  } else if (name == "BOOL.Bool") {
+  } else if (hookName == "BOOL.Bool") {
     category = SortCategory::Bool;
-  } else if (name == "KVAR.KVar") {
+  } else if (hookName == "KVAR.KVar") {
     category = SortCategory::Variable;
     // we expect the "hook" of a MInt to be of the form "MINT.MInt N" for some
     // bitwidth N
-  } else if (name.substr(0, 10) == "MINT.MInt ") {
+  } else if (hookName.substr(0, 10) == "MINT.MInt ") {
     category = SortCategory::MInt;
-    bits = std::stoi(name.substr(10));
+    bits = std::stoi(hookName.substr(10));
   } else {
     category = SortCategory::Symbol;
   }

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -808,9 +808,9 @@ void KORECompositePattern::prettyPrint(
 }
 
 struct CompareFirst {
-  bool isDigit(char c) { return c >= '0' && c <= '9'; }
+  static bool isDigit(char c) { return c >= '0' && c <= '9'; }
 
-  std::string getChunk(std::string s, size_t slength, size_t marker) {
+  static std::string getChunk(std::string s, size_t slength, size_t marker) {
     std::string chunk;
     char c = s[marker];
     chunk.push_back(c);

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -270,30 +270,21 @@ std::string KORESymbol::layoutString(KOREDefinition *definition) const {
 }
 
 bool KORECompositeSort::isConcrete() const {
-  for (auto const &sort : arguments) {
-    if (!sort->isConcrete()) {
-      return false;
-    }
-  }
-  return true;
+  return std::all_of(arguments.begin(), arguments.end(), [](auto const &sort) {
+    return sort->isConcrete();
+  });
 }
 
 bool KORESymbol::isConcrete() const {
-  for (auto const &sort : arguments) {
-    if (!sort->isConcrete()) {
-      return false;
-    }
-  }
-  return true;
+  return std::all_of(arguments.begin(), arguments.end(), [](auto const &sort) {
+    return sort->isConcrete();
+  });
 }
 
 bool KORESymbol::isPolymorphic() const {
-  for (auto const &sort : arguments) {
-    if (sort->isConcrete()) {
-      return false;
-    }
-  }
-  return true;
+  return std::none_of(arguments.begin(), arguments.end(), [](auto const &sort) {
+    return sort->isConcrete();
+  });
 }
 
 static std::unordered_set<std::string> BUILTINS{

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -962,7 +962,8 @@ sptr<KOREPattern> KORECompositePattern::dedupeDisjuncts() {
   if (constructor->getName() != "\\or") {
     return shared_from_this();
   }
-  std::vector<sptr<KOREPattern>> items, dedupedItems;
+  std::vector<sptr<KOREPattern>> items;
+  std::vector<sptr<KOREPattern>> dedupedItems;
   flatten(this, "\\or", items);
   std::set<std::string> printed;
   for (auto const &item : items) {

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -127,8 +127,9 @@ bool KORECompositeSort::operator==(const KORESort &other) const {
       return false;
     }
     for (int i = 0; i < arguments.size(); ++i) {
-      if (*sort->arguments[i] != *arguments[i])
+      if (*sort->arguments[i] != *arguments[i]) {
         return false;
+      }
     }
     return true;
   }
@@ -154,8 +155,9 @@ sptr<KORESort> KORECompositeSort::substitute(const substitution &subst) {
 }
 
 ValueType KORECompositeSort::getCategory(KOREDefinition *definition) {
-  if (category.cat != SortCategory::Uncomputed)
+  if (category.cat != SortCategory::Uncomputed) {
     return category;
+  }
   std::string name = getHook(definition);
   if (name == "MINT.MInt") {
     if (auto param = dynamic_cast<KORECompositeSort *>(arguments[0].get())) {
@@ -192,33 +194,34 @@ std::string KORECompositeSort::getHook(KOREDefinition *definition) const {
 ValueType KORECompositeSort::getCategory(std::string const &name) {
   SortCategory category;
   uint64_t bits = 0;
-  if (name == "MAP.Map")
+  if (name == "MAP.Map") {
     category = SortCategory::Map;
-  else if (name == "RANGEMAP.RangeMap")
+  } else if (name == "RANGEMAP.RangeMap") {
     category = SortCategory::RangeMap;
-  else if (name == "LIST.List")
+  } else if (name == "LIST.List") {
     category = SortCategory::List;
-  else if (name == "SET.Set")
+  } else if (name == "SET.Set") {
     category = SortCategory::Set;
-  else if (name == "ARRAY.Array")
+  } else if (name == "ARRAY.Array") {
     category = SortCategory::Symbol; // ARRAY is implemented in K
-  else if (name == "INT.Int")
+  } else if (name == "INT.Int") {
     category = SortCategory::Int;
-  else if (name == "FLOAT.Float")
+  } else if (name == "FLOAT.Float") {
     category = SortCategory::Float;
-  else if (name == "BUFFER.StringBuffer")
+  } else if (name == "BUFFER.StringBuffer") {
     category = SortCategory::StringBuffer;
-  else if (name == "BOOL.Bool")
+  } else if (name == "BOOL.Bool") {
     category = SortCategory::Bool;
-  else if (name == "KVAR.KVar")
+  } else if (name == "KVAR.KVar") {
     category = SortCategory::Variable;
-  // we expect the "hook" of a MInt to be of the form "MINT.MInt N" for some
-  // bitwidth N
-  else if (name.substr(0, 10) == "MINT.MInt ") {
+    // we expect the "hook" of a MInt to be of the form "MINT.MInt N" for some
+    // bitwidth N
+  } else if (name.substr(0, 10) == "MINT.MInt ") {
     category = SortCategory::MInt;
     bits = std::stoi(name.substr(10));
-  } else
+  } else {
     category = SortCategory::Symbol;
+  }
   return {category, bits};
 }
 
@@ -239,8 +242,9 @@ bool KORESymbol::operator==(const KORESymbol &other) const {
     return false;
   }
   for (int i = 0; i < arguments.size(); ++i) {
-    if (*arguments[i] != *other.arguments[i])
+    if (*arguments[i] != *other.arguments[i]) {
       return false;
+    }
   }
   return true;
 }
@@ -1515,8 +1519,9 @@ void KORECompositeSort::print(std::ostream &Out, unsigned indent) const {
   Out << Indent << name << "{";
   bool isFirst = true;
   for (auto &Argument : arguments) {
-    if (!isFirst)
+    if (!isFirst) {
       Out << ",";
+    }
     Argument->print(Out);
     isFirst = false;
   }
@@ -1532,8 +1537,9 @@ void KORESymbol::print(std::ostream &Out, unsigned indent, bool formal) const {
   Out << Indent << name << "{";
   bool isFirst = true;
   for (auto &Argument : (formal ? formalArguments : arguments)) {
-    if (!isFirst)
+    if (!isFirst) {
       Out << ", ";
+    }
     Argument->print(Out);
     isFirst = false;
   }
@@ -1560,8 +1566,9 @@ void KORECompositePattern::print(std::ostream &Out, unsigned indent) const {
   Out << "(";
   bool isFirst = true;
   for (auto &Argument : arguments) {
-    if (!isFirst)
+    if (!isFirst) {
       Out << ",";
+    }
     Argument->print(Out);
     isFirst = false;
   }
@@ -1599,8 +1606,9 @@ static void printAttributeList(
   Out << Indent << "[";
   bool isFirst = true;
   for (auto &Pattern : attributes) {
-    if (!isFirst)
+    if (!isFirst) {
       Out << ",";
+    }
     Pattern.second->print(Out);
     isFirst = false;
   }
@@ -1611,8 +1619,9 @@ void KOREDeclaration::printSortVariables(std::ostream &Out) const {
   Out << "{";
   bool isFirst = true;
   for (auto &Variable : objectSortVariables) {
-    if (!isFirst)
+    if (!isFirst) {
       Out << ",";
+    }
     Variable->print(Out);
     isFirst = false;
   }
@@ -1636,8 +1645,9 @@ void KORESymbolDeclaration::print(std::ostream &Out, unsigned indent) const {
   Out << "(";
   bool isFirst = true;
   for (auto &Argument : symbol->getArguments()) {
-    if (!isFirst)
+    if (!isFirst) {
       Out << ",";
+    }
     Argument->print(Out);
     isFirst = false;
   }
@@ -1654,8 +1664,9 @@ void KOREAliasDeclaration::print(std::ostream &Out, unsigned indent) const {
   Out << "(";
   bool isFirst = true;
   for (auto &Argument : symbol->getArguments()) {
-    if (!isFirst)
+    if (!isFirst) {
       Out << ",";
+    }
     Argument->print(Out);
     isFirst = false;
   }
@@ -1691,8 +1702,9 @@ void KOREModule::print(std::ostream &Out, unsigned indent) const {
   Out << Indent << "module " << name << "\n";
   bool isFirst = true;
   for (auto &Declaration : declarations) {
-    if (!isFirst)
+    if (!isFirst) {
       Out << "\n";
+    }
     Declaration->print(Out, indent + 2);
     Out << "\n";
     isFirst = false;

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -694,6 +694,7 @@ void KOREVariablePattern::prettyPrint(
   sort->prettyPrint(out);
 }
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 void KORECompositePattern::prettyPrint(
     std::ostream &out, PrettyPrintData const &data) const {
   std::string name = getConstructor()->getName();
@@ -981,6 +982,7 @@ sptr<KOREPattern> KORECompositePattern::dedupeDisjuncts() {
   return result;
 }
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 sptr<KOREPattern> KORECompositePattern::filterSubstitution(
     PrettyPrintData const &data, std::set<std::string> const &vars) {
   if (constructor->getName() == "\\equals") {
@@ -1166,6 +1168,7 @@ bool KOREVariablePattern::matches(
   return true;
 }
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 bool KORECompositePattern::matches(
     substitution &subst, SubsortMap const &subsorts, SymbolMap const &overloads,
     sptr<KOREPattern> subject) {
@@ -1395,6 +1398,7 @@ void KOREDefinition::insertReservedSymbols() {
   addModule(std::move(mod));
 }
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 void KOREDefinition::preprocess() {
   insertReservedSymbols();
 

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1046,7 +1046,7 @@ sptr<KOREPattern> KORECompositePattern::desugarAssociative() {
         = dynamic_cast<KORECompositePattern *>(arguments[0].get())) {
       auto accum = comp_arg->arguments[0]->desugarAssociative();
 
-      for (auto i = 1u; i < comp_arg->arguments.size(); i++) {
+      for (auto i = 1U; i < comp_arg->arguments.size(); i++) {
         auto new_accum
             = KORECompositePattern::Create(comp_arg->getConstructor());
         new_accum->addArgument(accum);
@@ -1093,7 +1093,7 @@ sptr<KOREPattern> KORECompositePattern::unflattenAndOr() {
     } else {
       auto accum = arguments[0]->unflattenAndOr();
 
-      for (auto i = 1u; i < arguments.size(); i++) {
+      for (auto i = 1U; i < arguments.size(); i++) {
         auto new_accum = KORECompositePattern::Create(constructor.get());
         new_accum->addArgument(accum);
         new_accum->addArgument(arguments[i]->unflattenAndOr());

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -678,7 +678,7 @@ void KORECompositeSort::prettyPrint(std::ostream &out) const {
   append(out, name.substr(4));
   if (!arguments.empty()) {
     append(out, '{');
-    std::string conn = "";
+    std::string conn;
     for (const auto &sort : arguments) {
       append(out, conn);
       sort->prettyPrint(out);

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -176,7 +176,7 @@ ValueType KORECompositeSort::getCategory(KOREDefinition *definition) {
   return category;
 }
 
-std::string KORECompositeSort::getHook(KOREDefinition *definition) {
+std::string KORECompositeSort::getHook(KOREDefinition *definition) const {
   auto &att
       = definition->getSortDeclarations().at(this->getName())->getAttributes();
   if (!att.count("hook")) {

--- a/lib/ast/pattern_matching.cpp
+++ b/lib/ast/pattern_matching.cpp
@@ -23,7 +23,7 @@ std::vector<KOREPattern *>
 getPatternsImpl(KOREPattern *pat, std::vector<KOREPattern *> &result) {
   if (auto *composite = dynamic_cast<KORECompositePattern *>(pat)) {
     if (composite->getConstructor()->getName() == "\\top"
-        && composite->getArguments().size() == 0) {
+        && composite->getArguments().empty()) {
       return result;
     } else if (
         composite->getConstructor()->getName() == "\\and"

--- a/lib/ast/pattern_matching.cpp
+++ b/lib/ast/pattern_matching.cpp
@@ -25,8 +25,8 @@ getPatternsImpl(KOREPattern *pat, std::vector<KOREPattern *> &result) {
     if (composite->getConstructor()->getName() == "\\top"
         && composite->getArguments().empty()) {
       return result;
-    } else if (
-        composite->getConstructor()->getName() == "\\and"
+    }
+    if (composite->getConstructor()->getName() == "\\and"
         && composite->getArguments().size() == 2) {
       if (auto *firstChild = dynamic_cast<KORECompositePattern *>(
               composite->getArguments()[0].get())) {
@@ -66,9 +66,8 @@ getBuiltin(std::shared_ptr<KOREPattern> const &term) {
 
   if (!lhs->getConstructor()->isBuiltin()) {
     return lhs;
-  } else {
-    return comp->getArguments()[1];
   }
+  return comp->getArguments()[1];
 }
 
 [[maybe_unused]] std::optional<std::vector<KOREPattern *>>

--- a/lib/ast/pattern_matching.cpp
+++ b/lib/ast/pattern_matching.cpp
@@ -21,14 +21,14 @@ auto X = subject(any);
  */
 std::vector<KOREPattern *>
 getPatternsImpl(KOREPattern *pat, std::vector<KOREPattern *> &result) {
-  if (auto composite = dynamic_cast<KORECompositePattern *>(pat)) {
+  if (auto *composite = dynamic_cast<KORECompositePattern *>(pat)) {
     if (composite->getConstructor()->getName() == "\\top"
         && composite->getArguments().size() == 0) {
       return result;
     } else if (
         composite->getConstructor()->getName() == "\\and"
         && composite->getArguments().size() == 2) {
-      if (auto firstChild = dynamic_cast<KORECompositePattern *>(
+      if (auto *firstChild = dynamic_cast<KORECompositePattern *>(
               composite->getArguments()[0].get())) {
         if (firstChild->getConstructor()->getName() == "\\in"
             && firstChild->getArguments().size() == 2) {

--- a/lib/binary/ProofTraceParser.cpp
+++ b/lib/binary/ProofTraceParser.cpp
@@ -4,7 +4,7 @@
 
 namespace kllvm {
 
-constexpr auto indent_size = 2u;
+constexpr auto indent_size = 2U;
 
 void LLVMRewriteEvent::printSubstitution(
     std::ostream &Out, unsigned indent) const {
@@ -18,21 +18,21 @@ void LLVMRuleEvent::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent * indent_size, ' ');
   Out << fmt::format(
       "{}rule: {} {}\n", Indent, ruleOrdinal, substitution.size());
-  printSubstitution(Out, indent + 1u);
+  printSubstitution(Out, indent + 1U);
 }
 
 void LLVMSideConditionEvent::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent * indent_size, ' ');
   Out << fmt::format(
       "{}side condition: {} {}\n", Indent, ruleOrdinal, substitution.size());
-  printSubstitution(Out, indent + 1u);
+  printSubstitution(Out, indent + 1U);
 }
 
 void LLVMFunctionEvent::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent * indent_size, ' ');
   Out << fmt::format("{}function: {} ({})\n", Indent, name, relativePosition);
   for (const auto &arg : arguments) {
-    arg.print(Out, true, indent + 1u);
+    arg.print(Out, true, indent + 1U);
   }
 }
 
@@ -40,7 +40,7 @@ void LLVMHookEvent::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent * indent_size, ' ');
   Out << fmt::format("{}hook: {} ({})\n", Indent, name, relativePosition);
   for (const auto &arg : arguments) {
-    arg.print(Out, true, indent + 1u);
+    arg.print(Out, true, indent + 1U);
   }
   Out << fmt::format("{}hook result: kore[{}]\n", Indent, patternLength);
 }

--- a/lib/binary/deserializer.cpp
+++ b/lib/binary/deserializer.cpp
@@ -20,7 +20,7 @@ std::string file_contents(std::string const &fn, int max_bytes) {
 
   ret.resize(max_bytes);
   ifs.seekg(0, std::ios::beg);
-  ifs.read(&ret[0], max_bytes);
+  ifs.read(ret.data(), max_bytes);
 
   return ret;
 }

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -19,11 +19,9 @@ serializer::serializer()
 serializer::serializer(flags f)
     : use_header_(!(f & DROP_HEADER))
     , use_arity_(!(f & DROP_ARITY))
-    , 
-     direct_string_prefix_{0x01}
+    , direct_string_prefix_{0x01}
     , backref_string_prefix_{0x02}
-    , next_idx_(0)
-     {
+    , next_idx_(0) {
   if (use_header_) {
     emit_header_and_version();
     emit_zero_size();

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -19,11 +19,11 @@ serializer::serializer()
 serializer::serializer(flags f)
     : use_header_(!(f & DROP_HEADER))
     , use_arity_(!(f & DROP_ARITY))
-    , buffer_{}
-    , direct_string_prefix_{0x01}
+    , 
+     direct_string_prefix_{0x01}
     , backref_string_prefix_{0x02}
     , next_idx_(0)
-    , intern_table_{} {
+     {
   if (use_header_) {
     emit_header_and_version();
     emit_zero_size();

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -114,7 +114,7 @@ int serializer::emit_length(uint64_t len) {
   return emitted;
 }
 
-int serializer::required_chunks(uint64_t len) const {
+int serializer::required_chunks(uint64_t len) {
   auto ret = 0;
   do {
     ++ret;

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -65,8 +65,8 @@ void serializer::emit_zero_size() {
 }
 
 void serializer::correct_emitted_size() {
-  auto header_prefix_length = 11u;
-  auto header_prefix_length_with_version = header_prefix_length + 8u;
+  auto header_prefix_length = 11U;
+  auto header_prefix_length_with_version = header_prefix_length + 8U;
 
   auto bytes = detail::to_bytes(
       uint64_t{buffer_.size() - header_prefix_length_with_version});

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -31,7 +31,7 @@ serializer::serializer(flags f)
 }
 
 std::string serializer::byte_string() const {
-  auto *ptr = reinterpret_cast<unsigned char const *>(buffer_.data());
+  const auto *ptr = reinterpret_cast<unsigned char const *>(buffer_.data());
   return {ptr, ptr + buffer_.size()};
 }
 

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -51,11 +51,11 @@ void generate_object_file(llvm::Module &mod, llvm::raw_ostream &os) {
     mod.setFramePointer(FramePointerKind::None);
   }
 
-  auto triple = BACKEND_TARGET_TRIPLE;
+  const auto *triple = BACKEND_TARGET_TRIPLE;
   mod.setTargetTriple(triple);
 
   auto error = std::string{};
-  auto target = TargetRegistry::lookupTarget(triple, error);
+  const auto *target = TargetRegistry::lookupTarget(triple, error);
   auto cpu = sys::getHostCPUName();
 
   auto features = SubtargetFeatures{};

--- a/lib/codegen/CreateStaticTerm.cpp
+++ b/lib/codegen/CreateStaticTerm.cpp
@@ -120,15 +120,12 @@ CreateStaticTerm::operator()(KOREPattern *pattern) {
         if (tag != (uint32_t)-1 && tag >= inj->getFirstTag()
             && tag <= inj->getLastTag()) {
           return std::make_pair(val.first, true);
-        } else {
-          return std::make_pair(notInjectionCase(constructor, val.first), true);
         }
-      } else {
         return std::make_pair(notInjectionCase(constructor, val.first), true);
       }
-    } else {
-      return std::make_pair(notInjectionCase(constructor, nullptr), false);
+      return std::make_pair(notInjectionCase(constructor, val.first), true);
     }
+    return std::make_pair(notInjectionCase(constructor, nullptr), false);
   }
   assert(false && "Something went wrong when trying to allocate a static term");
   abort();

--- a/lib/codegen/CreateStaticTerm.cpp
+++ b/lib/codegen/CreateStaticTerm.cpp
@@ -37,7 +37,7 @@ llvm::Constant *CreateStaticTerm::notInjectionCase(
   std::stringstream koreString;
   constructor->print(koreString);
   llvm::Constant *Block
-      = Module->getOrInsertGlobal(koreString.str().c_str(), BlockType);
+      = Module->getOrInsertGlobal(koreString.str(), BlockType);
   auto *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(Block);
 
   if (!globalVar->hasInitializer()) {

--- a/lib/codegen/CreateStaticTerm.cpp
+++ b/lib/codegen/CreateStaticTerm.cpp
@@ -202,7 +202,8 @@ CreateStaticTerm::createToken(ValueType sort, std::string contents) {
                                  Module->getContext(), FLOAT_WRAPPER_STRUCT));
     auto *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
-      size_t prec, exp;
+      size_t prec;
+      size_t exp;
       const char last = contents.back();
       if (last == 'f' || last == 'F') {
         prec = 24;

--- a/lib/codegen/CreateStaticTerm.cpp
+++ b/lib/codegen/CreateStaticTerm.cpp
@@ -59,7 +59,7 @@ llvm::Constant *CreateStaticTerm::notInjectionCase(
         EmptyArrayType, llvm::ArrayRef<llvm::Constant *>()));
 
     int idx = 2;
-    for (auto &child : constructor->getArguments()) {
+    for (const auto &child : constructor->getArguments()) {
       llvm::Constant *ChildValue;
       if (idx++ == 2 && val != nullptr) {
         ChildValue = val;
@@ -83,13 +83,13 @@ llvm::Constant *CreateStaticTerm::notInjectionCase(
 
 std::pair<llvm::Constant *, bool>
 CreateStaticTerm::operator()(KOREPattern *pattern) {
-  if (auto constructor = dynamic_cast<KORECompositePattern *>(pattern)) {
+  if (auto *constructor = dynamic_cast<KORECompositePattern *>(pattern)) {
     const KORESymbol *symbol = constructor->getConstructor();
     assert(symbol->isConcrete() && "not supported yet: sort variables");
     if (symbol->getName() == "\\dv") {
-      auto sort = dynamic_cast<KORECompositeSort *>(
+      auto *sort = dynamic_cast<KORECompositeSort *>(
           symbol->getFormalArguments()[0].get());
-      auto strPattern = dynamic_cast<KOREStringPattern *>(
+      auto *strPattern = dynamic_cast<KOREStringPattern *>(
           constructor->getArguments()[0].get());
       return std::make_pair(
           createToken(sort->getCategory(Definition), strPattern->getContents()),

--- a/lib/codegen/CreateStaticTerm.cpp
+++ b/lib/codegen/CreateStaticTerm.cpp
@@ -131,6 +131,7 @@ CreateStaticTerm::operator()(KOREPattern *pattern) {
   abort();
 }
 
+// NOLINTBEGIN(*-cognitive-complexity)
 llvm::Constant *
 CreateStaticTerm::createToken(ValueType sort, std::string contents) {
   switch (sort.cat) {
@@ -331,5 +332,6 @@ CreateStaticTerm::createToken(ValueType sort, std::string contents) {
   case SortCategory::Uncomputed: abort();
   }
 }
+// NOLINTEND(*-cognitive-complexity)
 
 } // namespace kllvm

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -329,6 +329,7 @@ std::string escape(std::string const &str) {
   return os.str();
 }
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 llvm::Value *CreateTerm::createHook(
     KORECompositePattern *hookAtt, KORECompositePattern *pattern,
     std::string const &locationStack) {

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -276,8 +276,8 @@ ValueType termType(
     KOREDefinition *definition) {
   if (auto *variable = dynamic_cast<KOREVariablePattern *>(pattern)) {
     return substitution.lookup(variable->getName());
-  } else if (
-      auto *constructor = dynamic_cast<KORECompositePattern *>(pattern)) {
+  }
+  if (auto *constructor = dynamic_cast<KORECompositePattern *>(pattern)) {
     KORESymbol *symbol = constructor->getConstructor();
     assert(symbol->isConcrete() && "not supported yet: sort variables");
     if (symbol->getName() == "\\dv") {
@@ -287,27 +287,25 @@ ValueType termType(
     }
     auto *sort = dynamic_cast<KORECompositeSort *>(symbol->getSort().get());
     return sort->getCategory(definition);
-  } else {
-    assert(false && "not supported yet: meta level");
-    abort();
   }
+  assert(false && "not supported yet: meta level");
+  abort();
 }
 
 sptr<KORESort> termSort(KOREPattern *pattern) {
   if (auto *variable = dynamic_cast<KOREVariablePattern *>(pattern)) {
     return variable->getSort();
-  } else if (
-      auto *constructor = dynamic_cast<KORECompositePattern *>(pattern)) {
+  }
+  if (auto *constructor = dynamic_cast<KORECompositePattern *>(pattern)) {
     KORESymbol *symbol = constructor->getConstructor();
     assert(symbol->isConcrete() && "not supported yet: sort variables");
     if (symbol->getName() == "\\dv") {
       return symbol->getFormalArguments()[0];
     }
     return symbol->getSort();
-  } else {
-    assert(false && "not supported yet: meta level");
-    abort();
   }
+  assert(false && "not supported yet: meta level");
+  abort();
 }
 
 llvm::Value *CreateTerm::alloc_arg(
@@ -356,7 +354,8 @@ llvm::Value *CreateTerm::createHook(
     Phi->addIncoming(firstArg, CondBlock);
     CurrentBlock = MergeBlock;
     return Phi;
-  } else if (name == "BOOL.or" || name == "BOOL.orElse") {
+  }
+  if (name == "BOOL.or" || name == "BOOL.orElse") {
     assert(pattern->getArguments().size() == 2);
     llvm::Value *firstArg = alloc_arg(pattern, 0, locationStack);
     llvm::BasicBlock *CondBlock = CurrentBlock;
@@ -374,7 +373,8 @@ llvm::Value *CreateTerm::createHook(
     Phi->addIncoming(firstArg, CondBlock);
     CurrentBlock = MergeBlock;
     return Phi;
-  } else if (name == "BOOL.not") {
+  }
+  if (name == "BOOL.not") {
     assert(pattern->getArguments().size() == 1);
     llvm::Value *arg = alloc_arg(pattern, 0, locationStack);
     llvm::BinaryOperator *Not = llvm::BinaryOperator::Create(
@@ -382,7 +382,8 @@ llvm::Value *CreateTerm::createHook(
         llvm::ConstantInt::get(llvm::Type::getInt1Ty(Ctx), 1), "hook_BOOL_not",
         CurrentBlock);
     return Not;
-  } else if (name == "BOOL.implies") {
+  }
+  if (name == "BOOL.implies") {
     assert(pattern->getArguments().size() == 2);
     llvm::Value *firstArg = alloc_arg(pattern, 0, locationStack);
     llvm::BasicBlock *CondBlock = CurrentBlock;
@@ -401,7 +402,8 @@ llvm::Value *CreateTerm::createHook(
         llvm::ConstantInt::get(llvm::Type::getInt1Ty(Ctx), 1), CondBlock);
     CurrentBlock = MergeBlock;
     return Phi;
-  } else if (name == "BOOL.ne" || name == "BOOL.xor") {
+  }
+  if (name == "BOOL.ne" || name == "BOOL.xor") {
     assert(pattern->getArguments().size() == 2);
     llvm::Value *firstArg = alloc_arg(pattern, 0, locationStack);
     llvm::Value *secondArg = alloc_arg(pattern, 1, locationStack);
@@ -409,7 +411,8 @@ llvm::Value *CreateTerm::createHook(
         llvm::Instruction::Xor, firstArg, secondArg, "hook_BOOL_ne",
         CurrentBlock);
     return Xor;
-  } else if (name == "BOOL.eq") {
+  }
+  if (name == "BOOL.eq") {
     assert(pattern->getArguments().size() == 2);
     llvm::Value *firstArg = alloc_arg(pattern, 0, locationStack);
     llvm::Value *secondArg = alloc_arg(pattern, 1, locationStack);
@@ -417,7 +420,8 @@ llvm::Value *CreateTerm::createHook(
         *CurrentBlock, llvm::CmpInst::ICMP_EQ, firstArg, secondArg,
         "hook_BOOL_eq");
     return Eq;
-  } else if (name == "KEQUAL.ite") {
+  }
+  if (name == "KEQUAL.ite") {
     assert(pattern->getArguments().size() == 3);
     llvm::Value *cond = alloc_arg(pattern, 0, locationStack);
     llvm::BasicBlock *TrueBlock
@@ -454,7 +458,8 @@ llvm::Value *CreateTerm::createHook(
     Phi->addIncoming(falseArg, CurrentBlock);
     CurrentBlock = MergeBlock;
     return Phi;
-  } else if (name == "MINT.uvalue") {
+  }
+  if (name == "MINT.uvalue") {
     llvm::Value *mint = alloc_arg(pattern, 0, locationStack);
     ValueType cat = dynamic_cast<KORECompositeSort *>(
                         pattern->getConstructor()->getArguments()[0].get())
@@ -505,7 +510,8 @@ llvm::Value *CreateTerm::createHook(
         "hook_MINT_uvalue", CurrentBlock);
     setDebugLoc(result);
     return result;
-  } else if (name == "MINT.svalue") {
+  }
+  if (name == "MINT.svalue") {
     llvm::Value *mint = alloc_arg(pattern, 0, locationStack);
     ValueType cat = dynamic_cast<KORECompositeSort *>(
                         pattern->getConstructor()->getArguments()[0].get())
@@ -556,7 +562,8 @@ llvm::Value *CreateTerm::createHook(
         "hook_MINT_svalue", CurrentBlock);
     setDebugLoc(result);
     return result;
-  } else if (name == "MINT.integer") {
+  }
+  if (name == "MINT.integer") {
     llvm::Value *mpz = alloc_arg(pattern, 0, locationStack);
     ValueType cat = dynamic_cast<KORECompositeSort *>(
                         pattern->getConstructor()->getSort().get())
@@ -574,46 +581,49 @@ llvm::Value *CreateTerm::createHook(
     llvm::Value *result = llvm::ConstantInt::get(Type, 0);
     if (nwords == 0) {
       return result;
-    } else if (nwords == 1) {
+    }
+
+    if (nwords == 1) {
       auto *Word = new llvm::LoadInst(
           llvm::Type::getInt64Ty(Ctx), Ptr, "word", CurrentBlock);
       if (cat.bits == 64) {
         return Word;
-      } else {
-        return new llvm::TruncInst(
-            Word, Type, "hook_MINT_integer", CurrentBlock);
       }
-    } else { // nwords >= 2
-      for (size_t i = 0; i < nwords; i++) {
-        auto *Word = new llvm::LoadInst(
-            llvm::Type::getInt64Ty(Ctx), Ptr, "word", CurrentBlock);
-        auto *Zext = new llvm::ZExtInst(Word, Type, "extended", CurrentBlock);
-        auto *Shl = llvm::BinaryOperator::Create(
-            llvm::Instruction::Shl, result, llvm::ConstantInt::get(Type, 64),
-            "shift", CurrentBlock);
-        result = llvm::BinaryOperator::Create(
-            llvm::Instruction::Or, Shl, Zext, "or", CurrentBlock);
-        Ptr = llvm::GetElementPtrInst::Create(
-            llvm::Type::getInt64Ty(Ctx), Ptr,
-            {llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 1)}, "ptr",
-            CurrentBlock);
-      }
-      return result;
+
+      return new llvm::TruncInst(Word, Type, "hook_MINT_integer", CurrentBlock);
     }
-  } else if (name == "MINT.neg") {
+    // nwords >= 2
+    for (size_t i = 0; i < nwords; i++) {
+      auto *Word = new llvm::LoadInst(
+          llvm::Type::getInt64Ty(Ctx), Ptr, "word", CurrentBlock);
+      auto *Zext = new llvm::ZExtInst(Word, Type, "extended", CurrentBlock);
+      auto *Shl = llvm::BinaryOperator::Create(
+          llvm::Instruction::Shl, result, llvm::ConstantInt::get(Type, 64),
+          "shift", CurrentBlock);
+      result = llvm::BinaryOperator::Create(
+          llvm::Instruction::Or, Shl, Zext, "or", CurrentBlock);
+      Ptr = llvm::GetElementPtrInst::Create(
+          llvm::Type::getInt64Ty(Ctx), Ptr,
+          {llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 1)}, "ptr",
+          CurrentBlock);
+    }
+    return result;
+  }
+  if (name == "MINT.neg") {
     llvm::Value *in = alloc_arg(pattern, 0, locationStack);
     return llvm::BinaryOperator::CreateNeg(in, "hook_MINT_neg", CurrentBlock);
-  } else if (name == "MINT.not") {
+  }
+  if (name == "MINT.not") {
     llvm::Value *in = alloc_arg(pattern, 0, locationStack);
     return llvm::BinaryOperator::CreateNot(in, "hook_MINT_not", CurrentBlock);
 #define MINT_CMP(hookname, inst)                                               \
   }                                                                            \
-  else if (name == "MINT." #hookname) {                                        \
+  if (name == "MINT." #hookname) {                                             \
     llvm::Value *first = alloc_arg(pattern, 0, locationStack);                 \
     llvm::Value *second = alloc_arg(pattern, 1, locationStack);                \
-    return new llvm::ICmpInst(                                                 \
-        *CurrentBlock, llvm::CmpInst::inst, first, second,                     \
-        "hook_MINT_" #hookname)
+  return new llvm::ICmpInst(                                                   \
+      *CurrentBlock, llvm::CmpInst::inst, first, second,                       \
+      "hook_MINT_" #hookname)
     MINT_CMP(eq, ICMP_EQ);
     MINT_CMP(ne, ICMP_NE);
     MINT_CMP(ult, ICMP_ULT);
@@ -626,12 +636,12 @@ llvm::Value *CreateTerm::createHook(
     MINT_CMP(sge, ICMP_SGE);
 #define MINT_BINOP(hookname, inst)                                             \
   }                                                                            \
-  else if (name == "MINT." #hookname) {                                        \
+  if (name == "MINT." #hookname) {                                             \
     llvm::Value *first = alloc_arg(pattern, 0, locationStack);                 \
     llvm::Value *second = alloc_arg(pattern, 1, locationStack);                \
-    return llvm::BinaryOperator::Create(                                       \
-        llvm::Instruction::inst, first, second, "hook_MINT_" #hookname,        \
-        CurrentBlock)
+  return llvm::BinaryOperator::Create(                                         \
+      llvm::Instruction::inst, first, second, "hook_MINT_" #hookname,          \
+      CurrentBlock)
     MINT_BINOP(xor, Xor);
     MINT_BINOP(or, Or);
     MINT_BINOP(and, And);
@@ -645,22 +655,22 @@ llvm::Value *CreateTerm::createHook(
     MINT_BINOP(udiv, UDiv);
     MINT_BINOP(srem, SRem);
     MINT_BINOP(urem, URem);
-  } else if (!name.compare(0, 5, "MINT.")) {
+  }
+  if (!name.compare(0, 5, "MINT.")) {
     std::cerr << name << std::endl;
     assert(false && "not implemented yet: MInt");
     abort();
-  } else {
-    std::string domain = name.substr(0, name.find('.'));
-    if (domain == "ARRAY") {
-      // array is not really hooked in llvm, it's implemented in K
-      auto fn_name = fmt::format(
-          "eval_{}", ast_to_string(*pattern->getConstructor(), 0, false));
-      return createFunctionCall(fn_name, pattern, false, true, locationStack);
-    }
-    std::string hookName
-        = "hook_" + domain + "_" + name.substr(name.find('.') + 1);
-    return createFunctionCall(hookName, pattern, true, false, locationStack);
   }
+  std::string domain = name.substr(0, name.find('.'));
+  if (domain == "ARRAY") {
+    // array is not really hooked in llvm, it's implemented in K
+    auto fn_name = fmt::format(
+        "eval_{}", ast_to_string(*pattern->getConstructor(), 0, false));
+    return createFunctionCall(fn_name, pattern, false, true, locationStack);
+  }
+  std::string hookName
+      = "hook_" + domain + "_" + name.substr(name.find('.') + 1);
+  return createFunctionCall(hookName, pattern, true, false, locationStack);
 }
 
 // We use tailcc calling convention for apply_rule_* and eval_* functions to
@@ -816,9 +826,8 @@ llvm::Value *CreateTerm::notInjectionCase(
         "withIndices", CurrentBlock);
     setDebugLoc(call);
     return call;
-  } else {
-    return bitcast;
   }
+  return bitcast;
 }
 
 // returns a value and a boolean indicating whether that value could be an
@@ -873,8 +882,8 @@ CreateTerm::createAllocation(KOREPattern *pattern, std::string locationStack) {
       abort();
     }
     return std::make_pair(val, true);
-  } else if (
-      auto *constructor = dynamic_cast<KORECompositePattern *>(pattern)) {
+  }
+  if (auto *constructor = dynamic_cast<KORECompositePattern *>(pattern)) {
     const KORESymbol *symbol = constructor->getConstructor();
     assert(symbol->isConcrete() && "not supported yet: sort variables");
     KORESymbolDeclaration *symbolDecl
@@ -901,19 +910,18 @@ CreateTerm::createAllocation(KOREPattern *pattern, std::string locationStack) {
         CurrentBlock = p.hookEvent_post(val, sort, CurrentBlock);
 
         return std::make_pair(val, true);
-      } else {
-        auto fn_name = fmt::format("eval_{}", ast_to_string(*symbol, 0, false));
-        return std::make_pair(
-            createFunctionCall(
-                fn_name, constructor, false, true, locationStack),
-            true);
       }
-    } else if (auto cat = dynamic_cast<KORECompositeSort *>(
-                              symbol->getArguments()[0].get())
-                              ->getCategory(Definition)
-                              .cat;
-               symbolDecl->getAttributes().count("sortInjection")
-               && (cat == SortCategory::Symbol)) {
+      auto fn_name = fmt::format("eval_{}", ast_to_string(*symbol, 0, false));
+      return std::make_pair(
+          createFunctionCall(fn_name, constructor, false, true, locationStack),
+          true);
+    }
+    if (auto cat
+        = dynamic_cast<KORECompositeSort *>(symbol->getArguments()[0].get())
+              ->getCategory(Definition)
+              .cat;
+        symbolDecl->getAttributes().count("sortInjection")
+        && (cat == SortCategory::Symbol)) {
       std::pair<llvm::Value *, bool> val = createAllocation(
           constructor->getArguments()[0].get(),
           fmt::format("{}:0", locationStack));
@@ -962,18 +970,15 @@ CreateTerm::createAllocation(KOREPattern *pattern, std::string locationStack) {
         Phi->addIncoming(Cast, FalseBlock);
         Phi->addIncoming(val.first, GeBlock);
         return std::make_pair(Phi, true);
-      } else {
-        return std::make_pair(
-            notInjectionCase(constructor, val.first, locationStack), true);
       }
-    } else {
       return std::make_pair(
-          notInjectionCase(constructor, nullptr, locationStack), false);
+          notInjectionCase(constructor, val.first, locationStack), true);
     }
-  } else {
-    assert(false && "not supported yet: meta level");
-    abort();
+    return std::make_pair(
+        notInjectionCase(constructor, nullptr, locationStack), false);
   }
+  assert(false && "not supported yet: meta level");
+  abort();
 }
 
 void addAbort(llvm::BasicBlock *block, llvm::Module *Module) {

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -165,8 +165,16 @@ llvm::DIType *getDebugType(ValueType type, std::string const &typeName) {
     return nullptr;
   }
   static std::map<std::string, llvm::DIType *> types;
-  llvm::DIType *map, *rangemap, *list, *set, *integer, *floating, *buffer,
-      *boolean, *mint, *symbol;
+  llvm::DIType *map;
+  llvm::DIType *rangemap;
+  llvm::DIType *list;
+  llvm::DIType *set;
+  llvm::DIType *integer;
+  llvm::DIType *floating;
+  llvm::DIType *buffer;
+  llvm::DIType *boolean;
+  llvm::DIType *mint;
+  llvm::DIType *symbol;
   if (types[typeName]) {
     return types[typeName];
   }

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -64,8 +64,9 @@ void initDebugFunction(
     std::string const &name, std::string const &linkageName,
     llvm::DISubroutineType *type, KOREDefinition *definition,
     llvm::Function *func) {
-  if (!Dbg)
+  if (!Dbg) {
     return;
+  }
   auto Unit = Dbg->createFile(DbgFile->getFilename(), DbgFile->getDirectory());
   llvm::DIScope *FContext = Unit;
   DbgSP = Dbg->createFunction(
@@ -77,8 +78,9 @@ void initDebugFunction(
 void initDebugParam(
     llvm::Function *func, unsigned argNo, std::string const &name,
     ValueType type, std::string const &typeName) {
-  if (!Dbg)
+  if (!Dbg) {
     return;
+  }
   llvm::DILocalVariable *DbgVar = Dbg->createParameterVariable(
       DbgSP, name, argNo + 1, DbgFile, DbgLine, getDebugType(type, typeName),
       true);
@@ -90,8 +92,9 @@ void initDebugParam(
 
 void initDebugGlobal(
     std::string const &name, llvm::DIType *type, llvm::GlobalVariable *var) {
-  if (!Dbg)
+  if (!Dbg) {
     return;
+  }
   resetDebugLoc();
   auto DbgExp = Dbg->createGlobalVariableExpression(
       DbgCU, name, name, DbgFile, DbgLine, type, false);
@@ -100,8 +103,9 @@ void initDebugGlobal(
 
 void initDebugAxiom(
     std::unordered_map<std::string, sptr<KORECompositePattern>> const &att) {
-  if (!Dbg)
+  if (!Dbg) {
     return;
+  }
   if (!att.count(SOURCE_ATT)) {
     resetDebugLoc();
     return;
@@ -130,16 +134,18 @@ void initDebugAxiom(
 }
 
 void resetDebugLoc() {
-  if (!Dbg)
+  if (!Dbg) {
     return;
+  }
   DbgLine = 0;
   DbgColumn = 0;
   DbgFile = DbgCU->getFile();
 }
 
 llvm::DIType *getForwardDecl(std::string const &name) {
-  if (!Dbg)
+  if (!Dbg) {
     return nullptr;
+  }
   auto Unit = Dbg->createFile(DbgFile->getFilename(), DbgFile->getDirectory());
   return Dbg->createForwardDecl(
       llvm::dwarf::DW_TAG_structure_type, name, DbgCU, Unit, 0);
@@ -155,8 +161,9 @@ static std::string BUFFER_STRUCT = "stringbuffer";
 static std::string BLOCK_STRUCT = "block";
 
 llvm::DIType *getDebugType(ValueType type, std::string const &typeName) {
-  if (!Dbg)
+  if (!Dbg) {
     return nullptr;
+  }
   static std::map<std::string, llvm::DIType *> types;
   llvm::DIType *map, *rangemap, *list, *set, *integer, *floating, *buffer,
       *boolean, *mint, *symbol;
@@ -211,20 +218,23 @@ llvm::DIType *getDebugType(ValueType type, std::string const &typeName) {
 }
 
 llvm::DIType *getIntDebugType() {
-  if (!Dbg)
+  if (!Dbg) {
     return nullptr;
+  }
   return Dbg->createBasicType("uint32_t", 32, llvm::dwarf::DW_ATE_unsigned);
 }
 
 llvm::DIType *getLongDebugType() {
-  if (!Dbg)
+  if (!Dbg) {
     return nullptr;
+  }
   return Dbg->createBasicType("uint64_t", 64, llvm::dwarf::DW_ATE_unsigned);
 }
 
 llvm::DIType *getBoolDebugType() {
-  if (!Dbg)
+  if (!Dbg) {
     return nullptr;
+  }
   return Dbg->createBasicType("bool", 8, llvm::dwarf::DW_ATE_boolean);
 }
 
@@ -233,53 +243,60 @@ llvm::DIType *getVoidDebugType() {
 }
 
 llvm::DIType *getCharPtrDebugType() {
-  if (!Dbg)
+  if (!Dbg) {
     return nullptr;
+  }
   return Dbg->createPointerType(
       Dbg->createBasicType("char", 8, llvm::dwarf::DW_ATE_signed_char),
       sizeof(size_t) * 8);
 }
 
 llvm::DIType *getCharDebugType() {
-  if (!Dbg)
+  if (!Dbg) {
     return nullptr;
+  }
   return Dbg->createBasicType("char", 8, llvm::dwarf::DW_ATE_signed_char);
 }
 
 llvm::DIType *
 getPointerDebugType(llvm::DIType *ty, std::string const &typeName) {
-  if (!Dbg)
+  if (!Dbg) {
     return nullptr;
+  }
   auto ptrType = Dbg->createPointerType(ty, sizeof(size_t) * 8);
   return Dbg->createTypedef(ptrType, typeName, DbgFile, 0, DbgCU);
 }
 
 llvm::DIType *
 getArrayDebugType(llvm::DIType *ty, size_t len, llvm::Align align) {
-  if (!Dbg)
+  if (!Dbg) {
     return nullptr;
+  }
   std::vector<llvm::Metadata *> subscripts;
   auto arr = Dbg->getOrCreateArray(subscripts);
   return Dbg->createArrayType(len, align.value(), ty, arr);
 }
 
 llvm::DIType *getShortDebugType() {
-  if (!Dbg)
+  if (!Dbg) {
     return nullptr;
+  }
   return Dbg->createBasicType("uint16_t", 16, llvm::dwarf::DW_ATE_unsigned);
 }
 
 llvm::DISubroutineType *getDebugFunctionType(
     llvm::Metadata *returnType, std::vector<llvm::Metadata *> argTypes) {
-  if (!Dbg)
+  if (!Dbg) {
     return nullptr;
+  }
   argTypes.insert(argTypes.begin(), returnType);
   return Dbg->createSubroutineType(Dbg->getOrCreateTypeArray(argTypes));
 }
 
 void setDebugLoc(llvm::Instruction *instr) {
-  if (!Dbg)
+  if (!Dbg) {
     return;
+  }
   instr->setDebugLoc(llvm::DebugLoc(
       llvm::DILocation::get(instr->getContext(), DbgLine, DbgColumn, DbgSP)));
 }

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -67,7 +67,7 @@ void initDebugFunction(
   if (!Dbg) {
     return;
   }
-  auto Unit = Dbg->createFile(DbgFile->getFilename(), DbgFile->getDirectory());
+  auto *Unit = Dbg->createFile(DbgFile->getFilename(), DbgFile->getDirectory());
   llvm::DIScope *FContext = Unit;
   DbgSP = Dbg->createFunction(
       FContext, name, name, Unit, DbgLine, type, DbgLine,
@@ -96,7 +96,7 @@ void initDebugGlobal(
     return;
   }
   resetDebugLoc();
-  auto DbgExp = Dbg->createGlobalVariableExpression(
+  auto *DbgExp = Dbg->createGlobalVariableExpression(
       DbgCU, name, name, DbgFile, DbgLine, type, false);
   var->addDebugInfo(DbgExp);
 }
@@ -112,7 +112,7 @@ void initDebugAxiom(
   }
   KORECompositePattern *sourceAtt = att.at(SOURCE_ATT).get();
   assert(sourceAtt->getArguments().size() == 1);
-  auto strPattern
+  auto *strPattern
       = dynamic_cast<KOREStringPattern *>(sourceAtt->getArguments()[0].get());
   std::string source = strPattern->getContents();
   if (!att.count(LOCATION_ATT)) {
@@ -121,7 +121,7 @@ void initDebugAxiom(
   }
   KORECompositePattern *locationAtt = att.at(LOCATION_ATT).get();
   assert(locationAtt->getArguments().size() == 1);
-  auto strPattern2
+  auto *strPattern2
       = dynamic_cast<KOREStringPattern *>(locationAtt->getArguments()[0].get());
   std::string location = strPattern2->getContents();
   source = source.substr(7, source.length() - 8);
@@ -146,7 +146,7 @@ llvm::DIType *getForwardDecl(std::string const &name) {
   if (!Dbg) {
     return nullptr;
   }
-  auto Unit = Dbg->createFile(DbgFile->getFilename(), DbgFile->getDirectory());
+  auto *Unit = Dbg->createFile(DbgFile->getFilename(), DbgFile->getDirectory());
   return Dbg->createForwardDecl(
       llvm::dwarf::DW_TAG_structure_type, name, DbgCU, Unit, 0);
 }
@@ -263,7 +263,7 @@ getPointerDebugType(llvm::DIType *ty, std::string const &typeName) {
   if (!Dbg) {
     return nullptr;
   }
-  auto ptrType = Dbg->createPointerType(ty, sizeof(size_t) * 8);
+  auto *ptrType = Dbg->createPointerType(ty, sizeof(size_t) * 8);
   return Dbg->createTypedef(ptrType, typeName, DbgFile, 0, DbgCU);
 }
 

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -109,7 +109,7 @@ getFailPattern(DecisionCase const &_case, bool isInt) {
   } else {
     auto result = fmt::format("{}(", ast_to_string(*_case.getConstructor()));
 
-    std::string conn = "";
+    std::string conn;
     for (const auto &i : _case.getConstructor()->getArguments()) {
       result += fmt::format("{}Var'Unds':{}", conn, ast_to_string(*i));
       conn = ",";

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -188,7 +188,8 @@ void SwitchNode::codegen(Decision *d) {
     val = cmp;
     isInt = true;
   }
-  llvm::Value *failSort, *failPattern;
+  llvm::Value *failSort;
+  llvm::Value *failPattern;
   if (d->FailPattern) {
     auto failReason = getFailPattern(caseData, isInt, d->FailureBlock);
     failSort = d->stringLiteral(failReason.first);
@@ -770,7 +771,8 @@ void makeEvalOrAnywhereFunction(
   llvm::BasicBlock *fail
       = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
 
-  llvm::AllocaInst *choiceBuffer, *choiceDepth;
+  llvm::AllocaInst *choiceBuffer;
+  llvm::AllocaInst *choiceDepth;
   llvm::IndirectBrInst *jump;
   initChoiceBuffer(
       dt, module, block, stuck, fail, &choiceBuffer, &choiceDepth, &jump);
@@ -1086,7 +1088,8 @@ void makeStepFunction(
   llvm::BasicBlock *fail
       = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
 
-  llvm::AllocaInst *choiceBuffer, *choiceDepth;
+  llvm::AllocaInst *choiceBuffer;
+  llvm::AllocaInst *choiceDepth;
   llvm::IndirectBrInst *jump;
 
   initChoiceBuffer(
@@ -1204,7 +1207,8 @@ void makeMatchReasonFunction(
       {FailSubject, FailPattern, FailSort}, "", fail);
   setDebugLoc(call);
 
-  llvm::AllocaInst *choiceBuffer, *choiceDepth;
+  llvm::AllocaInst *choiceBuffer;
+  llvm::AllocaInst *choiceDepth;
   llvm::IndirectBrInst *jump;
   initChoiceBuffer(
       dt, module, block, pre_stuck, fail, &choiceBuffer, &choiceDepth, &jump);
@@ -1299,7 +1303,8 @@ void makeStepFunction(
   llvm::BasicBlock *fail
       = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
 
-  llvm::AllocaInst *choiceBuffer, *choiceDepth;
+  llvm::AllocaInst *choiceBuffer;
+  llvm::AllocaInst *choiceDepth;
   llvm::IndirectBrInst *jump;
   initChoiceBuffer(
       res.dt, module, block, pre_stuck, fail, &choiceBuffer, &choiceDepth,

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -203,7 +203,7 @@ void SwitchNode::codegen(Decision *d) {
           _case.first);
     }
   } else {
-    if (caseData.size() == 0) {
+    if (caseData.empty()) {
       llvm::BranchInst::Create(_default, d->CurrentBlock);
     } else {
       llvm::Value *tagVal = d->getTag(val);
@@ -638,7 +638,7 @@ llvm::AllocaInst *Decision::decl(var_type const &name) {
 }
 
 llvm::Value *Decision::load(var_type const &name) {
-  if (name.first == "") {
+  if (name.first.empty()) {
     llvm::Type *ty = name.second;
     if (ty->isPointerTy()) {
       auto *ptr_ty = (llvm::PointerType *)ty;

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -80,7 +80,7 @@ bool DecisionNode::beginNode(Decision *d, std::string const &name) {
     llvm::BranchInst::Create(cachedCode, d->CurrentBlock);
     return true;
   }
-  auto Block = llvm::BasicBlock::Create(
+  auto *Block = llvm::BasicBlock::Create(
       d->Ctx, name.substr(0, max_name_length), d->CurrentBlock->getParent());
   cachedCode = Block;
   llvm::BranchInst::Create(Block, d->CurrentBlock);
@@ -127,8 +127,8 @@ static std::pair<std::string, std::string> getFailPattern(
     bool isInt, llvm::BasicBlock *FailBlock) {
   std::string reason;
   std::string sort;
-  for (auto &entry : caseData) {
-    auto &_case = *entry.second;
+  for (const auto &entry : caseData) {
+    const auto &_case = *entry.second;
     if (entry.first != FailBlock) {
       auto caseReason = getFailPattern(_case, isInt);
       if (reason.empty()) {
@@ -158,7 +158,7 @@ void SwitchNode::codegen(Decision *d) {
   int idx = 0;
   bool isInt = false;
   for (auto &_case : cases) {
-    auto child = _case.getChild();
+    auto *child = _case.getChild();
     llvm::BasicBlock *CaseBlock;
     if (child == FailNode::get()) {
       CaseBlock = d->FailureBlock;
@@ -168,7 +168,7 @@ void SwitchNode::codegen(Decision *d) {
           name.substr(0, max_name_length) + "_case_" + std::to_string(idx++),
           d->CurrentBlock->getParent());
     }
-    if (auto sym = _case.getConstructor()) {
+    if (auto *sym = _case.getConstructor()) {
       isInt = isInt || sym->getName() == "\\dv";
       caseData.emplace_back(CaseBlock, &_case);
     } else {
@@ -177,9 +177,9 @@ void SwitchNode::codegen(Decision *d) {
     }
   }
   if (isCheckNull) {
-    auto cast = new llvm::PtrToIntInst(
+    auto *cast = new llvm::PtrToIntInst(
         val, llvm::Type::getInt64Ty(d->Ctx), "", d->CurrentBlock);
-    auto cmp = new llvm::ICmpInst(
+    auto *cmp = new llvm::ICmpInst(
         *d->CurrentBlock, llvm::CmpInst::ICMP_NE, cast,
         llvm::ConstantExpr::getPtrToInt(
             llvm::ConstantPointerNull::get(
@@ -195,7 +195,7 @@ void SwitchNode::codegen(Decision *d) {
     failPattern = d->stringLiteral(failReason.second);
   }
   if (isInt) {
-    auto _switch = llvm::SwitchInst::Create(
+    auto *_switch = llvm::SwitchInst::Create(
         val, _default, cases.size(), d->CurrentBlock);
     for (auto &_case : caseData) {
       _switch->addCase(
@@ -207,7 +207,7 @@ void SwitchNode::codegen(Decision *d) {
       llvm::BranchInst::Create(_default, d->CurrentBlock);
     } else {
       llvm::Value *tagVal = d->getTag(val);
-      auto _switch = llvm::SwitchInst::Create(
+      auto *_switch = llvm::SwitchInst::Create(
           tagVal, _default, caseData.size(), d->CurrentBlock);
       for (auto &_case : caseData) {
         _switch->addCase(
@@ -218,11 +218,11 @@ void SwitchNode::codegen(Decision *d) {
       }
     }
   }
-  auto currChoiceBlock = d->ChoiceBlock;
+  auto *currChoiceBlock = d->ChoiceBlock;
   d->ChoiceBlock = nullptr;
-  auto switchBlock = d->CurrentBlock;
+  auto *switchBlock = d->CurrentBlock;
   for (auto &entry : caseData) {
-    auto &_case = *entry.second;
+    const auto &_case = *entry.second;
     if (entry.first == d->FailureBlock) {
       if (d->FailPattern) {
         d->FailSubject->addIncoming(ptrVal, switchBlock);
@@ -266,7 +266,7 @@ void SwitchNode::codegen(Decision *d) {
               binding.first.substr(0, max_name_length), d->CurrentBlock);
           break;
         }
-        auto BlockPtr
+        auto *BlockPtr
             = llvm::PointerType::getUnqual(llvm::StructType::getTypeByName(
                 d->Module->getContext(), BLOCK_STRUCT));
         if (symbolDecl->getAttributes().count("binder")) {
@@ -295,20 +295,20 @@ void SwitchNode::codegen(Decision *d) {
       }
     } else {
       if (currChoiceBlock && _case.getLiteral() == 1) {
-        auto PrevDepth = new llvm::LoadInst(
+        auto *PrevDepth = new llvm::LoadInst(
             llvm::Type::getInt64Ty(d->Ctx), d->ChoiceDepth, "",
             d->CurrentBlock);
-        auto CurrDepth = llvm::BinaryOperator::Create(
+        auto *CurrDepth = llvm::BinaryOperator::Create(
             llvm::Instruction::Add, PrevDepth,
             llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), 1), "",
             d->CurrentBlock);
         new llvm::StoreInst(CurrDepth, d->ChoiceDepth, d->CurrentBlock);
 
-        auto alloc = llvm::cast<llvm::AllocaInst>(d->ChoiceBuffer);
-        auto ty = alloc->getAllocatedType();
+        auto *alloc = llvm::cast<llvm::AllocaInst>(d->ChoiceBuffer);
+        auto *ty = alloc->getAllocatedType();
 
-        auto zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), 0);
-        auto currentElt = llvm::GetElementPtrInst::CreateInBounds(
+        auto *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), 0);
+        auto *currentElt = llvm::GetElementPtrInst::CreateInBounds(
             ty, d->ChoiceBuffer, {zero, CurrDepth}, "", d->CurrentBlock);
         new llvm::StoreInst(
             llvm::BlockAddress::get(
@@ -330,10 +330,10 @@ void SwitchNode::codegen(Decision *d) {
         // rule priority. Thus, since we know due to the way decision trees
         // are compiled that this subtree contains only lower-priority rules,
         // in this case we simply jump immediately to the failure node.
-        auto loaded = new llvm::LoadInst(
+        auto *loaded = new llvm::LoadInst(
             llvm::Type::getInt1Ty(d->Ctx), d->HasSearchResults, "",
             d->CurrentBlock);
-        auto newCaseBlock = llvm::BasicBlock::Create(
+        auto *newCaseBlock = llvm::BasicBlock::Create(
             d->Ctx, "hasNoSearchResults", d->CurrentBlock->getParent());
         llvm::BranchInst::Create(
             d->FailureBlock, newCaseBlock, loaded, d->CurrentBlock);
@@ -434,7 +434,7 @@ void FunctionNode::codegen(Decision *d) {
 
   CreateTerm creator(
       finalSubst, d->Definition, d->CurrentBlock, d->Module, false);
-  auto Call = creator.createFunctionCall(
+  auto *Call = creator.createFunctionCall(
       function, cat, args, function.substr(0, 5) == "hook_", false);
   Call->setName(name.substr(0, max_name_length));
   d->store(std::make_pair(name, type), Call);
@@ -453,7 +453,7 @@ void FunctionNode::codegen(Decision *d) {
     std::vector<llvm::Value *> functionArgs;
     functionArgs.push_back(d->stringLiteral(debugName));
     functionArgs.push_back(d->stringLiteral(function));
-    auto tempAllocCall = d->ptrTerm(Call);
+    auto *tempAllocCall = d->ptrTerm(Call);
     if (Call->getType() == llvm::Type::getInt1Ty(d->Ctx)) {
       llvm::Value *zext = new llvm::ZExtInst(
           Call, llvm::Type::getInt8Ty(d->Ctx), "", d->CurrentBlock);
@@ -461,10 +461,10 @@ void FunctionNode::codegen(Decision *d) {
     }
     functionArgs.push_back(tempAllocCall);
     for (auto i = 0u; i < args.size(); ++i) {
-      auto arg = args[i];
+      auto *arg = args[i];
       auto cat = bindings[i].second;
 
-      auto tempAllocArg = d->ptrTerm(arg);
+      auto *tempAllocArg = d->ptrTerm(arg);
       if (arg->getType() == llvm::Type::getInt1Ty(d->Ctx)) {
         llvm::Value *zext = new llvm::ZExtInst(
             Call, llvm::Type::getInt8Ty(d->Ctx), "", d->CurrentBlock);
@@ -477,7 +477,7 @@ void FunctionNode::codegen(Decision *d) {
     functionArgs.push_back(
         llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(d->Ctx)));
 
-    auto call = llvm::CallInst::Create(
+    auto *call = llvm::CallInst::Create(
         getOrInsertFunction(
             d->Module, "addMatchFunction",
             llvm::FunctionType::get(
@@ -513,7 +513,7 @@ void MakeIteratorNode::codegen(Decision *d) {
   llvm::FunctionType *funcType = llvm::FunctionType::get(
       llvm::Type::getVoidTy(d->Module->getContext()), types, false);
   llvm::Function *func = getOrInsertFunction(d->Module, hookName, funcType);
-  auto call = llvm::CallInst::Create(func, args, "", d->CurrentBlock);
+  auto *call = llvm::CallInst::Create(func, args, "", d->CurrentBlock);
   setDebugLoc(call);
   llvm::Attribute sretAttr
       = llvm::Attribute::get(d->Ctx, llvm::Attribute::StructRet, sretType);
@@ -535,7 +535,7 @@ void IterNextNode::codegen(Decision *d) {
       getValueType({SortCategory::Symbol, 0}, d->Module), {arg->getType()},
       false);
   llvm::Function *func = getOrInsertFunction(d->Module, hookName, funcType);
-  auto Call = llvm::CallInst::Create(
+  auto *Call = llvm::CallInst::Create(
       func, {arg}, binding.substr(0, max_name_length), d->CurrentBlock);
   setDebugLoc(Call);
   d->store(std::make_pair(binding, bindingType), Call);
@@ -549,7 +549,7 @@ void LeafNode::codegen(Decision *d) {
     return;
   }
   if (d->FailPattern) {
-    auto call = llvm::CallInst::Create(
+    auto *call = llvm::CallInst::Create(
         getOrInsertFunction(
             d->Module, "addMatchSuccess", llvm::Type::getVoidTy(d->Ctx)),
         {}, "", d->CurrentBlock);
@@ -562,20 +562,20 @@ void LeafNode::codegen(Decision *d) {
   std::vector<llvm::Value *> args;
   std::vector<llvm::Type *> types;
   for (auto const &arg : bindings) {
-    auto val = d->load(arg);
+    auto *val = d->load(arg);
     args.push_back(val);
     types.push_back(val->getType());
   }
-  auto type = getParamType(d->Cat, d->Module);
+  auto *type = getParamType(d->Cat, d->Module);
 
-  auto applyRule = getOrInsertFunction(
+  auto *applyRule = getOrInsertFunction(
       d->Module, name, llvm::FunctionType::get(type, types, false));
 
   // We are generating code for a function with name beginning apply_rule_\d+; to
   // retrieve the corresponding ordinal we drop the apply_rule_ prefix.
   auto ordinal = std::stoll(name.substr(11));
   auto arity = applyRule->arg_end() - applyRule->arg_begin();
-  auto axiom = d->Definition->getAxiomByOrdinal(ordinal);
+  auto *axiom = d->Definition->getAxiomByOrdinal(ordinal);
 
   auto vars = std::map<std::string, KOREVariablePattern *>{};
   for (KOREPattern *lhs : axiom->getLeftHandSide()) {
@@ -593,7 +593,7 @@ void LeafNode::codegen(Decision *d) {
       = ProofEvent(d->Definition, d->Module)
             .rewriteEvent_pre(axiom, arity, vars, subst, d->CurrentBlock);
 
-  auto Call = llvm::CallInst::Create(applyRule, args, "", d->CurrentBlock);
+  auto *Call = llvm::CallInst::Create(applyRule, args, "", d->CurrentBlock);
   setDebugLoc(Call);
   Call->setCallingConv(llvm::CallingConv::Tail);
 
@@ -603,7 +603,7 @@ void LeafNode::codegen(Decision *d) {
     new llvm::StoreInst(
         llvm::ConstantInt::getTrue(d->Ctx), d->HasSearchResults,
         d->CurrentBlock);
-    auto Call2 = llvm::CallInst::Create(
+    auto *Call2 = llvm::CallInst::Create(
         getOrInsertFunction(
             d->Module, "addSearchResult",
             llvm::FunctionType::get(
@@ -620,7 +620,7 @@ void LeafNode::codegen(Decision *d) {
 }
 
 llvm::Value *Decision::getTag(llvm::Value *val) {
-  auto res = llvm::CallInst::Create(
+  auto *res = llvm::CallInst::Create(
       getOrInsertFunction(
           Module, "getTag", llvm::Type::getInt32Ty(Ctx),
           getValueType({SortCategory::Symbol, 0}, Module)),
@@ -630,7 +630,7 @@ llvm::Value *Decision::getTag(llvm::Value *val) {
 }
 
 llvm::AllocaInst *Decision::decl(var_type const &name) {
-  auto sym = new llvm::AllocaInst(
+  auto *sym = new llvm::AllocaInst(
       name.second, 0, "",
       this->CurrentBlock->getParent()->getEntryBlock().getFirstNonPHI());
   this->symbols[name] = sym;
@@ -641,26 +641,26 @@ llvm::Value *Decision::load(var_type const &name) {
   if (name.first == "") {
     llvm::Type *ty = name.second;
     if (ty->isPointerTy()) {
-      auto ptr_ty = (llvm::PointerType *)ty;
+      auto *ptr_ty = (llvm::PointerType *)ty;
       return llvm::ConstantPointerNull::get(ptr_ty);
     } else if (ty->isIntegerTy()) {
-      auto int_ty = (llvm::IntegerType *)ty;
+      auto *int_ty = (llvm::IntegerType *)ty;
       return llvm::ConstantInt::get(int_ty, 0);
     }
     assert(false && "Unbound variable on LHS is neither pointer nor integral");
   }
-  auto sym = this->symbols[name];
+  auto *sym = this->symbols[name];
   if (!sym) {
     sym = this->decl(name);
   }
-  auto alloc = llvm::cast<llvm::AllocaInst>(sym);
-  auto ty = alloc->getAllocatedType();
+  auto *alloc = llvm::cast<llvm::AllocaInst>(sym);
+  auto *ty = alloc->getAllocatedType();
   return new llvm::LoadInst(
       ty, sym, name.first.substr(0, max_name_length), this->CurrentBlock);
 }
 
 void Decision::store(var_type const &name, llvm::Value *val) {
-  auto sym = this->symbols[name];
+  auto *sym = this->symbols[name];
   if (!sym) {
     sym = this->decl(name);
   }
@@ -668,15 +668,15 @@ void Decision::store(var_type const &name, llvm::Value *val) {
 }
 
 llvm::Constant *Decision::stringLiteral(std::string const &str) {
-  auto Str = llvm::ConstantDataArray::getString(Ctx, str, true);
-  auto global = Module->getOrInsertGlobal("str_lit_" + str, Str->getType());
+  auto *Str = llvm::ConstantDataArray::getString(Ctx, str, true);
+  auto *global = Module->getOrInsertGlobal("str_lit_" + str, Str->getType());
   auto *globalVar = llvm::cast<llvm::GlobalVariable>(global);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(Str);
   }
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
   auto indices = std::vector<llvm::Constant *>{zero, zero};
-  auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(
+  auto *Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(
       Str->getType(), globalVar, indices);
   return Ptr;
 }
@@ -688,26 +688,26 @@ static void initChoiceBuffer(
     llvm::IndirectBrInst **jumpOut) {
   std::unordered_set<LeafNode *> leaves;
   dt->preprocess(leaves);
-  auto ty = llvm::ArrayType::get(
+  auto *ty = llvm::ArrayType::get(
       llvm::Type::getInt8PtrTy(module->getContext()), dt->getChoiceDepth() + 1);
   auto *choiceBuffer = new llvm::AllocaInst(ty, 0, "choiceBuffer", block);
   auto *choiceDepth = new llvm::AllocaInst(
       llvm::Type::getInt64Ty(module->getContext()), 0, "choiceDepth", block);
-  auto zero
+  auto *zero
       = llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 0);
   new llvm::StoreInst(zero, choiceDepth, block);
-  auto firstElt = llvm::GetElementPtrInst::CreateInBounds(
+  auto *firstElt = llvm::GetElementPtrInst::CreateInBounds(
       ty, choiceBuffer, {zero, zero}, "", block);
   new llvm::StoreInst(
       llvm::BlockAddress::get(block->getParent(), stuck), firstElt, block);
 
   auto *currDepth = new llvm::LoadInst(
       llvm::Type::getInt64Ty(module->getContext()), choiceDepth, "", fail);
-  auto currentElt = llvm::GetElementPtrInst::CreateInBounds(
+  auto *currentElt = llvm::GetElementPtrInst::CreateInBounds(
       ty, choiceBuffer, {zero, currDepth}, "", fail);
   auto *failAddress
       = new llvm::LoadInst(ty->getElementType(), currentElt, "", fail);
-  auto newDepth = llvm::BinaryOperator::Create(
+  auto *newDepth = llvm::BinaryOperator::Create(
       llvm::Instruction::Sub, currDepth,
       llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 1),
       "", fail);
@@ -728,13 +728,13 @@ void makeEvalOrAnywhereFunction(
         KOREDefinition *)) {
   auto returnSort = dynamic_cast<KORECompositeSort *>(function->getSort().get())
                         ->getCategory(definition);
-  auto returnType = getParamType(returnSort, module);
-  auto debugReturnType
+  auto *returnType = getParamType(returnSort, module);
+  auto *debugReturnType
       = getDebugType(returnSort, ast_to_string(*function->getSort()));
   std::vector<llvm::Type *> args;
   std::vector<llvm::Metadata *> debugArgs;
   std::vector<ValueType> cats;
-  for (auto &sort : function->getArguments()) {
+  for (const auto &sort : function->getArguments()) {
     auto cat = dynamic_cast<KORECompositeSort *>(sort.get())
                    ->getCategory(definition);
     debugArgs.push_back(getDebugType(cat, ast_to_string(*sort)));
@@ -779,7 +779,7 @@ void makeEvalOrAnywhereFunction(
   Decision codegen(
       definition, block, fail, jump, choiceBuffer, choiceDepth, module,
       returnSort, nullptr, nullptr, nullptr, nullptr);
-  for (auto val = matchFunc->arg_begin(); val != matchFunc->arg_end();
+  for (auto *val = matchFunc->arg_begin(); val != matchFunc->arg_end();
        ++val, ++i) {
     val->setName("_" + std::to_string(i + 1));
     codegen.store(std::make_pair(val->getName().str(), val->getType()), val);
@@ -797,9 +797,9 @@ void abortWhenStuck(
     Decision &codegen, KOREDefinition *d) {
   auto &Ctx = Module->getContext();
   symbol = d->getAllSymbols().at(ast_to_string(*symbol));
-  auto BlockType = getBlockType(Module, d, symbol);
+  auto *BlockType = getBlockType(Module, d, symbol);
   llvm::Value *Ptr;
-  auto BlockPtr = llvm::PointerType::getUnqual(
+  auto *BlockPtr = llvm::PointerType::getUnqual(
       llvm::StructType::getTypeByName(Module->getContext(), BLOCK_STRUCT));
   if (symbol->getArguments().empty()) {
     Ptr = llvm::ConstantExpr::getIntToPtr(
@@ -820,7 +820,7 @@ void abortWhenStuck(
       auto cat
           = dynamic_cast<KORECompositeSort *>(symbol->getArguments()[idx].get())
                 ->getCategory(d);
-      auto type = getParamType(cat, Module);
+      auto *type = getParamType(cat, Module);
       llvm::Value *ChildValue
           = codegen.load(std::make_pair("_" + std::to_string(idx + 1), type));
       llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(
@@ -859,7 +859,7 @@ void addOwise(
     auto cat
         = dynamic_cast<KORECompositeSort *>(symbol->getArguments()[i].get())
               ->getCategory(d);
-    auto type = getParamType(cat, module);
+    auto *type = getParamType(cat, module);
 
     std::string name = "_" + std::to_string(i + 1);
     finalSubst[name] = codegen.load(std::make_pair(name, type));
@@ -873,7 +873,7 @@ void addOwise(
   auto returnSort = dynamic_cast<KORECompositeSort *>(symbol->getSort().get())
                         ->getCategory(d);
   if (isCollectionSort(returnSort)) {
-    auto tempAlloc = allocateTerm(
+    auto *tempAlloc = allocateTerm(
         retval->getType(), creator.getCurrentBlock(), "koreAllocAlwaysGC");
     new llvm::StoreInst(retval, tempAlloc, creator.getCurrentBlock());
     retval = tempAlloc;
@@ -893,24 +893,24 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(
     unsigned ordinal, llvm::Module *module, KOREDefinition *definition,
     llvm::BasicBlock *block, llvm::BasicBlock *stuck,
     std::vector<llvm::Value *> args, std::vector<ValueType> const &types) {
-  auto finished = getOrInsertFunction(
+  auto *finished = getOrInsertFunction(
       module, "finished_rewriting",
       llvm::FunctionType::get(
           llvm::Type::getInt1Ty(module->getContext()), {}, false));
-  auto isFinished = llvm::CallInst::Create(finished, {}, "", block);
-  auto checkCollect = llvm::BasicBlock::Create(
+  auto *isFinished = llvm::CallInst::Create(finished, {}, "", block);
+  auto *checkCollect = llvm::BasicBlock::Create(
       module->getContext(), "checkCollect", block->getParent());
   llvm::BranchInst::Create(stuck, checkCollect, isFinished, block);
 
-  auto collection = getOrInsertFunction(
+  auto *collection = getOrInsertFunction(
       module, "is_collection",
       llvm::FunctionType::get(
           llvm::Type::getInt1Ty(module->getContext()), {}, false));
-  auto isCollection = llvm::CallInst::Create(collection, {}, "", checkCollect);
+  auto *isCollection = llvm::CallInst::Create(collection, {}, "", checkCollect);
   setDebugLoc(isCollection);
-  auto collect = llvm::BasicBlock::Create(
+  auto *collect = llvm::BasicBlock::Create(
       module->getContext(), "isCollect", block->getParent());
-  auto merge = llvm::BasicBlock::Create(
+  auto *merge = llvm::BasicBlock::Create(
       module->getContext(), "step", block->getParent());
   llvm::BranchInst::Create(collect, merge, isCollection, checkCollect);
 
@@ -944,19 +944,19 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(
     }
     i++;
   }
-  auto root_ty = llvm::ArrayType::get(
+  auto *root_ty = llvm::ArrayType::get(
       llvm::Type::getInt8PtrTy(module->getContext()), 256);
-  auto arr = module->getOrInsertGlobal("gc_roots", root_ty);
+  auto *arr = module->getOrInsertGlobal("gc_roots", root_ty);
   std::vector<std::pair<llvm::Value *, llvm::Type *>> rootPtrs;
   for (unsigned i = 0; i < nroots; i++) {
-    auto ptr = llvm::GetElementPtrInst::CreateInBounds(
+    auto *ptr = llvm::GetElementPtrInst::CreateInBounds(
         root_ty, arr,
         {llvm::ConstantInt::get(
              llvm::Type::getInt64Ty(module->getContext()), 0),
          llvm::ConstantInt::get(
              llvm::Type::getInt64Ty(module->getContext()), i)},
         "", collect);
-    auto casted = new llvm::BitCastInst(
+    auto *casted = new llvm::BitCastInst(
         ptr, llvm::PointerType::getUnqual(ptrTypes[i]), "", collect);
     new llvm::StoreInst(roots[i], casted, collect);
     rootPtrs.emplace_back(casted, ptrTypes[i]);
@@ -988,28 +988,28 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(
     case SortCategory::Uncomputed: abort();
     }
   }
-  auto layoutArr = llvm::ConstantArray::get(
+  auto *layoutArr = llvm::ConstantArray::get(
       llvm::ArrayType::get(
           llvm::StructType::getTypeByName(
               module->getContext(), LAYOUTITEM_STRUCT),
           elements.size()),
       elements);
-  auto layout = module->getOrInsertGlobal(
+  auto *layout = module->getOrInsertGlobal(
       "layout_item_rule_" + std::to_string(ordinal), layoutArr->getType());
   auto *globalVar = llvm::cast<llvm::GlobalVariable>(layout);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(layoutArr);
   }
-  auto ptrTy = llvm::PointerType::getUnqual(llvm::ArrayType::get(
+  auto *ptrTy = llvm::PointerType::getUnqual(llvm::ArrayType::get(
       llvm::StructType::getTypeByName(module->getContext(), LAYOUTITEM_STRUCT),
       0));
-  auto koreCollect = getOrInsertFunction(
+  auto *koreCollect = getOrInsertFunction(
       module, "koreCollect",
       llvm::FunctionType::get(
           llvm::Type::getVoidTy(module->getContext()),
           {arr->getType(), llvm::Type::getInt8Ty(module->getContext()), ptrTy},
           false));
-  auto call = llvm::CallInst::Create(
+  auto *call = llvm::CallInst::Create(
       koreCollect,
       {arr,
        llvm::ConstantInt::get(
@@ -1020,8 +1020,8 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(
   i = 0;
   std::vector<llvm::Value *> phis;
   for (auto [ptr, pointee_ty] : rootPtrs) {
-    auto loaded = new llvm::LoadInst(pointee_ty, ptr, "", collect);
-    auto phi = llvm::PHINode::Create(loaded->getType(), 2, "phi", merge);
+    auto *loaded = new llvm::LoadInst(pointee_ty, ptr, "", collect);
+    auto *phi = llvm::PHINode::Create(loaded->getType(), 2, "phi", merge);
     phi->addIncoming(loaded, collect);
     phi->addIncoming(roots[i++], checkCollect);
     phis.push_back(phi);
@@ -1051,8 +1051,8 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(
 void makeStepFunction(
     KOREDefinition *definition, llvm::Module *module, DecisionNode *dt,
     bool search) {
-  auto blockType = getValueType({SortCategory::Symbol, 0}, module);
-  auto debugType
+  auto *blockType = getValueType({SortCategory::Symbol, 0}, module);
+  auto *debugType
       = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
   llvm::FunctionType *funcType;
   std::string name;
@@ -1076,7 +1076,7 @@ void makeStepFunction(
         matchFunc);
   }
   matchFunc->setCallingConv(llvm::CallingConv::Tail);
-  auto val = matchFunc->arg_begin();
+  auto *val = matchFunc->arg_begin();
   llvm::BasicBlock *block
       = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
   llvm::BasicBlock *stuck
@@ -1107,7 +1107,7 @@ void makeStepFunction(
   llvm::BranchInst::Create(stuck, pre_stuck);
   auto result = stepFunctionHeader(
       0, module, definition, block, stuck, {val}, {{SortCategory::Symbol, 0}});
-  auto collectedVal = result.first[0];
+  auto *collectedVal = result.first[0];
   collectedVal->setName("_1");
   Decision codegen(
       definition, result.second, fail, jump, choiceBuffer, choiceDepth, module,
@@ -1118,7 +1118,7 @@ void makeStepFunction(
   if (search) {
     llvm::ReturnInst::Create(module->getContext(), stuck);
   } else {
-    auto phi
+    auto *phi
         = llvm::PHINode::Create(collectedVal->getType(), 2, "phi_1", stuck);
     phi->addIncoming(val, block);
     phi->addIncoming(collectedVal, pre_stuck);
@@ -1131,7 +1131,7 @@ void makeStepFunction(
 void makeMatchReasonFunctionWrapper(
     KOREDefinition *definition, llvm::Module *module,
     KOREAxiomDeclaration *axiom, std::string const &name) {
-  auto blockType = getValueType({SortCategory::Symbol, 0}, module);
+  auto *blockType = getValueType({SortCategory::Symbol, 0}, module);
   llvm::FunctionType *funcType = llvm::FunctionType::get(
       llvm::Type::getVoidTy(module->getContext()), {blockType}, false);
   std::string wrapperName = "match_" + std::to_string(axiom->getOrdinal());
@@ -1141,7 +1141,7 @@ void makeMatchReasonFunctionWrapper(
   if (axiom->getAttributes().count("label")) {
     debugName = axiom->getStringAttribute("label") + "_tailcc_" + ".match";
   }
-  auto debugType
+  auto *debugType
       = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
   resetDebugLoc();
   initDebugFunction(
@@ -1152,8 +1152,8 @@ void makeMatchReasonFunctionWrapper(
   llvm::BasicBlock *entry
       = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
 
-  auto ci = module->getFunction(name);
-  auto call = llvm::CallInst::Create(ci, matchFunc->getArg(0), "", entry);
+  auto *ci = module->getFunction(name);
+  auto *call = llvm::CallInst::Create(ci, matchFunc->getArg(0), "", entry);
   setDebugLoc(call);
 
   llvm::ReturnInst::Create(module->getContext(), entry);
@@ -1162,7 +1162,7 @@ void makeMatchReasonFunctionWrapper(
 void makeMatchReasonFunction(
     KOREDefinition *definition, llvm::Module *module,
     KOREAxiomDeclaration *axiom, DecisionNode *dt) {
-  auto blockType = getValueType({SortCategory::Symbol, 0}, module);
+  auto *blockType = getValueType({SortCategory::Symbol, 0}, module);
   llvm::FunctionType *funcType = llvm::FunctionType::get(
       llvm::Type::getVoidTy(module->getContext()), {blockType}, false);
   std::string name = "intern_match_" + std::to_string(axiom->getOrdinal());
@@ -1171,14 +1171,14 @@ void makeMatchReasonFunction(
   if (axiom->getAttributes().count("label")) {
     debugName = axiom->getStringAttribute("label") + ".match";
   }
-  auto debugType
+  auto *debugType
       = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
   resetDebugLoc();
   initDebugFunction(
       debugName, debugName,
       getDebugFunctionType(getVoidDebugType(), {debugType}), definition,
       matchFunc);
-  auto val = matchFunc->arg_begin();
+  auto *val = matchFunc->arg_begin();
   llvm::BasicBlock *block
       = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
   llvm::BasicBlock *stuck
@@ -1193,7 +1193,7 @@ void makeMatchReasonFunction(
       llvm::Type::getInt8PtrTy(module->getContext()), 0, "pattern", fail);
   llvm::PHINode *FailSort = llvm::PHINode::Create(
       llvm::Type::getInt8PtrTy(module->getContext()), 0, "sort", fail);
-  auto call = llvm::CallInst::Create(
+  auto *call = llvm::CallInst::Create(
       getOrInsertFunction(
           module, "addMatchFailReason",
           llvm::FunctionType::get(
@@ -1239,7 +1239,7 @@ KOREPattern *makePartialTerm(
   if (occurrences.count(occurrence)) {
     return KOREVariablePattern::Create(occurrence, term->getSort()).release();
   }
-  if (auto pat = dynamic_cast<KORECompositePattern *>(term)) {
+  if (auto *pat = dynamic_cast<KORECompositePattern *>(term)) {
     if (pat->getConstructor()->getName() == "\\dv") {
       return term;
     }
@@ -1258,11 +1258,11 @@ KOREPattern *makePartialTerm(
 void makeStepFunction(
     KOREAxiomDeclaration *axiom, KOREDefinition *definition,
     llvm::Module *module, PartialStep res) {
-  auto blockType = getValueType({SortCategory::Symbol, 0}, module);
+  auto *blockType = getValueType({SortCategory::Symbol, 0}, module);
   std::vector<llvm::Type *> argTypes;
   std::vector<llvm::Metadata *> debugTypes;
   for (auto const &res : res.residuals) {
-    auto argSort
+    auto *argSort
         = dynamic_cast<KORECompositeSort *>(res.pattern->getSort().get());
     auto cat = argSort->getCategory(definition);
     debugTypes.push_back(getDebugType(cat, ast_to_string(*argSort)));
@@ -1277,7 +1277,7 @@ void makeStepFunction(
     default: argTypes.push_back(getValueType(cat, module)); break;
     }
   }
-  auto blockDebugType
+  auto *blockDebugType
       = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
   llvm::FunctionType *funcType
       = llvm::FunctionType::get(blockType, argTypes, false);
@@ -1310,10 +1310,10 @@ void makeStepFunction(
   int i = 0;
   std::vector<llvm::Value *> args;
   std::vector<ValueType> types;
-  for (auto val = matchFunc->arg_begin(); val != matchFunc->arg_end();
+  for (auto *val = matchFunc->arg_begin(); val != matchFunc->arg_end();
        ++val, ++i) {
     args.push_back(val);
-    auto phi = llvm::PHINode::Create(
+    auto *phi = llvm::PHINode::Create(
         val->getType(), 2, "phi" + res.residuals[i].occurrence, stuck);
     phi->addIncoming(val, block);
     phis.push_back(phi);
@@ -1330,7 +1330,7 @@ void makeStepFunction(
   Decision codegen(
       definition, header.second, fail, jump, choiceBuffer, choiceDepth, module,
       {SortCategory::Symbol, 0}, nullptr, nullptr, nullptr, nullptr);
-  for (auto val : header.first) {
+  for (auto *val : header.first) {
     val->setName(res.residuals[i].occurrence.substr(0, max_name_length));
     codegen.store(std::make_pair(val->getName().str(), val->getType()), val);
     stuckSubst.insert({val->getName(), phis[i]});

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -98,27 +98,25 @@ getFailPattern(DecisionCase const &_case, bool isInt) {
                             + (_case.getLiteral() == 0 ? std::string("false")
                                                        : std::string("true"))
                             + "\")");
-    } else {
-      std::string sort = "SortMInt{Sort" + std::to_string(bitwidth) + "{}}";
-      llvm::SmallString<25> vec;
-      _case.getLiteral().toString(vec, 10, false);
-      return std::make_pair(
-          sort, "\\dv{" + sort + "}(\"" + std::string(vec.c_str()) + "p"
-                    + std::to_string(bitwidth) + "\")");
     }
-  } else {
-    auto result = fmt::format("{}(", ast_to_string(*_case.getConstructor()));
-
-    std::string conn;
-    for (const auto &i : _case.getConstructor()->getArguments()) {
-      result += fmt::format("{}Var'Unds':{}", conn, ast_to_string(*i));
-      conn = ",";
-    }
-    result += ")";
-
-    auto return_sort = ast_to_string(*_case.getConstructor()->getSort());
-    return std::make_pair(return_sort, result);
+    std::string sort = "SortMInt{Sort" + std::to_string(bitwidth) + "{}}";
+    llvm::SmallString<25> vec;
+    _case.getLiteral().toString(vec, 10, false);
+    return std::make_pair(
+        sort, "\\dv{" + sort + "}(\"" + std::string(vec.c_str()) + "p"
+                  + std::to_string(bitwidth) + "\")");
   }
+  auto result = fmt::format("{}(", ast_to_string(*_case.getConstructor()));
+
+  std::string conn;
+  for (const auto &i : _case.getConstructor()->getArguments()) {
+    result += fmt::format("{}Var'Unds':{}", conn, ast_to_string(*i));
+    conn = ",";
+  }
+  result += ")";
+
+  auto return_sort = ast_to_string(*_case.getConstructor()->getSort());
+  return std::make_pair(return_sort, result);
 }
 
 static std::pair<std::string, std::string> getFailPattern(
@@ -644,7 +642,8 @@ llvm::Value *Decision::load(var_type const &name) {
     if (ty->isPointerTy()) {
       auto *ptr_ty = (llvm::PointerType *)ty;
       return llvm::ConstantPointerNull::get(ptr_ty);
-    } else if (ty->isIntegerTy()) {
+    }
+    if (ty->isIntegerTy()) {
       auto *int_ty = (llvm::IntegerType *)ty;
       return llvm::ConstantInt::get(int_ty, 0);
     }

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -141,6 +141,7 @@ static std::pair<std::string, std::string> getFailPattern(
   return std::make_pair(sort, reason);
 }
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 void SwitchNode::codegen(Decision *d) {
   if (beginNode(d, "switch" + name)) {
     return;

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -460,7 +460,7 @@ void FunctionNode::codegen(Decision *d) {
       new llvm::StoreInst(zext, tempAllocCall, d->CurrentBlock);
     }
     functionArgs.push_back(tempAllocCall);
-    for (auto i = 0u; i < args.size(); ++i) {
+    for (auto i = 0U; i < args.size(); ++i) {
       auto *arg = args[i];
       auto cat = bindings[i].second;
 

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -117,7 +117,7 @@ public:
   }
 
   static std::string to_string(std::vector<std::string> const &occurrence) {
-    std::string result = "";
+    std::string result;
     for (auto const &i : occurrence) {
       result.push_back('_');
       result += i;

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -221,32 +221,32 @@ public:
   }
 
   DecisionNode *makeIterator(yaml_node_t *node) {
-    std::string name = to_string(vec(get(node, "collection")));
-    llvm::Type *type = getParamType(
+    auto collection = to_string(vec(get(node, "collection")));
+    auto *type = getParamType(
         KORECompositeSort::getCategory(str(get(node, "sort"))), mod);
-    std::string function = str(get(node, "function"));
+    auto hookName = str(get(node, "function"));
     auto *child = (*this)(get(node, "next"));
 
     return MakeIteratorNode::Create(
-        name, type, name + "_iter",
+        collection, type, collection + "_iter",
         llvm::PointerType::getUnqual(
             llvm::StructType::getTypeByName(mod->getContext(), "iter")),
-        function, child);
+        hookName, child);
   }
 
   DecisionNode *iterNext(yaml_node_t *node) {
-    std::string iterator = to_string(vec(get(node, "iterator"))) + "_iter";
-    std::string name = to_string(vec(get(node, "binding")));
-    llvm::Type *type = getParamType(
+    auto iterator = to_string(vec(get(node, "iterator"))) + "_iter";
+    auto binding = to_string(vec(get(node, "binding")));
+    auto *type = getParamType(
         KORECompositeSort::getCategory(str(get(node, "sort"))), mod);
-    std::string function = str(get(node, "function"));
+    auto function = str(get(node, "function"));
     auto *child = (*this)(get(node, "next"));
 
     return IterNextNode::Create(
         iterator,
         llvm::PointerType::getUnqual(
             llvm::StructType::getTypeByName(mod->getContext(), "iter")),
-        name, type, function, child);
+        binding, type, function, child);
   }
 
   DecisionNode *switchCase(Kind kind, yaml_node_t *node) {

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -44,24 +44,33 @@ private:
   };
 
   Kind getKind(yaml_node_t *node) {
-    if (node->type == YAML_SCALAR_NODE)
+    if (node->type == YAML_SCALAR_NODE) {
       return Fail;
-    if (get(node, "collection"))
+    }
+    if (get(node, "collection")) {
       return MakeIterator;
-    if (get(node, "iterator"))
+    }
+    if (get(node, "iterator")) {
       return IterNext;
-    if (get(node, "isnull"))
+    }
+    if (get(node, "isnull")) {
       return CheckNull;
-    if (get(node, "pattern"))
+    }
+    if (get(node, "pattern")) {
       return MakePattern;
-    if (get(node, "bitwidth"))
+    }
+    if (get(node, "bitwidth")) {
       return SwitchLiteral;
-    if (get(node, "specializations"))
+    }
+    if (get(node, "specializations")) {
       return Switch;
-    if (get(node, "action"))
+    }
+    if (get(node, "action")) {
       return Leaf;
-    if (get(node, "function"))
+    }
+    if (get(node, "function")) {
       return Function;
+    }
     throw *node;
   }
 

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -91,7 +91,7 @@ public:
     return yaml_document_get_node(doc, node->data.sequence.items.start[off]);
   }
 
-  std::string str(yaml_node_t *node) {
+  static std::string str(yaml_node_t *node) {
     return {(char *)node->data.scalar.value, node->data.scalar.length};
   }
 
@@ -116,7 +116,7 @@ public:
     dv = KORESymbol::Create("\\dv").release();
   }
 
-  std::string to_string(std::vector<std::string> const &occurrence) {
+  static std::string to_string(std::vector<std::string> const &occurrence) {
     std::string result = "";
     for (auto const &i : occurrence) {
       result.push_back('_');

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -168,7 +168,9 @@ public:
       ValueType hook = KORECompositeSort::getCategory(str(get(node, "hook")));
       uses.emplace_back(name, getParamType(hook, mod));
       return KOREVariablePattern::Create(name, sorts.at(hook));
-    } else if (get(node, "literal")) {
+    }
+
+    if (get(node, "literal")) {
       auto sym = KORESymbol::Create("\\dv");
       auto hook = str(get(node, "hook"));
       auto sort = sorts.at(KORECompositeSort::getCategory(hook));
@@ -186,21 +188,22 @@ public:
       auto pat = KORECompositePattern::Create(std::move(sym));
       pat->addArgument(KOREStringPattern::Create(val));
       return pat;
-    } else {
-      if (!get(node, "constructor")) {
-        std::cerr << node << std::endl;
-        abort();
-      }
-      auto *sym = syms.at(str(get(node, "constructor")));
-      auto pat = KORECompositePattern::Create(sym);
-      auto *seq = get(node, "args");
-      for (auto *iter = seq->data.sequence.items.start;
-           iter < seq->data.sequence.items.top; iter++) {
-        auto *child = yaml_document_get_node(doc, *iter);
-        pat->addArgument(parsePattern(child, uses));
-      }
-      return pat;
     }
+
+    if (!get(node, "constructor")) {
+      std::cerr << node << std::endl;
+      abort();
+    }
+
+    auto *sym = syms.at(str(get(node, "constructor")));
+    auto pat = KORECompositePattern::Create(sym);
+    auto *seq = get(node, "args");
+    for (auto *iter = seq->data.sequence.items.start;
+         iter < seq->data.sequence.items.top; iter++) {
+      auto *child = yaml_document_get_node(doc, *iter);
+      pat->addArgument(parsePattern(child, uses));
+    }
+    return pat;
   }
 
   DecisionNode *makePattern(yaml_node_t *node) {

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -917,6 +917,7 @@ static void visitCollection(
       "", CaseBlock);
 }
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 static void getVisitor(
     KOREDefinition *definition, llvm::Module *module, KORESymbol *symbol,
     llvm::BasicBlock *CaseBlock, std::vector<llvm::Value *> const &callbacks) {

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -28,8 +28,8 @@ llvm::Constant *createGlobalSortStringPtr(
 
 llvm::CallInst *ProofEvent::emitSerializeTerm(
     KORECompositeSort &sort, llvm::Value *outputFile, llvm::Value *term,
-    llvm::BasicBlock *insert_at_end) {
-  auto B = llvm::IRBuilder(insert_at_end);
+    llvm::BasicBlock *insertAtEnd) {
+  auto B = llvm::IRBuilder(insertAtEnd);
 
   auto cat = sort.getCategory(Definition);
   auto *sort_name_ptr = createGlobalSortStringPtr(B, sort, Module);
@@ -80,7 +80,7 @@ llvm::CallInst *ProofEvent::emitSerializeConfiguration(
 }
 
 llvm::CallInst *ProofEvent::emitWriteUInt64(
-    llvm::Value *outputFile, uint64_t value, llvm::BasicBlock *insert_at_end) {
+    llvm::Value *outputFile, uint64_t value, llvm::BasicBlock *insertAtEnd) {
   auto *void_ty = llvm::Type::getVoidTy(Ctx);
   auto *i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
   auto *i64_ptr_ty = llvm::Type::getInt64Ty(Ctx);
@@ -91,8 +91,7 @@ llvm::CallInst *ProofEvent::emitWriteUInt64(
 
   auto *i64_value = llvm::ConstantInt::get(i64_ptr_ty, value);
 
-  return llvm::CallInst::Create(
-      func, {outputFile, i64_value}, "", insert_at_end);
+  return llvm::CallInst::Create(func, {outputFile, i64_value}, "", insertAtEnd);
 }
 
 llvm::CallInst *ProofEvent::emitWriteString(
@@ -112,31 +111,30 @@ llvm::CallInst *ProofEvent::emitWriteString(
   return B.CreateCall(print, {outputFile, varname});
 }
 
-llvm::BinaryOperator *ProofEvent::emitNoOp(llvm::BasicBlock *insert_at_end) {
+llvm::BinaryOperator *ProofEvent::emitNoOp(llvm::BasicBlock *insertAtEnd) {
   auto *i8_ty = llvm::Type::getInt8Ty(Ctx);
   auto *zero = llvm::ConstantInt::get(i8_ty, 0);
 
   return llvm::BinaryOperator::Create(
-      llvm::Instruction::Add, zero, zero, "no-op", insert_at_end);
+      llvm::Instruction::Add, zero, zero, "no-op", insertAtEnd);
 }
 
 llvm::LoadInst *
-ProofEvent::emitGetOutputFileName(llvm::BasicBlock *insert_at_end) {
+ProofEvent::emitGetOutputFileName(llvm::BasicBlock *insertAtEnd) {
   auto *i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
   auto *fileNamePointer = Module->getOrInsertGlobal("output_file", i8_ptr_ty);
-  return new llvm::LoadInst(
-      i8_ptr_ty, fileNamePointer, "output", insert_at_end);
+  return new llvm::LoadInst(i8_ptr_ty, fileNamePointer, "output", insertAtEnd);
 }
 
 std::pair<llvm::BasicBlock *, llvm::BasicBlock *> ProofEvent::proofBranch(
-    std::string const &label, llvm::BasicBlock *insert_at_end) {
+    std::string const &label, llvm::BasicBlock *insertAtEnd) {
   auto *i1_ty = llvm::Type::getInt1Ty(Ctx);
 
   auto *proof_output_flag = Module->getOrInsertGlobal("proof_output", i1_ty);
   auto *proof_output = new llvm::LoadInst(
-      i1_ty, proof_output_flag, "proof_output", insert_at_end);
+      i1_ty, proof_output_flag, "proof_output", insertAtEnd);
 
-  auto *f = insert_at_end->getParent();
+  auto *f = insertAtEnd->getParent();
   auto *true_block
       = llvm::BasicBlock::Create(Ctx, fmt::format("if_{}", label), f);
   auto *merge_block
@@ -144,8 +142,7 @@ std::pair<llvm::BasicBlock *, llvm::BasicBlock *> ProofEvent::proofBranch(
 
   emitNoOp(merge_block);
 
-  llvm::BranchInst::Create(
-      true_block, merge_block, proof_output, insert_at_end);
+  llvm::BranchInst::Create(true_block, merge_block, proof_output, insertAtEnd);
   return {true_block, merge_block};
 }
 

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -47,21 +47,20 @@ llvm::CallInst *ProofEvent::emitSerializeTerm(
         = getOrInsertFunction(Module, "serializeTermToFile", func_ty);
 
     return B.CreateCall(serialize, {outputFile, term, sort_name_ptr});
-  } else {
-    if (term->getType()->isIntegerTy()) {
-      term = B.CreateIntToPtr(term, i8_ptr_ty);
-    } else {
-      term = B.CreatePointerCast(term, i8_ptr_ty);
-    }
-
-    auto *func_ty = llvm::FunctionType::get(
-        void_ty, {i8_ptr_ty, i8_ptr_ty, i8_ptr_ty}, false);
-
-    auto *serialize
-        = getOrInsertFunction(Module, "serializeRawTermToFile", func_ty);
-
-    return B.CreateCall(serialize, {outputFile, term, sort_name_ptr});
   }
+  if (term->getType()->isIntegerTy()) {
+    term = B.CreateIntToPtr(term, i8_ptr_ty);
+  } else {
+    term = B.CreatePointerCast(term, i8_ptr_ty);
+  }
+
+  auto *func_ty = llvm::FunctionType::get(
+      void_ty, {i8_ptr_ty, i8_ptr_ty, i8_ptr_ty}, false);
+
+  auto *serialize
+      = getOrInsertFunction(Module, "serializeRawTermToFile", func_ty);
+
+  return B.CreateCall(serialize, {outputFile, term, sort_name_ptr});
 }
 
 llvm::CallInst *ProofEvent::emitSerializeConfiguration(

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -32,18 +32,18 @@ llvm::CallInst *ProofEvent::emitSerializeTerm(
   auto B = llvm::IRBuilder(insert_at_end);
 
   auto cat = sort.getCategory(Definition);
-  auto sort_name_ptr = createGlobalSortStringPtr(B, sort, Module);
+  auto *sort_name_ptr = createGlobalSortStringPtr(B, sort, Module);
 
-  auto void_ty = llvm::Type::getVoidTy(Ctx);
-  auto i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
+  auto *void_ty = llvm::Type::getVoidTy(Ctx);
+  auto *i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
 
   if (cat.cat == SortCategory::Symbol || cat.cat == SortCategory::Variable) {
-    auto block_ty = getValueType({SortCategory::Symbol, 0}, Module);
+    auto *block_ty = getValueType({SortCategory::Symbol, 0}, Module);
 
-    auto func_ty = llvm::FunctionType::get(
+    auto *func_ty = llvm::FunctionType::get(
         void_ty, {i8_ptr_ty, block_ty, i8_ptr_ty}, false);
 
-    auto serialize
+    auto *serialize
         = getOrInsertFunction(Module, "serializeTermToFile", func_ty);
 
     return B.CreateCall(serialize, {outputFile, term, sort_name_ptr});
@@ -54,10 +54,10 @@ llvm::CallInst *ProofEvent::emitSerializeTerm(
       term = B.CreatePointerCast(term, i8_ptr_ty);
     }
 
-    auto func_ty = llvm::FunctionType::get(
+    auto *func_ty = llvm::FunctionType::get(
         void_ty, {i8_ptr_ty, i8_ptr_ty, i8_ptr_ty}, false);
 
-    auto serialize
+    auto *serialize
         = getOrInsertFunction(Module, "serializeRawTermToFile", func_ty);
 
     return B.CreateCall(serialize, {outputFile, term, sort_name_ptr});
@@ -67,12 +67,13 @@ llvm::CallInst *ProofEvent::emitSerializeTerm(
 llvm::CallInst *ProofEvent::emitSerializeConfiguration(
     llvm::Value *outputFile, llvm::Value *config,
     llvm::BasicBlock *insertAtEnd) {
-  auto void_ty = llvm::Type::getVoidTy(Ctx);
-  auto i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
-  auto block_ty = getValueType({SortCategory::Symbol, 0}, Module);
+  auto *void_ty = llvm::Type::getVoidTy(Ctx);
+  auto *i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
+  auto *block_ty = getValueType({SortCategory::Symbol, 0}, Module);
 
-  auto func_ty = llvm::FunctionType::get(void_ty, {i8_ptr_ty, block_ty}, false);
-  auto serialize
+  auto *func_ty
+      = llvm::FunctionType::get(void_ty, {i8_ptr_ty, block_ty}, false);
+  auto *serialize
       = getOrInsertFunction(Module, "serializeConfigurationToFile", func_ty);
 
   return llvm::CallInst::Create(
@@ -81,15 +82,15 @@ llvm::CallInst *ProofEvent::emitSerializeConfiguration(
 
 llvm::CallInst *ProofEvent::emitWriteUInt64(
     llvm::Value *outputFile, uint64_t value, llvm::BasicBlock *insert_at_end) {
-  auto void_ty = llvm::Type::getVoidTy(Ctx);
-  auto i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
-  auto i64_ptr_ty = llvm::Type::getInt64Ty(Ctx);
+  auto *void_ty = llvm::Type::getVoidTy(Ctx);
+  auto *i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
+  auto *i64_ptr_ty = llvm::Type::getInt64Ty(Ctx);
 
-  auto func_ty
+  auto *func_ty
       = llvm::FunctionType::get(void_ty, {i8_ptr_ty, i64_ptr_ty}, false);
-  auto func = getOrInsertFunction(Module, "writeUInt64ToFile", func_ty);
+  auto *func = getOrInsertFunction(Module, "writeUInt64ToFile", func_ty);
 
-  auto i64_value = llvm::ConstantInt::get(i64_ptr_ty, value);
+  auto *i64_value = llvm::ConstantInt::get(i64_ptr_ty, value);
 
   return llvm::CallInst::Create(
       func, {outputFile, i64_value}, "", insert_at_end);
@@ -100,21 +101,21 @@ llvm::CallInst *ProofEvent::emitWriteString(
     llvm::BasicBlock *insertAtEnd) {
   auto B = llvm::IRBuilder(insertAtEnd);
 
-  auto void_ty = llvm::Type::getVoidTy(Ctx);
-  auto i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
+  auto *void_ty = llvm::Type::getVoidTy(Ctx);
+  auto *i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
 
-  auto func_ty
+  auto *func_ty
       = llvm::FunctionType::get(void_ty, {i8_ptr_ty, i8_ptr_ty}, false);
 
-  auto print = getOrInsertFunction(Module, "printVariableToFile", func_ty);
+  auto *print = getOrInsertFunction(Module, "printVariableToFile", func_ty);
 
-  auto varname = B.CreateGlobalStringPtr(str, "", 0, Module);
+  auto *varname = B.CreateGlobalStringPtr(str, "", 0, Module);
   return B.CreateCall(print, {outputFile, varname});
 }
 
 llvm::BinaryOperator *ProofEvent::emitNoOp(llvm::BasicBlock *insert_at_end) {
-  auto i8_ty = llvm::Type::getInt8Ty(Ctx);
-  auto zero = llvm::ConstantInt::get(i8_ty, 0);
+  auto *i8_ty = llvm::Type::getInt8Ty(Ctx);
+  auto *zero = llvm::ConstantInt::get(i8_ty, 0);
 
   return llvm::BinaryOperator::Create(
       llvm::Instruction::Add, zero, zero, "no-op", insert_at_end);
@@ -122,22 +123,22 @@ llvm::BinaryOperator *ProofEvent::emitNoOp(llvm::BasicBlock *insert_at_end) {
 
 llvm::LoadInst *
 ProofEvent::emitGetOutputFileName(llvm::BasicBlock *insert_at_end) {
-  auto i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
-  auto fileNamePointer = Module->getOrInsertGlobal("output_file", i8_ptr_ty);
+  auto *i8_ptr_ty = llvm::Type::getInt8PtrTy(Ctx);
+  auto *fileNamePointer = Module->getOrInsertGlobal("output_file", i8_ptr_ty);
   return new llvm::LoadInst(
       i8_ptr_ty, fileNamePointer, "output", insert_at_end);
 }
 
 std::pair<llvm::BasicBlock *, llvm::BasicBlock *> ProofEvent::proofBranch(
     std::string const &label, llvm::BasicBlock *insert_at_end) {
-  auto i1_ty = llvm::Type::getInt1Ty(Ctx);
+  auto *i1_ty = llvm::Type::getInt1Ty(Ctx);
 
-  auto proof_output_flag = Module->getOrInsertGlobal("proof_output", i1_ty);
-  auto proof_output = new llvm::LoadInst(
+  auto *proof_output_flag = Module->getOrInsertGlobal("proof_output", i1_ty);
+  auto *proof_output = new llvm::LoadInst(
       i1_ty, proof_output_flag, "proof_output", insert_at_end);
 
-  auto f = insert_at_end->getParent();
-  auto true_block
+  auto *f = insert_at_end->getParent();
+  auto *true_block
       = llvm::BasicBlock::Create(Ctx, fmt::format("if_{}", label), f);
   auto *merge_block
       = llvm::BasicBlock::Create(Ctx, fmt::format("tail_{}", label), f);
@@ -233,8 +234,8 @@ llvm::BasicBlock *ProofEvent::rewriteEvent_pre(
   emitWriteUInt64(outputFile, arity, true_block);
   for (auto entry = subst.begin(); entry != subst.end(); ++entry) {
     auto key = entry->getKey();
-    auto val = entry->getValue();
-    auto var = vars[key.str()];
+    auto *val = entry->getValue();
+    auto *var = vars[key.str()];
 
     auto sort = std::dynamic_pointer_cast<KORECompositeSort>(var->getSort());
 
@@ -331,8 +332,8 @@ llvm::BasicBlock *ProofEvent::sideConditionEvent(
   int i = 0;
   for (auto entry = vars.begin(); entry != vars.end(); ++i, ++entry) {
     auto varName = entry->first;
-    auto var = entry->second;
-    auto val = args[i];
+    auto *var = entry->second;
+    auto *val = args[i];
 
     auto sort = std::dynamic_pointer_cast<KORECompositeSort>(var->getSort());
 

--- a/lib/codegen/Util.cpp
+++ b/lib/codegen/Util.cpp
@@ -16,7 +16,7 @@ namespace kllvm {
 
 llvm::Function *koreHeapAlloc(std::string const &name, llvm::Module *module) {
   llvm::Type *size_type = llvm::Type::getInt64Ty(module->getContext());
-  auto allocType = llvm::FunctionType::get(
+  auto *allocType = llvm::FunctionType::get(
       llvm::Type::getInt8PtrTy(module->getContext()),
       llvm::ArrayRef<llvm::Type *>(size_type), false);
   return getOrInsertFunction(module, name, allocType);

--- a/lib/parser/KOREParser.cpp
+++ b/lib/parser/KOREParser.cpp
@@ -64,8 +64,9 @@ std::string KOREParser::consume(token next) {
     data = buffer.data;
     buffer.tok = token::EMPTY;
   }
-  if (actual == next)
+  if (actual == next) {
     return data;
+  }
   error(loc, "Expected: " + str(next) + " Actual: " + str(actual));
 }
 
@@ -414,8 +415,9 @@ KOREParser::_applicationPattern(std::string const &name) {
 }
 
 void KOREParser::patterns(KORECompositePattern *node) {
-  if (peek() == token::RIGHTPAREN)
+  if (peek() == token::RIGHTPAREN) {
     return;
+  }
   patternsNE(node);
 }
 
@@ -430,8 +432,9 @@ void KOREParser::patternsNE(KORECompositePattern *node) {
 }
 
 void KOREParser::patterns(std::vector<sptr<KOREPattern>> &node) {
-  if (peek() == token::RIGHTPAREN)
+  if (peek() == token::RIGHTPAREN) {
     return;
+  }
   patternsNE(node);
 }
 

--- a/lib/parser/KOREParser.cpp
+++ b/lib/parser/KOREParser.cpp
@@ -307,9 +307,8 @@ sptr<KORESort> KOREParser::sort() {
     sorts(sort.get());
     consume(token::RIGHTBRACE);
     return sort;
-  } else {
-    return KORESortVariable::Create(name);
   }
+  return KORESortVariable::Create(name);
 }
 
 sptr<KOREPattern> KOREParser::_pattern() {
@@ -364,17 +363,16 @@ sptr<KOREPattern> KOREParser::applicationPattern(std::string const &name) {
         accum = newAccum;
       }
       return accum;
-    } else {
-      sptr<KOREPattern> accum = pats[pats.size() - 1];
-      for (int i = pats.size() - 2; i >= 0; i--) {
-        sptr<KORECompositePattern> newAccum
-            = KORECompositePattern::Create(pat->getConstructor());
-        newAccum->addArgument(pats[i]);
-        newAccum->addArgument(accum);
-        accum = newAccum;
-      }
-      return accum;
     }
+    sptr<KOREPattern> accum = pats[pats.size() - 1];
+    for (int i = pats.size() - 2; i >= 0; i--) {
+      sptr<KORECompositePattern> newAccum
+          = KORECompositePattern::Create(pat->getConstructor());
+      newAccum->addArgument(pats[i]);
+      newAccum->addArgument(accum);
+      accum = newAccum;
+    }
+    return accum;
   }
   auto result = _applicationPattern(name);
   if (name == "\\or") {
@@ -384,7 +382,8 @@ sptr<KOREPattern> KOREParser::applicationPattern(std::string const &name) {
           result->getConstructor()->getFormalArguments()[0]);
       pat->getConstructor()->initPatternArguments();
       return pat;
-    } else if (result->getArguments().size() == 1) {
+    }
+    if (result->getArguments().size() == 1) {
       return result->getArguments()[0];
     }
   } else if (name == "\\and") {
@@ -394,7 +393,8 @@ sptr<KOREPattern> KOREParser::applicationPattern(std::string const &name) {
           result->getConstructor()->getFormalArguments()[0]);
       pat->getConstructor()->initPatternArguments();
       return pat;
-    } else if (result->getArguments().size() == 1) {
+    }
+    if (result->getArguments().size() == 1) {
       return result->getArguments()[0];
     }
   }

--- a/lib/parser/KOREParser.cpp
+++ b/lib/parser/KOREParser.cpp
@@ -378,7 +378,7 @@ sptr<KOREPattern> KOREParser::applicationPattern(std::string const &name) {
   }
   auto result = _applicationPattern(name);
   if (name == "\\or") {
-    if (result->getArguments().size() == 0) {
+    if (result->getArguments().empty()) {
       auto pat = KORECompositePattern::Create("\\bottom");
       pat->getConstructor()->addArgument(
           result->getConstructor()->getFormalArguments()[0]);
@@ -388,7 +388,7 @@ sptr<KOREPattern> KOREParser::applicationPattern(std::string const &name) {
       return result->getArguments()[0];
     }
   } else if (name == "\\and") {
-    if (result->getArguments().size() == 0) {
+    if (result->getArguments().empty()) {
       auto pat = KORECompositePattern::Create("\\top");
       pat->getConstructor()->addArgument(
           result->getConstructor()->getFormalArguments()[0]);

--- a/lib/parser/KOREParser.cpp
+++ b/lib/parser/KOREParser.cpp
@@ -356,7 +356,7 @@ sptr<KOREPattern> KOREParser::applicationPattern(std::string const &name) {
     consume(token::RIGHTPAREN);
     if (name == "\\left-assoc") {
       sptr<KOREPattern> accum = pats[0];
-      for (auto i = 1u; i < pats.size(); i++) {
+      for (auto i = 1U; i < pats.size(); i++) {
         sptr<KORECompositePattern> newAccum
             = KORECompositePattern::Create(pat->getConstructor());
         newAccum->addArgument(accum);

--- a/lib/printer/addBrackets.cpp
+++ b/lib/printer/addBrackets.cpp
@@ -355,8 +355,8 @@ bool requiresBracketWithSimpleAlgorithm(
     KORECompositePattern *outer, KORECompositePattern *leftCapture,
     KORECompositePattern *rightCapture, KOREPattern *inner, int position,
     PrettyPrintData const &data) {
-  if (auto *innerComposite = dynamic_cast<KORECompositePattern *>(inner)) {
-    std::string innerName = innerComposite->getConstructor()->getName();
+  if (auto *composite = dynamic_cast<KORECompositePattern *>(inner)) {
+    std::string innerName = composite->getConstructor()->getName();
     if (innerName == outer->getConstructor()->getName()) {
       if (data.assoc.count(innerName)) {
         return false;
@@ -369,32 +369,34 @@ bool requiresBracketWithSimpleAlgorithm(
     if (fixity == EMPTY) {
       return false;
     }
-    bool priority = isPriorityWrong(outer, innerComposite, position, data);
+    bool priority = isPriorityWrong(outer, composite, position, data);
     if (priority) {
       return true;
     }
     if (data.terminals.at(innerName) == "0") {
       return false;
     }
-    Fixity innerFixity = getFixity(innerComposite->getConstructor(), data);
+
+    Fixity innerFixity = getFixity(composite->getConstructor(), data);
+
     if ((innerFixity & BARE_RIGHT) && rightCapture != nullptr) {
       bool inversePriority = isPriorityWrong(
-          innerComposite, rightCapture,
-          innerComposite->getArguments().size() - 1, data);
+          composite, rightCapture, composite->getArguments().size() - 1, data);
       Fixity rightCaptureFixity
           = getFixity(rightCapture->getConstructor(), data);
       if (!inversePriority && (rightCaptureFixity & BARE_LEFT)) {
         return true;
       }
     }
+
     if ((innerFixity & BARE_LEFT) && leftCapture != nullptr) {
-      bool inversePriority
-          = isPriorityWrong(innerComposite, leftCapture, 0, data);
+      bool inversePriority = isPriorityWrong(composite, leftCapture, 0, data);
       Fixity leftCaptureFixity = getFixity(leftCapture->getConstructor(), data);
       if (!inversePriority && (leftCaptureFixity & BARE_RIGHT)) {
         return true;
       }
     }
+
     return false;
   }
   return false;

--- a/lib/printer/addBrackets.cpp
+++ b/lib/printer/addBrackets.cpp
@@ -139,9 +139,9 @@ KORECompositePattern *getLeftCapture(
   Fixity fixity = getFixity(outer->getConstructor(), data);
   if (position == 0 && (fixity & BARE_LEFT)) {
     return previousLeftCapture;
-  } else {
-    return outer;
   }
+
+  return outer;
 }
 
 /**
@@ -173,9 +173,9 @@ KORECompositePattern *getRightCapture(
   Fixity fixity = getFixity(outer->getConstructor(), data);
   if (position == outer->getArguments().size() - 1 && (fixity & BARE_RIGHT)) {
     return previousRightCapture;
-  } else {
-    return outer;
   }
+
+  return outer;
 }
 
 /**
@@ -199,8 +199,9 @@ sptr<KORESort>
 getArgSort(KORESymbol *symbol, int position, sptr<KORESort> firstArgSort) {
   if (!symbol->isBuiltin()) {
     return symbol->getArguments()[position];
-  } else if (
-      symbol->getName() == "\\and" || symbol->getName() == "\\not"
+  }
+
+  if (symbol->getName() == "\\and" || symbol->getName() == "\\not"
       || symbol->getName() == "\\or" || symbol->getName() == "\\implies"
       || symbol->getName() == "\\iff" || symbol->getName() == "\\ceil"
       || symbol->getName() == "\\floor" || symbol->getName() == "\\equals"
@@ -210,20 +211,23 @@ getArgSort(KORESymbol *symbol, int position, sptr<KORESort> firstArgSort) {
       || symbol->getName() == "weakExistsFinally"
       || symbol->getName() == "allPathGlobally") {
     return symbol->getFormalArguments()[0];
-  } else if (
-      symbol->getName() == "\\forall" || symbol->getName() == "\\exists") {
+  }
+
+  if (symbol->getName() == "\\forall" || symbol->getName() == "\\exists") {
     if (position == 0) {
       assert(firstArgSort != nullptr);
       return firstArgSort;
-    } else {
-      return symbol->getFormalArguments()[0];
     }
-  } else if (symbol->getName() == "\\mu" || symbol->getName() == "\\nu") {
+
+    return symbol->getFormalArguments()[0];
+  }
+
+  if (symbol->getName() == "\\mu" || symbol->getName() == "\\nu") {
     assert(firstArgSort != nullptr);
     return firstArgSort;
-  } else {
-    abort();
   }
+
+  abort();
 }
 
 sptr<KORESort> getReturnSort(KOREPattern *pat) {
@@ -231,8 +235,8 @@ sptr<KORESort> getReturnSort(KOREPattern *pat) {
     auto *symbol = composite->getConstructor();
     if (!symbol->isBuiltin()) {
       return pat->getSort();
-    } else if (
-        symbol->getName() == "\\top" || symbol->getName() == "\\bottom"
+    }
+    if (symbol->getName() == "\\top" || symbol->getName() == "\\bottom"
         || symbol->getName() == "\\and" || symbol->getName() == "\\not"
         || symbol->getName() == "\\or" || symbol->getName() == "\\implies"
         || symbol->getName() == "\\iff" || symbol->getName() == "\\exists"
@@ -242,15 +246,16 @@ sptr<KORESort> getReturnSort(KOREPattern *pat) {
         || symbol->getName() == "weakExistsFinally"
         || symbol->getName() == "allPathGlobally") {
       return symbol->getFormalArguments()[0];
-    } else if (
-        symbol->getName() == "\\ceil" || symbol->getName() == "\\floor"
+    }
+    if (symbol->getName() == "\\ceil" || symbol->getName() == "\\floor"
         || symbol->getName() == "\\equals" || symbol->getName() == "\\in") {
       return symbol->getFormalArguments()[1];
-    } else if (symbol->getName() == "\\mu" || symbol->getName() == "\\nu") {
-      return composite->getArguments()[0]->getSort();
-    } else {
-      abort();
     }
+    if (symbol->getName() == "\\mu" || symbol->getName() == "\\nu") {
+      return composite->getArguments()[0]->getSort();
+    }
+    abort();
+
   } else {
     return pat->getSort();
   }
@@ -390,9 +395,8 @@ bool requiresBracketWithSimpleAlgorithm(
       }
     }
     return false;
-  } else {
-    return false;
   }
+  return false;
 }
 
 sptr<KOREPattern> addBrackets(
@@ -458,9 +462,8 @@ sptr<KOREPattern> addBrackets(
       position++;
     }
     return result;
-  } else {
-    return t;
   }
+  return t;
 }
 
 sptr<KOREPattern>

--- a/lib/printer/addBrackets.cpp
+++ b/lib/printer/addBrackets.cpp
@@ -350,6 +350,7 @@ bool isPriorityWrong(
  * The terms `(1 ++) 1` and `1 (++ 1)` will not have brackets inserted
  * into them by this algorithm, even though they are required.
  */
+// NOLINTNEXTLINE(*-cognitive-complexity)
 bool requiresBracketWithSimpleAlgorithm(
     KORECompositePattern *outer, KORECompositePattern *leftCapture,
     KORECompositePattern *rightCapture, KOREPattern *inner, int position,

--- a/lib/printer/addBrackets.cpp
+++ b/lib/printer/addBrackets.cpp
@@ -227,8 +227,8 @@ getArgSort(KORESymbol *symbol, int position, sptr<KORESort> firstArgSort) {
 }
 
 sptr<KORESort> getReturnSort(KOREPattern *pat) {
-  if (auto composite = dynamic_cast<KORECompositePattern *>(pat)) {
-    auto symbol = composite->getConstructor();
+  if (auto *composite = dynamic_cast<KORECompositePattern *>(pat)) {
+    auto *symbol = composite->getConstructor();
     if (!symbol->isBuiltin()) {
       return pat->getSort();
     } else if (
@@ -349,7 +349,7 @@ bool requiresBracketWithSimpleAlgorithm(
     KORECompositePattern *outer, KORECompositePattern *leftCapture,
     KORECompositePattern *rightCapture, KOREPattern *inner, int position,
     PrettyPrintData const &data) {
-  if (auto innerComposite = dynamic_cast<KORECompositePattern *>(inner)) {
+  if (auto *innerComposite = dynamic_cast<KORECompositePattern *>(inner)) {
     std::string innerName = innerComposite->getConstructor()->getName();
     if (innerName == outer->getConstructor()->getName()) {
       if (data.assoc.count(innerName)) {
@@ -399,7 +399,8 @@ sptr<KOREPattern> addBrackets(
     sptr<KOREPattern> inner, KORECompositePattern *outer,
     KORECompositePattern *leftCapture, KORECompositePattern *rightCapture,
     int position, PrettyPrintData const &data) {
-  if (auto innerComposite = dynamic_cast<KORECompositePattern *>(inner.get())) {
+  if (auto *innerComposite
+      = dynamic_cast<KORECompositePattern *>(inner.get())) {
     if (innerComposite->getConstructor()->getName() == "inj") {
       return addBrackets(
           innerComposite->getArguments()[0], outer, leftCapture, rightCapture,
@@ -411,7 +412,7 @@ sptr<KOREPattern> addBrackets(
     sptr<KORESort> outerSort = getArgSort(
         outer->getConstructor(), position, outer->getArguments()[0]->getSort());
     sptr<KORESort> innerSort = getReturnSort(inner.get());
-    for (auto &entry : data.brackets) {
+    for (const auto &entry : data.brackets) {
       bool isCorrectOuterSort = lessThanEq(data, entry.first, outerSort.get());
       if (isCorrectOuterSort) {
         for (KORESymbol *s : entry.second) {
@@ -436,7 +437,7 @@ sptr<KOREPattern> addBrackets(
 sptr<KOREPattern> addBrackets(
     sptr<KOREPattern> t, KORECompositePattern *previousLeftCapture,
     KORECompositePattern *previousRightCapture, PrettyPrintData const &data) {
-  if (auto outer = dynamic_cast<KORECompositePattern *>(t.get())) {
+  if (auto *outer = dynamic_cast<KORECompositePattern *>(t.get())) {
     if (outer->getConstructor()->getName() == "\\dv") {
       return t;
     }
@@ -445,7 +446,7 @@ sptr<KOREPattern> addBrackets(
     sptr<KORECompositePattern> result
         = KORECompositePattern::Create(outer->getConstructor());
     int position = 0;
-    for (auto &inner : outer->getArguments()) {
+    for (const auto &inner : outer->getArguments()) {
       KORECompositePattern *leftCapture
           = getLeftCapture(previousLeftCapture, outer, position, data);
       KORECompositePattern *rightCapture

--- a/lib/printer/printer.cpp
+++ b/lib/printer/printer.cpp
@@ -255,7 +255,7 @@ PreprocessedPrintData getPrintData(
   SubsortMap subsorts;
   SymbolMap overloads;
 
-  for (auto &entry : def->getSymbolDeclarations()) {
+  for (const auto &entry : def->getSymbolDeclarations()) {
     std::string name = entry.first;
 
     if (entry.second->getAttributes().count("format")) {
@@ -297,14 +297,14 @@ PreprocessedPrintData getPrintData(
     }
   }
 
-  for (auto &entry : def->getSortDeclarations()) {
+  for (const auto &entry : def->getSortDeclarations()) {
     std::string name = entry.first;
     if (entry.second->getAttributes().count("hook")) {
       hooks[name] = entry.second->getStringAttribute("hook");
     }
   }
 
-  for (auto axiom : def->getAxioms()) {
+  for (auto *axiom : def->getAxioms()) {
     if (axiom->getAttributes().count("subsort")) {
       KORECompositePattern *att = axiom->getAttributes().at("subsort").get();
       KORESort *innerSort
@@ -362,14 +362,14 @@ std::ostream &printKORE(
   std::map<std::string, std::vector<KORESymbol *>> symbols;
   config->markSymbols(symbols);
 
-  for (auto &decl : axioms) {
-    auto axiom = dynamic_cast<KOREAxiomDeclaration *>(decl.get());
+  for (const auto &decl : axioms) {
+    auto *axiom = dynamic_cast<KOREAxiomDeclaration *>(decl.get());
     axiom->getPattern()->markSymbols(symbols);
   }
 
   for (auto &entry : symbols) {
-    for (auto symbol : entry.second) {
-      auto decl = def->getSymbolDeclarations().at(symbol->getName());
+    for (auto *symbol : entry.second) {
+      auto *decl = def->getSymbolDeclarations().at(symbol->getName());
       symbol->instantiateSymbol(decl);
     }
   }

--- a/lib/printer/printer.cpp
+++ b/lib/printer/printer.cpp
@@ -278,10 +278,10 @@ PreprocessedPrintData getPrintData(
           if (pos == std::string::npos) {
             color.push_back(trim(colorAtt.substr(idx)));
             break;
-          } else {
-            color.push_back(trim(colorAtt.substr(idx, pos - idx)));
-            idx = pos + 1;
           }
+          color.push_back(trim(colorAtt.substr(idx, pos - idx)));
+          idx = pos + 1;
+
         } while (true);
         colors[name] = color;
       }

--- a/lib/printer/printer.cpp
+++ b/lib/printer/printer.cpp
@@ -236,6 +236,7 @@ struct PreprocessedPrintData {
   SymbolMap overloads;
 };
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 PreprocessedPrintData getPrintData(
     ptr<KOREDefinition> const &def,
     std::vector<ptr<KOREDeclaration>> const &axioms, bool hasColor) {

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -93,20 +93,22 @@ __attribute__((always_inline)) void *koreAllocAlwaysGC(size_t requested) {
 void *koreResizeLastAlloc(void *oldptr, size_t newrequest, size_t last_size) {
   newrequest = (newrequest + 7) & ~7;
   last_size = (last_size + 7) & ~7;
+
   if (oldptr != *arenaEndPtr(&youngspace) - last_size) {
     MEM_LOG(
         "May only reallocate last allocation. Tried to reallocate %p to %zd\n",
         oldptr, newrequest);
     exit(255);
   }
+
   ssize_t increase = newrequest - last_size;
   if (arenaResizeLastAlloc(&youngspace, increase)) {
     return oldptr;
-  } else {
-    void *newptr = koreAlloc(newrequest);
-    memcpy(newptr, oldptr, last_size);
-    return newptr;
   }
+
+  void *newptr = koreAlloc(newrequest);
+  memcpy(newptr, oldptr, last_size);
+  return newptr;
 }
 
 void *koreAllocMP(size_t requested) {

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -118,15 +118,14 @@ doAllocSlow(size_t requested, struct arena *Arena) {
       Arena->block_end - Arena->block, requested);
   if (requested > BLOCK_SIZE - sizeof(memory_block_header)) {
     return malloc(requested);
-  } else {
-    freshBlock(Arena);
-    void *result = Arena->block;
-    Arena->block += requested;
-    MEM_LOG(
-        "Allocation at %p (size %zd), next alloc at %p (if it fits)\n", result,
-        requested, Arena->block);
-    return result;
   }
+  freshBlock(Arena);
+  void *result = Arena->block;
+  Arena->block += requested;
+  MEM_LOG(
+      "Allocation at %p (size %zd), next alloc at %p (if it fits)\n", result,
+      requested, Arena->block);
+  return result;
 }
 
 __attribute__((always_inline)) void *
@@ -213,16 +212,14 @@ ssize_t ptrDiff(char *ptr1, char *ptr2) {
   if (hdr == mem_block_header(ptr1)) {
     result += ptr1 - (char *)(hdr + 1);
     return result;
-  } else {
-    // reached the end of the arena and didn't find the block
-    // it's possible that the result should be negative, in which
-    // case the block will have been prior to the block we started
-    // at. To handle this, we recurse with reversed arguments and
-    // negate the result. This means that the code might not
-    // terminate if the two pointers do not belong to the same
-    // arena.
-    return -ptrDiff(ptr2, ptr1);
-  }
+  } // reached the end of the arena and didn't find the block
+  // it's possible that the result should be negative, in which
+  // case the block will have been prior to the block we started
+  // at. To handle this, we recurse with reversed arguments and
+  // negate the result. This means that the code might not
+  // terminate if the two pointers do not belong to the same
+  // arena.
+  return -ptrDiff(ptr2, ptr1);
 }
 
 size_t arenaSize(const struct arena *Arena) {

--- a/runtime/arithmetic/float.cpp
+++ b/runtime/arithmetic/float.cpp
@@ -54,7 +54,7 @@ static void mpfr_leave(int t, floating *result) {
 extern "C" {
 
 floating *move_float(floating *);
-mpz_ptr move_int(mpz_t);
+
 void add_hash64(void *, uint64_t);
 void *move_mint(mpz_t, uint64_t) {
   KLLVM_HOOK_INVALID_ARGUMENT("not yet implemented");

--- a/runtime/arithmetic/int.cpp
+++ b/runtime/arithmetic/int.cpp
@@ -7,7 +7,6 @@
 
 extern "C" {
 
-
 void add_hash64(void *, uint64_t);
 
 SortInt hook_INT_tmod(SortInt a, SortInt b) {
@@ -434,13 +433,15 @@ mpz_ptr hook_MINT_import(size_t *i, uint64_t bits, bool isSigned) {
   mpz_t twos;
   mpz_init(twos);
   mpz_init(result);
+
   uint64_t nwords = (bits + 63) / 64;
   mpz_import(twos, nwords, -1, sizeof(size_t), 0, 0, i);
+
   if (isSigned) {
     signed_extract(result, twos, 0, bits);
     return move_int(result);
-  } else {
-    return move_int(twos);
   }
+
+  return move_int(twos);
 }
 }

--- a/runtime/arithmetic/int.cpp
+++ b/runtime/arithmetic/int.cpp
@@ -7,7 +7,7 @@
 
 extern "C" {
 
-mpz_ptr move_int(mpz_t);
+
 void add_hash64(void *, uint64_t);
 
 SortInt hook_INT_tmod(SortInt a, SortInt b) {

--- a/runtime/arithmetic/int.cpp
+++ b/runtime/arithmetic/int.cpp
@@ -321,7 +321,8 @@ void signed_extract(mpz_t result, mpz_t i, size_t off, size_t len) {
     return;
   }
   if (mpz_tstbit(i, off + len - 1)) {
-    mpz_t max, tmp;
+    mpz_t max;
+    mpz_t tmp;
     mpz_init(max);
     mpz_init(tmp);
     mpz_set_ui(max, 1);
@@ -429,7 +430,8 @@ size_t *hook_MINT_export(mpz_t in, uint64_t bits) {
 }
 
 mpz_ptr hook_MINT_import(size_t *i, uint64_t bits, bool isSigned) {
-  mpz_t result, twos;
+  mpz_t result;
+  mpz_t twos;
   mpz_init(twos);
   mpz_init(result);
   uint64_t nwords = (bits + 63) / 64;

--- a/runtime/arithmetic/int.cpp
+++ b/runtime/arithmetic/int.cpp
@@ -405,12 +405,14 @@ size_t *hook_MINT_export(mpz_t in, uint64_t bits) {
   mpz_t twos;
   mpz_init(twos);
   extract(twos, in, 0, nwords * 64);
-  if (nwords == 0)
+  if (nwords == 0) {
     return nullptr;
+  }
   uint64_t numb = 8 * sizeof(size_t);
   uint64_t count = (mpz_sizeinbase(twos, 2) + numb - 1) / numb;
-  if (mpz_sgn(twos) == 0)
+  if (mpz_sgn(twos) == 0) {
     count = 0;
+  }
   uint64_t alloccount = nwords > count ? nwords : count;
   size_t allocsize = alloccount * sizeof(size_t);
   auto *allocptr = (size_t *)koreAllocAlwaysGC(allocsize);
@@ -419,8 +421,9 @@ size_t *hook_MINT_export(mpz_t in, uint64_t bits) {
   size_t actualcount;
   mpz_export(exportptr, &actualcount, 1, sizeof(size_t), 0, 0, twos);
   assert(count == actualcount);
-  if (count == 0)
+  if (count == 0) {
     return allocptr;
+  }
   size_t *resultptr = nwords > count ? allocptr : allocptr + count - nwords;
   return resultptr;
 }

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -37,9 +37,8 @@ size_t get_size(uint64_t hdr, uint16_t layout) {
   if (!layout) {
     size_t size = (len_hdr(hdr) + sizeof(blockheader) + 7) & ~7;
     return hdr == NOT_YOUNG_OBJECT_BIT ? 8 : size < 16 ? 16 : size;
-  } else {
-    return size_hdr(hdr);
   }
+  return size_hdr(hdr);
 }
 
 void migrate(block **blockPtr) {

--- a/runtime/collect/migrate_collection.cpp
+++ b/runtime/collect/migrate_collection.cpp
@@ -58,7 +58,7 @@ struct migrate_visitor : immer::detail::rbts::visitor_base<migrate_visitor> {
 };
 
 void migrate_list(void *l) {
-  auto &impl = ((list *)l)->impl();
+  const auto &impl = ((list *)l)->impl();
   migrate_collection_node((void **)&impl.root);
   migrate_collection_node((void **)&impl.tail);
   if (auto &relaxed = impl.root->impl.d.data.inner.relaxed) {
@@ -93,26 +93,26 @@ void migrate_champ_traversal(
 
 void migrate_map_leaf(
     std::pair<KElem, KElem> *start, std::pair<KElem, KElem> *end) {
-  for (auto it = start; it != end; ++it) {
+  for (auto *it = start; it != end; ++it) {
     migrate_once(&it->first.elem);
     migrate_once(&it->second.elem);
   }
 }
 
 void migrate_set_leaf(KElem *start, KElem *end) {
-  for (auto it = start; it != end; ++it) {
+  for (auto *it = start; it != end; ++it) {
     migrate_once(&it->elem);
   }
 }
 
 void migrate_set(void *s) {
-  auto &impl = ((set *)s)->impl();
+  const auto &impl = ((set *)s)->impl();
   migrate_collection_node((void **)&impl.root);
   migrate_champ_traversal(impl.root, 0, migrate_set_leaf);
 }
 
 void migrate_map(void *m) {
-  auto &impl = ((map *)m)->impl();
+  const auto &impl = ((map *)m)->impl();
   migrate_collection_node((void **)&impl.root);
   migrate_champ_traversal(impl.root, 0, migrate_map_leaf);
 }

--- a/runtime/collections/kelemle.cpp
+++ b/runtime/collections/kelemle.cpp
@@ -18,126 +18,123 @@ bool hook_KEQUAL_eq(block *arg1, block *arg2) {
     if (arg1lb) {
       // Both arg1 and arg2 are constants.
       return arg1intptr == arg2intptr;
-    } else {
+    } // Both arg1 and arg2 are blocks.
+    uint64_t arg1hdrcanon = arg1->h.hdr & HDR_MASK;
+    uint64_t arg2hdrcanon = arg2->h.hdr & HDR_MASK;
+    if (arg1hdrcanon == arg2hdrcanon) {
+      // Canonical headers of arg1 and arg2 are equal.
+      // Both arg1 and arg2 are either strings or symbols.
+      uint64_t arglayout = get_layout(arg1);
+      if (arglayout == 0) {
+        // Both arg1 and arg2 are strings.
+        return hook_STRING_eq((string *)arg1, (string *)arg2);
+      } // arglayout != 0
       // Both arg1 and arg2 are blocks.
-      uint64_t arg1hdrcanon = arg1->h.hdr & HDR_MASK;
-      uint64_t arg2hdrcanon = arg2->h.hdr & HDR_MASK;
-      if (arg1hdrcanon == arg2hdrcanon) {
-        // Canonical headers of arg1 and arg2 are equal.
-        // Both arg1 and arg2 are either strings or symbols.
-        uint64_t arglayout = get_layout(arg1);
-        if (arglayout == 0) {
-          // Both arg1 and arg2 are strings.
-          return hook_STRING_eq((string *)arg1, (string *)arg2);
-        } else { // arglayout != 0
-          // Both arg1 and arg2 are blocks.
-          auto arglayoutshort = (uint16_t)arglayout;
-          layout *layoutPtr = getLayoutData(arglayoutshort);
-          uint8_t length = layoutPtr->nargs;
-          for (uint8_t i = 0; i < length; i++) {
-            uint64_t offset = layoutPtr->args[i].offset;
-            uint64_t child1intptr = arg1intptr + offset;
-            uint64_t child2intptr = arg2intptr + offset;
-            uint16_t cat = layoutPtr->args[i].cat;
-            switch (cat) {
-            case MAP_LAYOUT: {
-              map *map1ptr = (map *)(child1intptr);
-              map *map2ptr = (map *)(child2intptr);
-              bool cmp = hook_MAP_eq(map1ptr, map2ptr);
-              if (!cmp) {
-                return false;
-              }
-              break;
-            }
-            case RANGEMAP_LAYOUT: {
-              auto *rangemap1ptr = (rangemap *)(child1intptr);
-              auto *rangemap2ptr = (rangemap *)(child2intptr);
-              bool cmp = hook_RANGEMAP_eq(rangemap1ptr, rangemap2ptr);
-              if (!cmp) {
-                return false;
-              }
-              break;
-            }
-            case LIST_LAYOUT: {
-              list *list1ptr = (list *)(child1intptr);
-              list *list2ptr = (list *)(child2intptr);
-              bool cmp = hook_LIST_eq(list1ptr, list2ptr);
-              if (!cmp) {
-                return false;
-              }
-              break;
-            }
-            case SET_LAYOUT: {
-              set *set1ptr = (set *)(child1intptr);
-              set *set2ptr = (set *)(child2intptr);
-              bool cmp = hook_SET_eq(set1ptr, set2ptr);
-              if (!cmp) {
-                return false;
-              }
-              break;
-            }
-            case INT_LAYOUT: {
-              auto *int1ptrptr = (mpz_ptr *)(child1intptr);
-              auto *int2ptrptr = (mpz_ptr *)(child2intptr);
-              bool cmp = hook_INT_eq(*int1ptrptr, *int2ptrptr);
-              if (!cmp) {
-                return false;
-              }
-              break;
-            }
-            case FLOAT_LAYOUT: {
-              auto **float1ptrptr = (floating **)(child1intptr);
-              auto **float2ptrptr = (floating **)(child2intptr);
-              bool cmp = hook_FLOAT_trueeq(*float1ptrptr, *float2ptrptr);
-              if (!cmp) {
-                return false;
-              }
-              break;
-            }
-            case STRINGBUFFER_LAYOUT: {
-              abort();
-            }
-            case BOOL_LAYOUT: {
-              bool *bool1ptr = (bool *)(child1intptr);
-              bool *bool2ptr = (bool *)(child2intptr);
-              bool cmp = *bool1ptr == *bool2ptr;
-              if (!cmp) {
-                return false;
-              }
-              break;
-            }
-            case SYMBOL_LAYOUT: {
-              auto **child1ptrptr = (block **)(child1intptr);
-              auto **child2ptrptr = (block **)(child2intptr);
-              bool cmp = hook_KEQUAL_eq(*child1ptrptr, *child2ptrptr);
-              if (!cmp) {
-                return false;
-              }
-              break;
-            }
-            case VARIABLE_LAYOUT: {
-              auto **var1ptrptr = (block **)(child1intptr);
-              auto **var2ptrptr = (block **)(child2intptr);
-              bool cmp = hook_STRING_eq(
-                  (string *)*var1ptrptr, (string *)*var2ptrptr);
-              if (!cmp) {
-                return false;
-              }
-              break;
-            }
-            default: abort();
-            }
+      auto arglayoutshort = (uint16_t)arglayout;
+      layout *layoutPtr = getLayoutData(arglayoutshort);
+      uint8_t length = layoutPtr->nargs;
+      for (uint8_t i = 0; i < length; i++) {
+        uint64_t offset = layoutPtr->args[i].offset;
+        uint64_t child1intptr = arg1intptr + offset;
+        uint64_t child2intptr = arg2intptr + offset;
+        uint16_t cat = layoutPtr->args[i].cat;
+        switch (cat) {
+        case MAP_LAYOUT: {
+          map *map1ptr = (map *)(child1intptr);
+          map *map2ptr = (map *)(child2intptr);
+          bool cmp = hook_MAP_eq(map1ptr, map2ptr);
+          if (!cmp) {
+            return false;
           }
-          return true;
+          break;
         }
-      } else { // arg1hdrcanon != arg2hdrcanon
-        return false;
+        case RANGEMAP_LAYOUT: {
+          auto *rangemap1ptr = (rangemap *)(child1intptr);
+          auto *rangemap2ptr = (rangemap *)(child2intptr);
+          bool cmp = hook_RANGEMAP_eq(rangemap1ptr, rangemap2ptr);
+          if (!cmp) {
+            return false;
+          }
+          break;
+        }
+        case LIST_LAYOUT: {
+          list *list1ptr = (list *)(child1intptr);
+          list *list2ptr = (list *)(child2intptr);
+          bool cmp = hook_LIST_eq(list1ptr, list2ptr);
+          if (!cmp) {
+            return false;
+          }
+          break;
+        }
+        case SET_LAYOUT: {
+          set *set1ptr = (set *)(child1intptr);
+          set *set2ptr = (set *)(child2intptr);
+          bool cmp = hook_SET_eq(set1ptr, set2ptr);
+          if (!cmp) {
+            return false;
+          }
+          break;
+        }
+        case INT_LAYOUT: {
+          auto *int1ptrptr = (mpz_ptr *)(child1intptr);
+          auto *int2ptrptr = (mpz_ptr *)(child2intptr);
+          bool cmp = hook_INT_eq(*int1ptrptr, *int2ptrptr);
+          if (!cmp) {
+            return false;
+          }
+          break;
+        }
+        case FLOAT_LAYOUT: {
+          auto **float1ptrptr = (floating **)(child1intptr);
+          auto **float2ptrptr = (floating **)(child2intptr);
+          bool cmp = hook_FLOAT_trueeq(*float1ptrptr, *float2ptrptr);
+          if (!cmp) {
+            return false;
+          }
+          break;
+        }
+        case STRINGBUFFER_LAYOUT: {
+          abort();
+        }
+        case BOOL_LAYOUT: {
+          bool *bool1ptr = (bool *)(child1intptr);
+          bool *bool2ptr = (bool *)(child2intptr);
+          bool cmp = *bool1ptr == *bool2ptr;
+          if (!cmp) {
+            return false;
+          }
+          break;
+        }
+        case SYMBOL_LAYOUT: {
+          auto **child1ptrptr = (block **)(child1intptr);
+          auto **child2ptrptr = (block **)(child2intptr);
+          bool cmp = hook_KEQUAL_eq(*child1ptrptr, *child2ptrptr);
+          if (!cmp) {
+            return false;
+          }
+          break;
+        }
+        case VARIABLE_LAYOUT: {
+          auto **var1ptrptr = (block **)(child1intptr);
+          auto **var2ptrptr = (block **)(child2intptr);
+          bool cmp
+              = hook_STRING_eq((string *)*var1ptrptr, (string *)*var2ptrptr);
+          if (!cmp) {
+            return false;
+          }
+          break;
+        }
+        default: abort();
+        }
       }
-    }
-  } else { // arg1lb != arg2lb
-    // Between arg1 and arg2, one is a constant and one is a block.
+      return true;
+
+    } // arg1hdrcanon != arg2hdrcanon
     return false;
-  }
+
+  } // arg1lb != arg2lb
+  // Between arg1 and arg2, one is a constant and one is a block.
+  return false;
 }
 
 // We arbitrarily impose the following ordering betwene different types of
@@ -155,76 +152,73 @@ bool hook_KEQUAL_lt(block *arg1, block *arg2) {
   if (isconstant1 != isconstant2) {
     // Between arg1 and arg2, one is a constant and one is not.
     return isconstant1;
-  } else if (isconstant1) {
+  }
+  if (isconstant1) {
     // Both arg1 and arg2 are constants.
     return arg1intptr < arg2intptr;
-  } else {
-    // Both arg1 and arg2 are blocks.
-    uint16_t arg1layout = get_layout(arg1);
-    uint16_t arg2layout = get_layout(arg2);
-    if (arg1layout == 0 && arg2layout == 0) {
-      // Both arg1 and arg2 are strings.
-      return hook_STRING_lt((string *)arg1, (string *)arg2);
-    } else if (arg1layout == 0 || arg2layout == 0) {
-      // One of arg1, arg2 is a string, the other is a symbol.
-      return arg2layout == 0;
-    } else {
-      // Both arg1 and arg2 are symbols.
-      uint32_t arg1tag = tag(arg1);
-      uint32_t arg2tag = tag(arg2);
-      if (arg1tag != arg2tag) {
-        return arg1tag < arg2tag;
-      } else {
-        assert(arg1layout == arg2layout);
-        layout *layoutPtr = getLayoutData(arg1layout);
-        uint8_t length = layoutPtr->nargs;
-        for (uint8_t i = 0; i < length; i++) {
-          uint64_t offset = layoutPtr->args[i].offset;
-          uint16_t cat = layoutPtr->args[i].cat;
-          switch (cat) {
-          case MAP_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case RANGEMAP_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case LIST_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case SET_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case INT_LAYOUT: {
-            auto *int1ptrptr = (mpz_ptr *)(arg1intptr + offset);
-            auto *int2ptrptr = (mpz_ptr *)(arg2intptr + offset);
-            int cmp = mpz_cmp(*int1ptrptr, *int2ptrptr);
-            if (cmp != 0) {
-              return cmp < 0;
-            }
-            break;
-          }
-          case FLOAT_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case STRINGBUFFER_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case BOOL_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case SYMBOL_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          case VARIABLE_LAYOUT: {
-            abort(); // Implement when needed.
-          }
-          default: abort();
-          }
-        }
-        return false;
+  } // Both arg1 and arg2 are blocks.
+  uint16_t arg1layout = get_layout(arg1);
+  uint16_t arg2layout = get_layout(arg2);
+  if (arg1layout == 0 && arg2layout == 0) {
+    // Both arg1 and arg2 are strings.
+    return hook_STRING_lt((string *)arg1, (string *)arg2);
+  }
+  if (arg1layout == 0 || arg2layout == 0) {
+    // One of arg1, arg2 is a string, the other is a symbol.
+    return arg2layout == 0;
+  } // Both arg1 and arg2 are symbols.
+  uint32_t arg1tag = tag(arg1);
+  uint32_t arg2tag = tag(arg2);
+  if (arg1tag != arg2tag) {
+    return arg1tag < arg2tag;
+  }
+  assert(arg1layout == arg2layout);
+  layout *layoutPtr = getLayoutData(arg1layout);
+  uint8_t length = layoutPtr->nargs;
+  for (uint8_t i = 0; i < length; i++) {
+    uint64_t offset = layoutPtr->args[i].offset;
+    uint16_t cat = layoutPtr->args[i].cat;
+    switch (cat) {
+    case MAP_LAYOUT: {
+      abort(); // Implement when needed.
+    }
+    case RANGEMAP_LAYOUT: {
+      abort(); // Implement when needed.
+    }
+    case LIST_LAYOUT: {
+      abort(); // Implement when needed.
+    }
+    case SET_LAYOUT: {
+      abort(); // Implement when needed.
+    }
+    case INT_LAYOUT: {
+      auto *int1ptrptr = (mpz_ptr *)(arg1intptr + offset);
+      auto *int2ptrptr = (mpz_ptr *)(arg2intptr + offset);
+      int cmp = mpz_cmp(*int1ptrptr, *int2ptrptr);
+      if (cmp != 0) {
+        return cmp < 0;
       }
+      break;
+    }
+    case FLOAT_LAYOUT: {
+      abort(); // Implement when needed.
+    }
+    case STRINGBUFFER_LAYOUT: {
+      abort(); // Implement when needed.
+    }
+    case BOOL_LAYOUT: {
+      abort(); // Implement when needed.
+    }
+    case SYMBOL_LAYOUT: {
+      abort(); // Implement when needed.
+    }
+    case VARIABLE_LAYOUT: {
+      abort(); // Implement when needed.
+    }
+    default: abort();
     }
   }
+  return false;
 }
 
 bool hook_KEQUAL_ne(block *arg1, block *arg2) {

--- a/runtime/collections/kelemle.cpp
+++ b/runtime/collections/kelemle.cpp
@@ -9,6 +9,7 @@ bool hook_INT_eq(SortInt, SortInt);
 bool hook_FLOAT_trueeq(SortFloat, SortFloat);
 bool hook_STRING_lt(SortString, SortString);
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 bool hook_KEQUAL_eq(block *arg1, block *arg2) {
   auto arg1intptr = (uint64_t)arg1;
   auto arg2intptr = (uint64_t)arg2;

--- a/runtime/collections/lists.cpp
+++ b/runtime/collections/lists.cpp
@@ -20,9 +20,8 @@ list hook_LIST_concat(SortList l1, SortList l2) {
       tmp.push_back(*iter);
     }
     return tmp.persistent();
-  } else {
-    return (*l1) + (*l2);
   }
+  return (*l1) + (*l2);
 }
 
 bool hook_LIST_in(SortKItem value, SortList list) {
@@ -151,15 +150,14 @@ list hook_LIST_updateAll(SortList l1, SortInt index, SortList l2) {
     }
 
     return tmp.persistent();
-  } else {
-    auto tmp = l1->transient();
-    tmp.take(idx);
-    tmp.append(l2->transient());
-    auto tmp2 = l1->transient();
-    tmp2.drop(idx + size2);
-    tmp.append(tmp2);
-    return tmp.persistent();
   }
+  auto tmp = l1->transient();
+  tmp.take(idx);
+  tmp.append(l2->transient());
+  auto tmp2 = l1->transient();
+  tmp2.drop(idx + size2);
+  tmp.append(tmp2);
+  return tmp.persistent();
 }
 
 list hook_LIST_fill(SortList l, SortInt index, SortInt len, SortKItem val) {
@@ -192,16 +190,15 @@ list hook_LIST_fill(SortList l, SortInt index, SortInt len, SortKItem val) {
     }
 
     return tmp.persistent();
-  } else {
-    auto tmp = l->transient();
-    tmp.take(idx);
-    auto l2 = list{length, val}.transient();
-    tmp.append(l2);
-    auto tmp2 = l->transient();
-    tmp2.drop(idx + length);
-    tmp.append(tmp2);
-    return tmp.persistent();
   }
+  auto tmp = l->transient();
+  tmp.take(idx);
+  auto l2 = list{length, val}.transient();
+  tmp.append(l2);
+  auto tmp2 = l->transient();
+  tmp2.drop(idx + length);
+  tmp.append(tmp2);
+  return tmp.persistent();
 }
 
 bool hook_LIST_eq(SortList l1, SortList l2) {

--- a/runtime/collections/lists.cpp
+++ b/runtime/collections/lists.cpp
@@ -247,7 +247,7 @@ void printList(
   }
 
   auto tag = getTagForSymbolName(element);
-  auto arg_sorts = getArgumentSortsForTag(tag);
+  auto *arg_sorts = getArgumentSortsForTag(tag);
 
   sfprintf(file, "\\left-assoc{}(%s(", concat);
 

--- a/runtime/collections/maps.cpp
+++ b/runtime/collections/maps.cpp
@@ -23,7 +23,7 @@ map hook_MAP_unit() {
 }
 
 map hook_MAP_concat(SortMap m1, SortMap m2) {
-  auto from = m1->size() < m2->size() ? m1 : m2;
+  auto *from = m1->size() < m2->size() ? m1 : m2;
   auto to = m1->size() < m2->size() ? *m2 : *m1;
   for (auto iter = from->begin(); iter != from->end(); ++iter) {
     auto entry = *iter;
@@ -36,14 +36,14 @@ map hook_MAP_concat(SortMap m1, SortMap m2) {
 }
 
 SortKItem hook_MAP_lookup_null(SortMap m, SortKItem key) {
-  if (auto val = m->find(key)) {
+  if (const auto *val = m->find(key)) {
     return *val;
   }
   return nullptr;
 }
 
 SortKItem hook_MAP_lookup(SortMap m, SortKItem key) {
-  auto res = hook_MAP_lookup_null(m, key);
+  auto *res = hook_MAP_lookup_null(m, key);
   if (!res) {
     KLLVM_HOOK_INVALID_ARGUMENT("Key not found for map lookup");
   }
@@ -52,7 +52,7 @@ SortKItem hook_MAP_lookup(SortMap m, SortKItem key) {
 
 SortKItem
 hook_MAP_lookupOrDefault(SortMap m, SortKItem key, SortKItem _default) {
-  auto res = hook_MAP_lookup_null(m, key);
+  auto *res = hook_MAP_lookup_null(m, key);
   if (!res) {
     return _default;
   }
@@ -68,11 +68,11 @@ map hook_MAP_remove(SortMap m, SortKItem key) {
 }
 
 map hook_MAP_difference(SortMap m1, SortMap m2) {
-  auto from = m2;
+  auto *from = m2;
   auto to = *m1;
   for (auto iter = from->begin(); iter != from->end(); ++iter) {
     auto entry = *iter;
-    if (auto value = to.find(entry.first)) {
+    if (const auto *value = to.find(entry.first)) {
       if (*value == entry.second) {
         to = to.erase(entry.first);
       }
@@ -135,7 +135,7 @@ SortInt hook_MAP_size(SortMap m) {
 bool hook_MAP_inclusion(SortMap m1, SortMap m2) {
   for (auto iter = m1->begin(); iter != m1->end(); ++iter) {
     auto entry = *iter;
-    auto val = m2->find(entry.first);
+    const auto *val = m2->find(entry.first);
     if (!val || *val != entry.second) {
       return false;
     }
@@ -144,7 +144,7 @@ bool hook_MAP_inclusion(SortMap m1, SortMap m2) {
 }
 
 map hook_MAP_updateAll(SortMap m1, SortMap m2) {
-  auto from = m2;
+  auto *from = m2;
   auto to = *m1;
   for (auto iter = from->begin(); iter != from->end(); ++iter) {
     to = to.insert(*iter);
@@ -201,7 +201,7 @@ void printMap(
   }
 
   auto tag = getTagForSymbolName(element);
-  auto arg_sorts = getArgumentSortsForTag(tag);
+  auto *arg_sorts = getArgumentSortsForTag(tag);
 
   sfprintf(file, "\\left-assoc{}(%s(", concat);
 

--- a/runtime/collections/rangemaps.cpp
+++ b/runtime/collections/rangemaps.cpp
@@ -31,8 +31,8 @@ rangemap hook_RANGEMAP_unit() {
 }
 
 rangemap hook_RANGEMAP_concat(SortRangeMap m1, SortRangeMap m2) {
-  auto mfirst = m1->size() >= m2->size() ? m1 : m2;
-  auto msec = m1->size() >= m2->size() ? m2 : m1;
+  auto *mfirst = m1->size() >= m2->size() ? m1 : m2;
+  auto *msec = m1->size() >= m2->size() ? m2 : m1;
   return mfirst->concat(*msec);
 }
 
@@ -45,7 +45,7 @@ SortKItem hook_RANGEMAP_lookup_null(SortRangeMap m, SortKItem key) {
 }
 
 SortKItem hook_RANGEMAP_lookup(SortRangeMap m, SortKItem key) {
-  auto res = hook_RANGEMAP_lookup_null(m, key);
+  auto *res = hook_RANGEMAP_lookup_null(m, key);
   if (!res) {
     KLLVM_HOOK_INVALID_ARGUMENT("Key not found for range map lookup");
   }
@@ -54,7 +54,7 @@ SortKItem hook_RANGEMAP_lookup(SortRangeMap m, SortKItem key) {
 
 SortKItem hook_RANGEMAP_lookupOrDefault(
     SortRangeMap m, SortKItem key, SortKItem _default) {
-  auto res = hook_RANGEMAP_lookup_null(m, key);
+  auto *res = hook_RANGEMAP_lookup_null(m, key);
   if (!res) {
     return _default;
   }
@@ -196,7 +196,7 @@ bool hook_RANGEMAP_inclusion(SortRangeMap m1, SortRangeMap m2) {
 }
 
 rangemap hook_RANGEMAP_updateAll(SortRangeMap m1, SortRangeMap m2) {
-  auto from = m2;
+  auto *from = m2;
   auto to = *m1;
   for (auto iter = rng_map::ConstRangeMapIterator<KElem, KElem>(*from);
        iter.has_next(); ++iter) {
@@ -264,7 +264,7 @@ void printRangeMap(
   }
 
   auto tag = getTagForSymbolName(element);
-  auto arg_sorts = getArgumentSortsForTag(tag);
+  auto *arg_sorts = getArgumentSortsForTag(tag);
 
   sfprintf(file, "\\left-assoc{}(%s(", concat);
 

--- a/runtime/collections/rangemaps.cpp
+++ b/runtime/collections/rangemaps.cpp
@@ -225,10 +225,7 @@ bool hook_RANGEMAP_eq(SortRangeMap m1, SortRangeMap m2) {
       return false;
     }
   }
-  if (it1.has_next() || it2.has_next()) {
-    return false;
-  }
-  return true;
+  return !(it1.has_next() || it2.has_next());
 }
 
 void rangemap_hash(rangemap *m, void *hasher) {

--- a/runtime/collections/rangemaps.cpp
+++ b/runtime/collections/rangemaps.cpp
@@ -69,9 +69,8 @@ SortRange hook_RANGEMAP_find_range(SortRangeMap m, SortKItem key) {
     ptr->start = val.value().first.start();
     ptr->end = val.value().first.end();
     return (SortRange)ptr;
-  } else {
-    KLLVM_HOOK_INVALID_ARGUMENT("Key not found for range map lookup");
   }
+  KLLVM_HOOK_INVALID_ARGUMENT("Key not found for range map lookup");
 }
 
 rangemap hook_RANGEMAP_update(

--- a/runtime/collections/sets.cpp
+++ b/runtime/collections/sets.cpp
@@ -27,7 +27,7 @@ bool hook_SET_in(SortKItem elem, SortSet set) {
 }
 
 set hook_SET_concat(SortSet s1, SortSet s2) {
-  auto from = s1->size() < s2->size() ? s1 : s2;
+  auto *from = s1->size() < s2->size() ? s1 : s2;
   auto to = s1->size() < s2->size() ? *s2 : *s1;
   for (auto iter = from->begin(); iter != from->end(); ++iter) {
     to = to.insert(*iter);
@@ -41,7 +41,7 @@ set hook_SET_union(SortSet s1, SortSet s2) {
 }
 
 set hook_SET_difference(SortSet s1, SortSet s2) {
-  auto from = s2;
+  auto *from = s2;
   auto to = *s1;
   for (auto iter = from->begin(); iter != from->end(); ++iter) {
     to = to.erase(*iter);
@@ -63,8 +63,8 @@ bool hook_SET_inclusion(SortSet s1, SortSet s2) {
 }
 
 set hook_SET_intersection(SortSet s1, SortSet s2) {
-  auto from = s1->size() < s2->size() ? s1 : s2;
-  auto to = s1->size() < s2->size() ? s2 : s1;
+  auto *from = s1->size() < s2->size() ? s1 : s2;
+  auto *to = s1->size() < s2->size() ? s2 : s1;
   auto result = set();
   for (auto iter = from->begin(); iter != from->end(); ++iter) {
     auto elem = *iter;
@@ -147,7 +147,7 @@ void printSet(
   }
 
   auto tag = getTagForSymbolName(element);
-  auto arg_sorts = getArgumentSortsForTag(tag);
+  auto *arg_sorts = getArgumentSortsForTag(tag);
 
   sfprintf(file, "\\left-assoc{}(%s(", concat);
 

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -26,7 +26,6 @@ extern "C" {
 
 extern char kompiled_directory;
 
-
 char *getTerminatedString(string *str);
 
 static block *dotK = leaf_block(getTagForSymbolName("dotk{}"));
@@ -297,14 +296,16 @@ SortIOInt hook_IO_getc(SortInt i) {
   char c;
   ssize_t ret = read(fd, &c, sizeof(char));
 
-  if (0 == ret) {
+  if (ret == 0) {
     block *p = leaf_block(getTagForSymbolName(GETTAG(EOF)));
     auto *retBlock
         = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
     retBlock->h = header_err();
     memcpy(retBlock->children, &p, sizeof(block *));
     return retBlock;
-  } else if (-1 == ret) {
+  }
+
+  if (ret == -1) {
     return getInjErrorBlock();
   }
 
@@ -711,7 +712,9 @@ SortKItem hook_IO_system(SortString cmd) {
       int nread = read(out[0], buf, IOBUFSIZE);
       if (nread == -1) {
         return getKSeqErrorBlock();
-      } else if (nread == 0) {
+      }
+
+      if (nread == 0) {
         FD_CLR(out[0], &read_fds);
         done++;
       } else {
@@ -722,7 +725,9 @@ SortKItem hook_IO_system(SortString cmd) {
       int nread = read(err[0], buf, IOBUFSIZE);
       if (nread == -1) {
         return getKSeqErrorBlock();
-      } else if (nread == 0) {
+      }
+
+      if (nread == 0) {
         FD_CLR(err[0], &read_fds);
         done++;
       } else {

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -661,6 +661,7 @@ SortIOFile hook_IO_mkstemp(SortString filename) {
   return retBlock;
 }
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 SortKItem hook_IO_system(SortString cmd) {
   pid_t pid;
   int ret = 0;

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -26,7 +26,7 @@ extern "C" {
 
 extern char kompiled_directory;
 
-mpz_ptr move_int(mpz_t);
+
 char *getTerminatedString(string *str);
 
 static block *dotK = leaf_block(getTagForSymbolName("dotk{}"));

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -541,7 +541,7 @@ void flush_IO_logs() {
       abort();
     }
     char *base = basename(path2);
-    std::string prefix = "";
+    std::string prefix;
     if (getenv("K_LOG_PREFIX")) {
       prefix = getenv("K_LOG_PREFIX");
     }

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -662,7 +662,9 @@ SortIOFile hook_IO_mkstemp(SortString filename) {
 
 SortKItem hook_IO_system(SortString cmd) {
   pid_t pid;
-  int ret = 0, out[2], err[2];
+  int ret = 0;
+  int out[2];
+  int err[2];
   stringbuffer *outBuffer = hook_BUFFER_empty();
   stringbuffer *errBuffer = hook_BUFFER_empty();
   char buf[IOBUFSIZE];
@@ -692,7 +694,8 @@ SortKItem hook_IO_system(SortString cmd) {
   close(out[1]);
   close(err[1]);
 
-  fd_set read_fds, ready_fds;
+  fd_set read_fds;
+  fd_set ready_fds;
   FD_ZERO(&read_fds);
   FD_SET(out[0], &read_fds);
   FD_SET(err[0], &read_fds);
@@ -741,7 +744,8 @@ SortKItem hook_IO_system(SortString cmd) {
 
   retBlock->h = getBlockHeaderForSymbol(
       (uint64_t)getTagForSymbolName(GETTAG(systemResult)));
-  string *outStr, *errStr;
+  string *outStr;
+  string *errStr;
   outStr = hook_BUFFER_toString(outBuffer);
   errStr = hook_BUFFER_toString(errBuffer);
   memcpy(retBlock->children + 1, &outStr, sizeof(string *));

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -612,8 +612,9 @@ int llvm_backend_argc = 0;
 char const **llvm_backend_argv = nullptr;
 
 list hook_KREFLECTION_argv() {
-  if (!llvm_backend_argv)
+  if (!llvm_backend_argv) {
     KLLVM_HOOK_INVALID_ARGUMENT("KREFLECTION.argv: no arguments given");
+  }
 
   list l{};
 

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -327,7 +327,7 @@ SortIOString hook_IO_read(SortInt i, SortInt len) {
   int fd = mpz_get_si(i);
   size_t length = mpz_get_ui(len);
 
-  auto result = static_cast<string *>(koreAllocToken(sizeof(string) + length));
+  auto *result = static_cast<string *>(koreAllocToken(sizeof(string) + length));
   int bytes = read(fd, &(result->data), length);
 
   if (-1 == bytes) {
@@ -600,9 +600,9 @@ block *hook_KREFLECTION_fresh(string *str) {
 }
 
 string *hook_KREFLECTION_kompiledDir(void) {
-  auto str_ptr = &kompiled_directory;
+  auto *str_ptr = &kompiled_directory;
   auto len = strlen(str_ptr);
-  auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + len));
+  auto *ret = static_cast<string *>(koreAllocToken(sizeof(string) + len));
   memcpy(ret->data, str_ptr, len);
   init_with_len(ret, len);
   return ret;

--- a/runtime/io/logTerm.cpp
+++ b/runtime/io/logTerm.cpp
@@ -24,7 +24,7 @@ SortKItem hook_IO_logTerm(SortString path, SortKItem term) {
 
 SortK hook_IO_traceTerm(block *term) {
   auto temp_file = temporary_file("traceKORE_XXXXXX");
-  auto fp = temp_file.file_pointer("w");
+  auto *fp = temp_file.file_pointer("w");
 
   // Ensure that the term is injected into KItem correctly; if we don't do this
   // then the unparsed KORE ends up with a (null) in it which breaks the

--- a/runtime/json/json.cpp
+++ b/runtime/json/json.cpp
@@ -145,7 +145,7 @@ get_header(boolHdr, "inj{SortBool{}, SortJSON{}}")
     return true;
   }
 
-  bool StartObject() { return true; }
+  static bool StartObject() { return true; }
 
   bool Key(const char *str, SizeType len, bool copy) {
     return String(str, len, copy);
@@ -173,7 +173,7 @@ get_header(boolHdr, "inj{SortBool{}, SortJSON{}}")
     return true;
   }
 
-  bool StartArray() { return true; }
+  static bool StartArray() { return true; }
 
   bool EndArray(SizeType elementCount) {
     result = dotList();

--- a/runtime/json/json.cpp
+++ b/runtime/json/json.cpp
@@ -118,19 +118,18 @@ get_header(boolHdr, "inj{SortBool{}, SortJSON{}}")
       result = (block *)inj;
       stack.push_back(result);
       return true;
-    } else {
-      mpz_clear(z);
-      floating f[1]; // NOLINT(modernize-avoid-c-arrays)
-      mpfr_init2(f->f, 53);
-      f->exp = 11;
-      mpfr_set_str(f->f, str, 9, MPFR_RNDN);
-      auto *inj = (floatinj *)koreAlloc(sizeof(floatinj));
-      inj->h = floatHdr();
-      inj->data = move_float(f);
-      result = (block *)inj;
-      stack.push_back(result);
-      return true;
     }
+    mpz_clear(z);
+    floating f[1]; // NOLINT(modernize-avoid-c-arrays)
+    mpfr_init2(f->f, 53);
+    f->exp = 11;
+    mpfr_set_str(f->f, str, 9, MPFR_RNDN);
+    auto *inj = (floatinj *)koreAlloc(sizeof(floatinj));
+    inj->h = floatHdr();
+    inj->data = move_float(f);
+    result = (block *)inj;
+    stack.push_back(result);
+    return true;
   }
 
   bool String(const char *str, SizeType len, bool copy) {
@@ -272,8 +271,7 @@ SortJSON hook_JSON_string2json(SortString str) {
   bool result = reader.Parse<kParseNumbersAsStringsFlag>(s, handler);
   if (result) {
     return handler.stack.back();
-  } else {
-    abort();
   }
+  abort();
 }
 }

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -81,7 +81,7 @@ static void *so_lib_handle() {
   return handle;
 }
 
-// NOLINTBEGIN(*-else-after-return)
+// NOLINTBEGIN(*-else-after-return,*-cognitive-complexity)
 static ffi_type *getTypeFromBlock(block *elem) {
   if (is_leaf_block(elem)) {
     auto symbol = (uint64_t)elem;
@@ -172,8 +172,9 @@ static ffi_type *getTypeFromBlock(block *elem) {
 
   KLLVM_HOOK_INVALID_ARGUMENT("Arg is not a supported type");
 }
-// NOLINTEND(*-else-after-return)
+// NOLINTEND(*-else-after-return,*-cognitive-complexity)
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 string *ffiCall(
     bool isVariadic, mpz_t addr, list *args, list *fixtypes, list *vartypes,
     block *ret) {

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -16,8 +16,6 @@
 
 extern "C" {
 
-
-
 #define KCHAR char
 #define TYPETAG(type) "Lbl'Hash'ffi'Unds'" #type "{}"
 
@@ -64,7 +62,6 @@ TAG_TYPE(complexdouble)
 TAG_TYPE(complexlongdouble)
 #endif
 
-
 char *getTerminatedString(string *str);
 
 size_t hook_LIST_size_long(list *l);
@@ -84,6 +81,7 @@ static void *so_lib_handle() {
   return handle;
 }
 
+// NOLINTBEGIN(*-else-after-return)
 static ffi_type *getTypeFromBlock(block *elem) {
   if (is_leaf_block(elem)) {
     auto symbol = (uint64_t)elem;
@@ -174,6 +172,7 @@ static ffi_type *getTypeFromBlock(block *elem) {
 
   KLLVM_HOOK_INVALID_ARGUMENT("Arg is not a supported type");
 }
+// NOLINTEND(*-else-after-return)
 
 string *ffiCall(
     bool isVariadic, mpz_t addr, list *args, list *fixtypes, list *vartypes,

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -179,7 +179,8 @@ string *ffiCall(
     bool isVariadic, mpz_t addr, list *args, list *fixtypes, list *vartypes,
     block *ret) {
   ffi_cif cif;
-  ffi_type **argtypes, *rtype;
+  ffi_type **argtypes;
+  ffi_type *rtype;
   void (*address)();
 
   if (!mpz_fits_ulong_p(addr)) {

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -16,7 +16,7 @@
 
 extern "C" {
 
-bool hook_KEQUAL_eq(block *, block *);
+
 
 #define KCHAR char
 #define TYPETAG(type) "Lbl'Hash'ffi'Unds'" #type "{}"
@@ -64,7 +64,7 @@ TAG_TYPE(complexdouble)
 TAG_TYPE(complexlongdouble)
 #endif
 
-mpz_ptr move_int(mpz_t);
+
 char *getTerminatedString(string *str);
 
 size_t hook_LIST_size_long(list *l);

--- a/runtime/meta/substitution.cpp
+++ b/runtime/meta/substitution.cpp
@@ -99,9 +99,8 @@ block *debruijnizeInternal(block *currBlock) {
       idx--;
     }
     return newBlock;
-  } else {
-    return currBlock;
   }
+  return currBlock;
 }
 
 block *replaceBinderInternal(block *currBlock) {
@@ -109,13 +108,14 @@ block *replaceBinderInternal(block *currBlock) {
     uint64_t varIdx = ((uintptr_t)currBlock) >> 32;
     if (idx == varIdx) {
       return (block *)var;
-    } else if (idx < varIdx) {
+    }
+    if (idx < varIdx) {
       varIdx--;
       return variable_block(varIdx);
-    } else {
-      return currBlock;
     }
-  } else if (is_leaf_block(currBlock)) {
+    return currBlock;
+  }
+  if (is_leaf_block(currBlock)) {
     return currBlock;
   }
   const uint64_t hdr = currBlock->h.hdr;
@@ -174,9 +174,8 @@ block *replaceBinderInternal(block *currBlock) {
       idx--;
     }
     return newBlock;
-  } else {
-    return currBlock;
   }
+  return currBlock;
 }
 
 block *substituteInternal(block *currBlock) {
@@ -269,9 +268,8 @@ block *substituteInternal(block *currBlock) {
       return result;
     }
     return newBlock;
-  } else {
-    return currBlock;
   }
+  return currBlock;
 }
 
 extern "C" {
@@ -300,10 +298,10 @@ block *incrementDebruijn(block *currBlock) {
     if (varIdx >= idx2) {
       varIdx += idx;
       return variable_block(varIdx);
-    } else {
-      return currBlock;
     }
-  } else if (is_leaf_block(currBlock)) {
+    return currBlock;
+  }
+  if (is_leaf_block(currBlock)) {
     return currBlock;
   }
   const uint64_t hdr = currBlock->h.hdr;
@@ -367,9 +365,8 @@ block *incrementDebruijn(block *currBlock) {
       idx2--;
     }
     return newBlock;
-  } else {
-    return currBlock;
   }
+  return currBlock;
 }
 
 block *alphaRename(block *term) {

--- a/runtime/meta/substitution.cpp
+++ b/runtime/meta/substitution.cpp
@@ -12,7 +12,7 @@ static thread_local uint64_t idx;
 static thread_local uint64_t idx2;
 
 extern "C" {
-bool hook_KEQUAL_eq(block *, block *);
+
 map map_map(void *, block *(block *));
 rangemap rangemap_map(void *, block *(block *));
 list list_map(void *, block *(block *));

--- a/runtime/meta/substitution.cpp
+++ b/runtime/meta/substitution.cpp
@@ -261,7 +261,7 @@ block *substituteInternal(block *currBlock) {
       block *to_replace_stack = to_replace;
       block *replacement_stack = replacement;
       block *replacementInj_stack = replacementInj;
-      auto *result = (block *)evaluateFunctionSymbol(tag, &arguments[0]);
+      auto *result = (block *)evaluateFunctionSymbol(tag, arguments.data());
       to_replace = to_replace_stack;
       replacement = replacement_stack;
       replacementInj = replacementInj_stack;

--- a/runtime/meta/substitution.cpp
+++ b/runtime/meta/substitution.cpp
@@ -277,19 +277,19 @@ block *substituteInternal(block *currBlock) {
 extern "C" {
 
 block *debruijnize(block *term) {
-  auto layoutData = getLayoutData(get_layout(term));
+  auto *layoutData = getLayoutData(get_layout(term));
   auto layoutVar = layoutData->args[0];
   auto layoutBody = layoutData->args[layoutData->nargs - 1];
   var = *(string **)(((char *)term) + layoutVar.offset);
   idx = 0;
-  auto bodyPtr = *(block **)(((char *)term) + layoutBody.offset);
-  auto newBody = debruijnizeInternal(bodyPtr);
-  auto newBlock = term;
+  auto *bodyPtr = *(block **)(((char *)term) + layoutBody.offset);
+  auto *newBody = debruijnizeInternal(bodyPtr);
+  auto *newBlock = term;
   if (newBody != bodyPtr) {
     bool dirty = false;
     makeDirty(dirty, layoutBody.offset, newBody, newBlock);
   }
-  auto newVar = *(string **)(((char *)newBlock) + layoutVar.offset);
+  auto *newVar = *(string **)(((char *)newBlock) + layoutVar.offset);
   newVar->h.hdr |= VARIABLE_BIT;
   return newBlock;
 }
@@ -375,7 +375,7 @@ block *incrementDebruijn(block *currBlock) {
 block *alphaRename(block *term) {
   auto *var = (string *)term;
   size_t var_len = len(var);
-  auto newToken = (string *)koreAllocToken(sizeof(string) + var_len);
+  auto *newToken = (string *)koreAllocToken(sizeof(string) + var_len);
   memcpy(newToken->data, var->data, var_len);
   init_with_len(newToken, var_len);
   newToken->h.hdr |= VARIABLE_BIT;

--- a/runtime/meta/substitution.cpp
+++ b/runtime/meta/substitution.cpp
@@ -81,7 +81,7 @@ block *debruijnizeInternal(block *currBlock) {
         break;
       }
       case VARIABLE_LAYOUT: {
-        if (!(i == 0 && isBinder) && hook_STRING_eq(var, *(string **)arg)) {
+        if ((i != 0 || !isBinder) && hook_STRING_eq(var, *(string **)arg)) {
           block *newArg = variable_block(idx);
           makeDirty(dirty, argData->offset, newArg, newBlock);
         }

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -14,7 +14,7 @@ extern "C" {
 #define get_ui(x) get_ui_named(x, __func__)
 #define KCHAR char
 
-mpz_ptr move_int(mpz_t);
+
 
 SortBytes hook_BYTES_empty() {
   static string empty;
@@ -22,7 +22,7 @@ SortBytes hook_BYTES_empty() {
   return &empty;
 }
 
-uint32_t getTagForSymbolName(const char *);
+
 
 // bytes2int and int2bytes expect constructors of sort Endianness, which become
 // a uint64_t constant value in the K term representation

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -14,15 +14,11 @@ extern "C" {
 #define get_ui(x) get_ui_named(x, __func__)
 #define KCHAR char
 
-
-
 SortBytes hook_BYTES_empty() {
   static string empty;
   empty.h.hdr = NOT_YOUNG_OBJECT_BIT;
   return &empty;
 }
-
-
 
 // bytes2int and int2bytes expect constructors of sort Endianness, which become
 // a uint64_t constant value in the K term representation

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -138,7 +138,7 @@ SortBytes hook_BYTES_substr(SortBytes input, SortInt start, SortInt end) {
         uend, input_len);
   }
   uint64_t len = uend - ustart;
-  auto ret = static_cast<string *>(
+  auto *ret = static_cast<string *>(
       koreAllocToken(sizeof(string) + sizeof(KCHAR) * len));
   init_with_len(ret, len);
   memcpy(&(ret->data), &(input->data[ustart]), len * sizeof(KCHAR));
@@ -256,7 +256,7 @@ SortBytes hook_BYTES_concat(SortBytes a, SortBytes b) {
   auto len_a = len(a);
   auto len_b = len(b);
   auto newlen = len_a + len_b;
-  auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + newlen));
+  auto *ret = static_cast<string *>(koreAllocToken(sizeof(string) + newlen));
   init_with_len(ret, newlen);
   memcpy(&(ret->data), &(a->data), len(a) * sizeof(KCHAR));
   memcpy(&(ret->data[len(a)]), &(b->data), len(b) * sizeof(KCHAR));

--- a/runtime/strings/numeric.cpp
+++ b/runtime/strings/numeric.cpp
@@ -10,30 +10,28 @@
 std::string floatToString(const floating *f, const char *suffix) {
   if (mpfr_nan_p(f->f)) {
     return "NaN" + std::string(suffix);
-  } else if (mpfr_inf_p(f->f)) {
+  }
+  if (mpfr_inf_p(f->f)) {
     if (mpfr_signbit(f->f)) {
       return "-Infinity" + std::string(suffix);
-    } else {
-      return "Infinity" + std::string(suffix);
     }
-  } else {
-    mpfr_exp_t printed_exp;
-    char *str = mpfr_get_str(nullptr, &printed_exp, 10, 0, f->f, MPFR_RNDN);
-    size_t len = strlen(str);
-    auto *newstr = (string *)koreAllocToken(sizeof(string) + len + 2);
-    init_with_len(newstr, len + 2);
-    size_t idx = 0;
-    if (str[0] == '-') {
-      newstr->data[0] = '-';
-      idx = 1;
-    }
-    newstr->data[idx] = '0';
-    newstr->data[idx + 1] = '.';
-    strncpy(newstr->data + idx + 2, str + idx, len - idx + 1);
-    newstr->data[len + 2] = '\0';
-    return std::string(newstr->data) + "e" + std::to_string(printed_exp)
-           + suffix;
+    return "Infinity" + std::string(suffix);
   }
+  mpfr_exp_t printed_exp;
+  char *str = mpfr_get_str(nullptr, &printed_exp, 10, 0, f->f, MPFR_RNDN);
+  size_t len = strlen(str);
+  auto *newstr = (string *)koreAllocToken(sizeof(string) + len + 2);
+  init_with_len(newstr, len + 2);
+  size_t idx = 0;
+  if (str[0] == '-') {
+    newstr->data[0] = '-';
+    idx = 1;
+  }
+  newstr->data[idx] = '0';
+  newstr->data[idx + 1] = '.';
+  strncpy(newstr->data + idx + 2, str + idx, len - idx + 1);
+  newstr->data[len + 2] = '\0';
+  return std::string(newstr->data) + "e" + std::to_string(printed_exp) + suffix;
 }
 
 std::string floatToString(const floating *f) {

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -84,7 +84,7 @@ SortString hook_STRING_chr(SortInt ord) {
   if (uord > 255) {
     KLLVM_HOOK_INVALID_ARGUMENT("Ord must be <= 255: {}", uord);
   }
-  auto ret
+  auto *ret
       = static_cast<string *>(koreAllocToken(sizeof(string) + sizeof(KCHAR)));
   init_with_len(ret, 1);
   ret->data[0] = static_cast<KCHAR>(uord);
@@ -112,7 +112,7 @@ SortInt hook_STRING_find(SortString haystack, SortString needle, SortInt pos) {
     mpz_init_set_si(result, -1);
     return move_int(result);
   }
-  auto out = std::search(
+  auto *out = std::search(
       haystack->data + upos * sizeof(KCHAR),
       haystack->data + len(haystack) * sizeof(KCHAR), needle->data,
       needle->data + len(needle) * sizeof(KCHAR));
@@ -132,7 +132,7 @@ SortInt hook_STRING_rfind(SortString haystack, SortString needle, SortInt pos) {
   uint64_t upos = gs(pos);
   upos += len(needle);
   auto end = (upos < len(haystack)) ? upos : len(haystack);
-  auto out = std::find_end(
+  auto *out = std::find_end(
       &haystack->data[0], &haystack->data[end], &needle->data[0],
       &needle->data[len(needle)]);
   auto ret = &*out - &haystack->data[0];
@@ -149,7 +149,7 @@ hook_STRING_findChar(SortString haystack, SortString needle, SortInt pos) {
     mpz_init_set_si(result, -1);
     return move_int(result);
   }
-  auto out = std::find_first_of(
+  auto *out = std::find_first_of(
       haystack->data + upos * sizeof(KCHAR),
       haystack->data + len(haystack) * sizeof(KCHAR), needle->data,
       needle->data + len(needle) * sizeof(KCHAR));
@@ -184,7 +184,7 @@ string *makeString(const KCHAR *input, ssize_t len = -1) {
   if (len == -1) {
     len = strlen(input);
   }
-  auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + len));
+  auto *ret = static_cast<string *>(koreAllocToken(sizeof(string) + len));
   memcpy(ret->data, input, len);
   init_with_len(ret, len);
   return ret;
@@ -207,7 +207,8 @@ SortString hook_STRING_base2string_long(SortInt input, uint64_t base) {
   // but not when setting the length of the string object itself. Any minus
   // signs will have been accounted for already by the intToString call.
   auto str_len = str.size() + 1;
-  auto result = static_cast<string *>(koreAllocToken(sizeof(string) + str_len));
+  auto *result
+      = static_cast<string *>(koreAllocToken(sizeof(string) + str_len));
   strncpy(result->data, str.c_str(), str_len);
   init_with_len(result, str.size());
 
@@ -228,7 +229,7 @@ SortInt hook_STRING_string2base_long(SortString input, uint64_t base) {
     dataStart = input->data;
   }
 
-  auto copy = static_cast<char *>(koreAllocToken(length + 1));
+  auto *copy = static_cast<char *>(koreAllocToken(length + 1));
   memcpy(copy, dataStart, length);
   copy[length] = 0;
   if (mpz_init_set_str(result, copy, base)) {
@@ -272,7 +273,7 @@ string *hook_STRING_string2token(SortString input) {
 }
 
 SortString hook_STRING_token2string(string *input) {
-  auto in_block = (block *)input;
+  auto *in_block = (block *)input;
   if (is_injection(in_block)) {
     input = (string *)strip_injection(in_block);
   }
@@ -289,9 +290,9 @@ inline SortString hook_STRING_replace(
     SortString haystack, SortString needle, SortString replacer,
     SortInt occurences) {
   uint64_t uoccurences = gs(occurences);
-  auto start = &haystack->data[0];
-  auto pos = start;
-  auto end = &haystack->data[len(haystack)];
+  auto *start = &haystack->data[0];
+  auto *pos = start;
+  auto *end = &haystack->data[len(haystack)];
   size_t matches[len(haystack)];
   int i = 0;
   while (i < uoccurences) {
@@ -308,7 +309,7 @@ inline SortString hook_STRING_replace(
   }
   auto diff = len(needle) - len(replacer);
   size_t new_len = len(haystack) - i * diff;
-  auto ret = static_cast<string *>(
+  auto *ret = static_cast<string *>(
       koreAllocToken(sizeof(string) + new_len * sizeof(KCHAR)));
   init_with_len(ret, new_len);
   int m = 0;
@@ -349,8 +350,8 @@ SortString hook_STRING_replaceFirst(
 
 SortInt
 hook_STRING_countAllOccurrences(SortString haystack, SortString needle) {
-  auto pos = &haystack->data[0];
-  auto end = &haystack->data[len(haystack)];
+  auto *pos = &haystack->data[0];
+  auto *end = &haystack->data[len(haystack)];
   int i = 0;
   while (true) {
     pos = std::search(pos, end, &needle->data[0], &needle->data[len(needle)]);
@@ -400,10 +401,10 @@ string *hook_STRING_floatFormat(string *str, string *fmt) {
 }
 
 SortStringBuffer hook_BUFFER_empty() {
-  auto result = static_cast<stringbuffer *>(koreAlloc(sizeof(stringbuffer)));
+  auto *result = static_cast<stringbuffer *>(koreAlloc(sizeof(stringbuffer)));
   init_with_len(result, sizeof(stringbuffer) - sizeof(blockheader));
   result->strlen = 0;
-  auto str = static_cast<string *>(koreAllocToken(sizeof(string) + 16));
+  auto *str = static_cast<string *>(koreAllocToken(sizeof(string) + 16));
   init_with_len(str, 16);
   result->contents = str;
   return result;

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -19,7 +19,7 @@ extern "C" {
 
 #define KCHAR char
 
-mpz_ptr move_int(mpz_t);
+
 floating *move_float(floating *);
 
 string *bytes2string(string *, size_t);

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -19,7 +19,6 @@ extern "C" {
 
 #define KCHAR char
 
-
 floating *move_float(floating *);
 
 string *bytes2string(string *, size_t);
@@ -317,7 +316,8 @@ inline SortString hook_STRING_replace(
     if (m >= i) {
       memcpy(ret->data + r, haystack->data + h, new_len - r);
       break;
-    } else if (r < matches[m] - diff * m) {
+    }
+    if (r < matches[m] - diff * m) {
       auto size = matches[m] - diff * m - r;
       memcpy(ret->data + r, haystack->data + h, size);
       r += size;

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -448,7 +448,8 @@ SortString hook_BUFFER_toString(SortStringBuffer buf) {
 }
 
 void init_float2(floating *result, std::string contents) {
-  size_t prec, exp;
+  size_t prec;
+  size_t exp;
   const char last = contents.back();
   if (last == 'f' || last == 'F') {
     prec = 24;

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -50,7 +50,7 @@ static uint32_t getTagForSymbol(KORESymbol const &symbol) {
 
 void *constructCompositePattern(uint32_t tag, std::vector<void *> &arguments) {
   if (isSymbolAFunction(tag)) {
-    return evaluateFunctionSymbol(tag, &arguments[0]);
+    return evaluateFunctionSymbol(tag, arguments.data());
   }
 
   struct blockheader headerVal = getBlockHeaderForSymbol(tag);
@@ -73,7 +73,7 @@ void *constructCompositePattern(uint32_t tag, std::vector<void *> &arguments) {
   auto *Block = (block *)koreAlloc(size);
   Block->h = headerVal;
 
-  storeSymbolChildren(Block, &arguments[0]);
+  storeSymbolChildren(Block, arguments.data());
   if (isSymbolABinder(tag)) {
     Block = debruijnize(Block);
   }

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -96,7 +96,7 @@ extern "C" void *constructInitialConfiguration(const KOREPattern *initial) {
     workList.pop_back();
 
     if (std::holds_alternative<const KOREPattern *>(current)) {
-      auto constructor = dynamic_cast<const KORECompositePattern *>(
+      const auto *constructor = dynamic_cast<const KORECompositePattern *>(
           *std::get_if<const KOREPattern *>(&current));
       assert(constructor && "Pattern in worklist is not composite");
 
@@ -105,9 +105,9 @@ extern "C" void *constructInitialConfiguration(const KOREPattern *initial) {
           symbol->isConcrete()
           && "found sort variable in initial configuration");
       if (symbol->getName() == "\\dv") {
-        const auto sort = dynamic_cast<KORECompositeSort *>(
+        auto *const sort = dynamic_cast<KORECompositeSort *>(
             symbol->getFormalArguments()[0].get());
-        const auto strPattern = dynamic_cast<KOREStringPattern *>(
+        auto *const strPattern = dynamic_cast<KOREStringPattern *>(
             constructor->getArguments()[0].get());
         std::string contents = strPattern->getContents();
         output.push_back(getToken(
@@ -172,7 +172,7 @@ deserializeInitialConfiguration(It ptr, It end, binary_version version) {
           && "found sort variable in initial configuration");
 
       if (symbol->getName() == "\\dv") {
-        auto sort = dynamic_cast<KORECompositeSort *>(
+        auto *sort = dynamic_cast<KORECompositeSort *>(
             symbol->getFormalArguments()[0].get());
         assert(sort && "Not a composite sort");
         auto const &token = token_stack.back();
@@ -252,15 +252,16 @@ block *parseConfiguration(const char *filename) {
     // InitialConfiguration->print(std::cout);
 
     // Allocate the llvm KORE datastructures for the configuration
-    auto b = (block *)constructInitialConfiguration(InitialConfiguration.get());
+    auto *b
+        = (block *)constructInitialConfiguration(InitialConfiguration.get());
     deallocateSPtrKorePattern(std::move(InitialConfiguration));
     return b;
   }
 }
 
 block *deserializeConfiguration(char *data, size_t size) {
-  auto ptr = data;
-  auto end = data + size;
+  auto *ptr = data;
+  auto *end = data + size;
 
   for (auto i = 0; i < serializer::magic_header.size(); ++i) {
     detail::read<char>(ptr, end);

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -86,6 +86,7 @@ struct construction {
   size_t nchildren;
 };
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 extern "C" void *constructInitialConfiguration(const KOREPattern *initial) {
   std::vector<std::variant<const KOREPattern *, construction>> workList{
       initial};
@@ -148,6 +149,7 @@ extern "C" void *constructInitialConfiguration(const KOREPattern *initial) {
   return output[0];
 }
 
+// NOLINTBEGIN(*-cognitive-complexity)
 template <typename It>
 static void *
 deserializeInitialConfiguration(It ptr, It end, binary_version version) {
@@ -244,6 +246,7 @@ deserializeInitialConfiguration(It ptr, It end, binary_version version) {
   assert(output.size() == 1 && "Output stack left in invalid state");
   return output.front();
 }
+// NOLINTEND(*-cognitive-complexity)
 
 block *parseConfiguration(const char *filename) {
   if (has_binary_kore_header(filename)) {

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -120,7 +120,8 @@ extern "C" void *constructInitialConfiguration(const KOREPattern *initial) {
       if (isSymbolAFunction(tag) && constructor->getArguments().empty()) {
         output.push_back(evaluateFunctionSymbol(tag, nullptr));
         continue;
-      } else if (constructor->getArguments().empty()) {
+      }
+      if (constructor->getArguments().empty()) {
         output.push_back(leaf_block(tag));
         continue;
       }
@@ -190,7 +191,8 @@ deserializeInitialConfiguration(It ptr, It end, binary_version version) {
       if (isSymbolAFunction(tag) && arity == 0) {
         output.push_back(evaluateFunctionSymbol(tag, nullptr));
         break;
-      } else if (arity == 0) {
+      }
+      if (arity == 0) {
         output.push_back(leaf_block(tag));
         break;
       }
@@ -247,16 +249,14 @@ block *parseConfiguration(const char *filename) {
   if (has_binary_kore_header(filename)) {
     auto data = file_contents(filename);
     return deserializeConfiguration(data.data(), data.size());
-  } else {
-    auto InitialConfiguration = parser::KOREParser(filename).pattern();
-    // InitialConfiguration->print(std::cout);
-
-    // Allocate the llvm KORE datastructures for the configuration
-    auto *b
-        = (block *)constructInitialConfiguration(InitialConfiguration.get());
-    deallocateSPtrKorePattern(std::move(InitialConfiguration));
-    return b;
   }
+  auto InitialConfiguration = parser::KOREParser(filename).pattern();
+  // InitialConfiguration->print(std::cout);
+
+  // Allocate the llvm KORE datastructures for the configuration
+  auto *b = (block *)constructInitialConfiguration(InitialConfiguration.get());
+  deallocateSPtrKorePattern(std::move(InitialConfiguration));
+  return b;
 }
 
 block *deserializeConfiguration(char *data, size_t size) {

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -34,8 +34,7 @@ struct StringEq {
 };
 
 struct print_state {
-  print_state()
-       = default;
+  print_state() = default;
 
   // We never want to copy the state; it should only ever get passed around by
   // reference.

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -35,7 +35,7 @@ struct StringEq {
 
 struct print_state {
   print_state()
-       { }
+       = default;
 
   // We never want to copy the state; it should only ever get passed around by
   // reference.

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -126,6 +126,7 @@ void printComma(writer *file, void *state) {
   sfprintf(file, ",");
 }
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 void printConfigurationInternal(
     writer *file, block *subject, const char *sort, bool isVar,
     void *state_ptr) {

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -310,7 +310,7 @@ extern "C" void printMatchResult(
     std::ostream &os, MatchLog *matchLog, size_t logSize,
     const std::string &definitionPath) {
   auto subject_file = temporary_file("subject_XXXXXX");
-  auto subject = subject_file.file_pointer("w");
+  auto *subject = subject_file.file_pointer("w");
   auto pattern_file = temporary_file("pattern_XXXXXX");
 
   for (int i = 0; i < logSize; i++) {
@@ -322,7 +322,7 @@ extern "C" void printMatchResult(
         printSortedConfigurationToFile(
             subject, (block *)matchLog[i].subject, matchLog[i].sort);
       } else {
-        auto subjectSort
+        auto *subjectSort
             = debug_print_term((block *)matchLog[i].subject, matchLog[i].sort);
         auto strSubjectSort = std::string(subjectSort->data, len(subjectSort));
         subject_file.ofstream() << strSubjectSort << std::endl;
@@ -337,7 +337,7 @@ extern "C" void printMatchResult(
       os << matchLog[i].debugName << "(";
 
       for (int j = 0; j < matchLog[i].args.size(); j += 2) {
-        auto typeName = reinterpret_cast<char *>(matchLog[i].args[j + 1]);
+        auto *typeName = reinterpret_cast<char *>(matchLog[i].args[j + 1]);
         printValueOfType(os, definitionPath, matchLog[i].args[j], typeName);
         if (j + 2 != matchLog[i].args.size()) {
           os << ", ";
@@ -360,7 +360,7 @@ void printValueOfType(
       f.ofstream() << std::string(s->data, len(s)) << std::endl;
       kllvm::printKORE(os, definitionPath, f.filename(), false, true);
     } else if ((((uintptr_t)value) & 1) == 0) {
-      auto s = reinterpret_cast<string *>(value);
+      auto *s = reinterpret_cast<string *>(value);
       os << std::string(s->data, len(s));
     } else {
       os << "Error: " << type << " not implemented!";

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -173,7 +173,7 @@ void printConfigurationInternal(
     }
     if (isVar && !state.varNames.count(str)) {
       std::string stdStr = std::string(str->data, len(str));
-      std::string suffix = "";
+      std::string suffix;
       while (state.usedVarNames.count(stdStr + suffix)) {
         suffix = std::to_string(state.varCounter++);
       }

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -350,9 +350,9 @@ extern "C" void printMatchResult(
 void printValueOfType(
     std::ostream &os, std::string const &definitionPath, void *value,
     std::string const &type) {
-  if (type.compare("%mpz*") == 0) {
+  if (type == "%mpz*") {
     os << reinterpret_cast<mpz_ptr>(value);
-  } else if (type.compare("%block*") == 0) {
+  } else if (type == "%block*") {
     if ((((uintptr_t)value) & 3) == 1) {
       auto f = temporary_file("subject_XXXXXX");
       string *s = printConfigurationToString(reinterpret_cast<block *>(value));
@@ -364,9 +364,9 @@ void printValueOfType(
     } else {
       os << "Error: " << type << " not implemented!";
     }
-  } else if (type.compare("%floating*") == 0) {
+  } else if (type == "%floating*") {
     os << floatToString(reinterpret_cast<floating *>(value));
-  } else if (type.compare("i1") == 0) {
+  } else if (type == "i1") {
     os << *reinterpret_cast<bool *>(value);
   } else {
     os << "Error: " << type << " not implemented!";

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -339,8 +339,9 @@ extern "C" void printMatchResult(
       for (int j = 0; j < matchLog[i].args.size(); j += 2) {
         auto typeName = reinterpret_cast<char *>(matchLog[i].args[j + 1]);
         printValueOfType(os, definitionPath, matchLog[i].args[j], typeName);
-        if (j + 2 != matchLog[i].args.size())
+        if (j + 2 != matchLog[i].args.size()) {
           os << ", ";
+        }
       }
       os << ") => " << *reinterpret_cast<bool *>(matchLog[i].result) << "\n";
     }

--- a/runtime/util/ConfigurationPrinter.cpp
+++ b/runtime/util/ConfigurationPrinter.cpp
@@ -35,9 +35,7 @@ struct StringEq {
 
 struct print_state {
   print_state()
-      : boundVariables{}
-      , varNames{}
-      , usedVarNames{} { }
+       { }
 
   // We never want to copy the state; it should only ever get passed around by
   // reference.

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -28,7 +28,7 @@ struct StringEq {
 
 struct serialization_state {
   serialization_state()
-       { }
+       = default;
 
   // We never want to copy the state; it should only ever get passed around by
   // reference.

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -28,10 +28,7 @@ struct StringEq {
 
 struct serialization_state {
   serialization_state()
-      : instance()
-      , boundVariables{}
-      , varNames{}
-      , usedVarNames{} { }
+       { }
 
   // We never want to copy the state; it should only ever get passed around by
   // reference.

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -303,7 +303,7 @@ void serializeConfigurationInternal(
 
     if (isVar && !state.varNames.count(str)) {
       std::string stdStr = std::string(str->data, len(str));
-      std::string suffix = "";
+      std::string suffix;
       while (state.usedVarNames.count(stdStr + suffix)) {
         suffix = std::to_string(state.varCounter++);
       }

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -114,7 +114,7 @@ void serializeMap(
   }
 
   auto tag = getTagForSymbolName(element);
-  auto arg_sorts = getArgumentSortsForTag(tag);
+  auto *arg_sorts = getArgumentSortsForTag(tag);
 
   for (auto iter = map->begin(); iter != map->end(); ++iter) {
     serializeConfigurationInternal(
@@ -141,7 +141,7 @@ void serializeRangeMap(
   }
 
   auto tag = getTagForSymbolName(element);
-  auto arg_sorts = getArgumentSortsForTag(tag);
+  auto *arg_sorts = getArgumentSortsForTag(tag);
 
   bool once = true;
   for (auto iter = rng_map::ConstRangeMapIterator<KElem, KElem>(*map);
@@ -175,7 +175,7 @@ void serializeList(
   }
 
   auto tag = getTagForSymbolName(element);
-  auto arg_sorts = getArgumentSortsForTag(tag);
+  auto *arg_sorts = getArgumentSortsForTag(tag);
 
   for (auto iter = list->begin(); iter != list->end(); ++iter) {
     serializeConfigurationInternal(file, *iter, arg_sorts[0], false, state);
@@ -199,7 +199,7 @@ void serializeSet(
   }
 
   auto tag = getTagForSymbolName(element);
-  auto arg_sorts = getArgumentSortsForTag(tag);
+  auto *arg_sorts = getArgumentSortsForTag(tag);
 
   for (auto iter = set->begin(); iter != set->end(); ++iter) {
     serializeConfigurationInternal(file, *iter, arg_sorts[0], false, state);
@@ -243,7 +243,7 @@ void serializeMInt(
     writer *file, size_t *i, size_t bits, const char *sort, void *state) {
   auto &instance = static_cast<serialization_state *>(state)->instance;
 
-  auto fmt = "%sp%zd";
+  const auto *fmt = "%sp%zd";
   auto str = std::string{};
 
   if (i == nullptr) {
@@ -342,7 +342,7 @@ void serializeConfigurationInternal(
 
   visitChildren(subject, file, &callbacks, state_ptr);
 
-  auto symbol = getSymbolNameForTag(tag);
+  const auto *symbol = getSymbolNameForTag(tag);
   auto symbolStr = std::string(symbol);
 
   auto [name, sorts] = cached_symbol_sort_list(symbolStr);
@@ -383,7 +383,7 @@ void serializeConfigurations(
     emitConstantSort(state.instance, "SortGeneratedTopCell");
     emitSymbol(state.instance, "\\bottom{}", size, 1);
   } else if (size == 1) {
-    auto result = *results.begin();
+    auto *result = *results.begin();
     serializeConfigurationInternal(&w, result, nullptr, false, &state);
   } else {
     for (auto const &subject : results) {
@@ -395,7 +395,7 @@ void serializeConfigurations(
   }
 
   auto buf_size = state.instance.data().size();
-  auto buf = static_cast<char *>(malloc(buf_size));
+  auto *buf = static_cast<char *>(malloc(buf_size));
   std::memcpy(buf, state.instance.data().data(), buf_size);
   fwrite(buf, 1, buf_size, file);
 
@@ -429,7 +429,7 @@ void serializeConfiguration(
   }
 
   auto size = state.instance.data().size();
-  auto buf = static_cast<char *>(malloc(size));
+  auto *buf = static_cast<char *>(malloc(size));
   std::memcpy(buf, state.instance.data().data(), size);
 
   *data_out = buf;

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -27,8 +27,7 @@ struct StringEq {
 };
 
 struct serialization_state {
-  serialization_state()
-       = default;
+  serialization_state() = default;
 
   // We never want to copy the state; it should only ever get passed around by
   // reference.

--- a/runtime/util/match_log.cpp
+++ b/runtime/util/match_log.cpp
@@ -52,8 +52,9 @@ void addMatchFunction(char *debugName, char *function, void *result, ...) {
   std::vector<void *> args;
   while (true) {
     void *arg = va_arg(ap, void *);
-    if (!arg)
+    if (!arg) {
       break;
+    }
     args.push_back(arg);
   }
 

--- a/runtime/util/match_log.cpp
+++ b/runtime/util/match_log.cpp
@@ -12,7 +12,7 @@ extern "C" void *getStderr(void) {
 static std::vector<MatchLog> matchLog;
 
 void **getMatchFnArgs(MatchLog *log) {
-  return &log->args[0];
+  return log->args.data();
 }
 
 extern "C" {
@@ -21,7 +21,7 @@ void resetMatchReason(void) {
 }
 
 MatchLog *getMatchLog(void) {
-  return &matchLog[0];
+  return matchLog.data();
 }
 
 size_t getMatchLogSize(void) {

--- a/runtime/util/match_log.cpp
+++ b/runtime/util/match_log.cpp
@@ -40,12 +40,13 @@ void addMatchSuccess(void) {
        nullptr});
 }
 
-void addMatchFailReason(void *subject, char *pattern, char *sort) {
+void addMatchFailReason(void *subject, const char *pattern, const char *sort) {
   matchLog.push_back(
       {MatchLog::FAIL, nullptr, nullptr, nullptr, {}, pattern, subject, sort});
 }
 
-void addMatchFunction(char *debugName, char *function, void *result, ...) {
+void addMatchFunction(
+    const char *debugName, const char *function, void *result, ...) {
   va_list ap;
   va_start(ap, result);
 

--- a/runtime/util/search.cpp
+++ b/runtime/util/search.cpp
@@ -82,7 +82,7 @@ std::unordered_set<block *, HashBlock, KEq> take_search_steps(
       results.insert(state);
       return results;
     }
-    if (stepResults.size() == 0) {
+    if (stepResults.empty()) {
       results.insert(state);
       if (results.size() == bound) {
         return results;

--- a/runtime/util/search.cpp
+++ b/runtime/util/search.cpp
@@ -37,11 +37,11 @@ blockEnumerator() {
     blocks.push_back(const_cast<block **>(&(keyVal)));
   }
 
-  for (auto &keyVal : states_set) {
+  for (const auto &keyVal : states_set) {
     blocks.push_back(const_cast<block **>(&(keyVal)));
   }
 
-  for (auto &keyVal : results) {
+  for (const auto &keyVal : results) {
     blocks.push_back(const_cast<block **>(&(keyVal)));
   }
 
@@ -98,7 +98,7 @@ std::unordered_set<block *, HashBlock, KEq> take_search_steps(
   }
 
   if (depth == 0) {
-    for (auto state : states) {
+    for (auto *state : states) {
       results.insert(state);
       if (results.size() == bound) {
         return results;

--- a/runtime/util/search.cpp
+++ b/runtime/util/search.cpp
@@ -48,6 +48,7 @@ blockEnumerator() {
   return std::make_pair(blocks.begin(), blocks.end());
 }
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 std::unordered_set<block *, HashBlock, KEq> take_search_steps(
     bool executeToBranch, int64_t depth, int64_t bound, block *subject) {
   static int registered = -1;

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -27,4 +27,5 @@ mapfile -t inputs < <(find "${source_dirs[@]}" -name '*.cpp' -or -name '*.h')
   "${inputs[@]}"                      \
   -clang-tidy-binary "${clang_tidy}"  \
   -j "$(nproc)"                       \
-  -p "${BUILD_DIR}" "$@"
+  -p "${BUILD_DIR}" "$@"              \
+  2>&1 | awk '!/(^Suppressed|^Use -header|^[0-9]+ warnings)/'

--- a/tools/k-rule-apply/main.cpp
+++ b/tools/k-rule-apply/main.cpp
@@ -28,7 +28,7 @@ std::optional<std::string> getMatchFunctionName() {
   kore_ast->preprocess();
 
   // Iterate through axioms and return the one with the give rulen label if exits.
-  for (auto axiom : kore_ast.get()->getAxioms()) {
+  for (auto *axiom : kore_ast.get()->getAxioms()) {
     if (axiom->getAttributes().size() > 0) {
       // Check if the current axiom has the attribute label.
       auto attr = axiom->getAttributes().find("label");
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
   }
 
   // Open the shared library that contains the llvm match functions.
-  auto handle = dlopen(SharedLibPath.c_str(), RTLD_LAZY);
+  auto *handle = dlopen(SharedLibPath.c_str(), RTLD_LAZY);
 
   // Check if the shared library exits in the given location.
   if (!handle) {
@@ -81,14 +81,14 @@ int main(int argc, char **argv) {
 
   resetMatchReason(handle);
   initStaticObjects(handle);
-  auto b = constructInitialConfiguration(InitialConfiguration.get(), handle);
+  auto *b = constructInitialConfiguration(InitialConfiguration.get(), handle);
   if (b == nullptr) {
     std::cerr << "Error: " << dlerror() << "\n";
     return EXIT_FAILURE;
   }
 
   match_function((block *)b);
-  auto log = getMatchLog(handle);
+  auto *log = getMatchLog(handle);
   if (log == nullptr) {
     std::cerr << "Error: " << dlerror() << "\n";
     return EXIT_FAILURE;

--- a/tools/k-rule-apply/main.cpp
+++ b/tools/k-rule-apply/main.cpp
@@ -35,8 +35,9 @@ std::optional<std::string> getMatchFunctionName() {
 
       if (attr != axiom->getAttributes().end()) {
         // Compare the axiom's label with the given rule label.
-        if (!RuleLabel.compare(axiom->getStringAttribute("label")))
+        if (RuleLabel == axiom->getStringAttribute("label")) {
           return "intern_match_" + std::to_string(axiom->getOrdinal());
+        }
       }
     }
   }

--- a/tools/k-rule-apply/main.cpp
+++ b/tools/k-rule-apply/main.cpp
@@ -29,7 +29,7 @@ std::optional<std::string> getMatchFunctionName() {
 
   // Iterate through axioms and return the one with the give rulen label if exits.
   for (auto *axiom : kore_ast.get()->getAxioms()) {
-    if (axiom->getAttributes().size() > 0) {
+    if (!axiom->getAttributes().empty()) {
       // Check if the current axiom has the attribute label.
       auto attr = axiom->getAttributes().find("label");
 

--- a/tools/k-rule-find/main.cpp
+++ b/tools/k-rule-find/main.cpp
@@ -76,7 +76,8 @@ Location parseLocation(std::string const &loc) {
   size_t pos_lc = lineColumn.find(':');
 
   // If another “:” isn’t found, the tool assumes no column number was given.
-  int64_t line, column = -1;
+  int64_t line;
+  int64_t column = -1;
   if (pos_lc == std::string::npos) {
     line = stoi(lineColumn);
   } else {

--- a/tools/k-rule-find/main.cpp
+++ b/tools/k-rule-find/main.cpp
@@ -32,7 +32,7 @@ std::string getSource(KOREAxiomDeclaration *axiom) {
   auto *sourceAtt = axiom->getAttributes().at(SOURCE_ATT).get();
   assert(sourceAtt->getArguments().size() == 1);
 
-  auto strPattern
+  auto *strPattern
       = dynamic_cast<KOREStringPattern *>(sourceAtt->getArguments()[0].get());
   return strPattern->getContents();
 }
@@ -41,7 +41,7 @@ Location getLocation(KOREAxiomDeclaration *axiom) {
   auto *locationAtt = axiom->getAttributes().at(LOCATION_ATT).get();
   assert(locationAtt->getArguments().size() == 1);
 
-  auto strPattern
+  auto *strPattern
       = dynamic_cast<KOREStringPattern *>(locationAtt->getArguments()[0].get());
   std::string location = strPattern->getContents();
 
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
   auto kore_ast = parser.definition();
 
   // Iterate through axioms.
-  for (auto axiom : kore_ast.get()->getAxioms()) {
+  for (auto *axiom : kore_ast.get()->getAxioms()) {
     if (axiom->getAttributes().count(SOURCE_ATT)) {
       auto source = getSource(axiom);
       if (source.find(loc.filename) != std::string::npos) {

--- a/tools/k-rule-find/main.cpp
+++ b/tools/k-rule-find/main.cpp
@@ -125,8 +125,9 @@ int main(int argc, char **argv) {
   if (rule_labels.empty()) {
     std::cerr << "Error: Couldn't find rule label within the given location.\n";
   } else {
-    for (auto const &rule_label : rule_labels)
+    for (auto const &rule_label : rule_labels) {
       std::cout << rule_label << "\n";
+    }
   }
 
   return 0;

--- a/tools/kore-convert/main.cpp
+++ b/tools/kore-convert/main.cpp
@@ -84,10 +84,9 @@ sptr<KOREPattern> get_input_pattern() {
     if (has_binary_kore_header(InputFilename)) {
       InputFormat = binary;
       return get_binary();
-    } else {
-      InputFormat = text;
-      return get_text();
     }
+    InputFormat = text;
+    return get_text();
 
     break;
   }

--- a/tools/kore-expand-macros/main.cpp
+++ b/tools/kore-expand-macros/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
   KOREParser parser(argv[1] + std::string("/syntaxDefinition.kore"));
   ptr<KOREDefinition> def = parser.definition();
 
-  for (auto axiom : def->getAxioms()) {
+  for (auto *axiom : def->getAxioms()) {
     if (axiom->getAttributes().count("subsort")) {
       KORECompositePattern *att = axiom->getAttributes().at("subsort").get();
       KORESort *innerSort
@@ -69,13 +69,13 @@ int main(int argc, char **argv) {
   std::map<std::string, std::vector<KORESymbol *>> symbols;
   config->markSymbols(symbols);
   for (auto &decl : axioms) {
-    auto axiom = dynamic_cast<KOREAxiomDeclaration *>(decl.get());
+    auto *axiom = dynamic_cast<KOREAxiomDeclaration *>(decl.get());
     axiom->getPattern()->markSymbols(symbols);
   }
 
   for (auto &entry : symbols) {
-    for (auto symbol : entry.second) {
-      auto decl = def->getSymbolDeclarations().at(symbol->getName());
+    for (auto *symbol : entry.second) {
+      auto *decl = def->getSymbolDeclarations().at(symbol->getName());
       symbol->instantiateSymbol(decl);
     }
   }

--- a/tools/kore-proof-trace-test/main.cpp
+++ b/tools/kore-proof-trace-test/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
   }
 
   // check that the trace after the initial configuration is 4 events long
-  if (Trace->getTrace().size() != 4u) {
+  if (Trace->getTrace().size() != 4U) {
     return 1;
   }
 

--- a/tools/kore-split/main.cpp
+++ b/tools/kore-split/main.cpp
@@ -32,8 +32,7 @@ int main(int argc, char **argv) {
     }
 
     return 0;
-  } else {
-    std::cerr << "pattern must be an \\or" << std::endl;
-    return 1;
   }
+  std::cerr << "pattern must be an \\or" << std::endl;
+  return 1;
 }

--- a/tools/kore-split/main.cpp
+++ b/tools/kore-split/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
   }
 
   auto config = KOREPattern::load(argv[1]);
-  if (auto composite = dynamic_cast<KORECompositePattern *>(config.get())) {
+  if (auto *composite = dynamic_cast<KORECompositePattern *>(config.get())) {
     if (composite->getConstructor()->getName() != "\\or") {
       std::cerr << "pattern must be an \\or" << std::endl;
       return 1;

--- a/tools/kore-strip/main.cpp
+++ b/tools/kore-strip/main.cpp
@@ -39,7 +39,7 @@ cl::opt<std::string> OutputFilename(
     cl::init("-"), cl::cat(KoreStripCat));
 
 std::FILE *check_fopen(char const *name, char const *mode) {
-  auto f = std::fopen(name, mode);
+  auto *f = std::fopen(name, mode);
   if (!f) {
     auto str = std::stringstream{};
     str << "Could not open file " << name;
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
   cl::HideUnrelatedOptions({&KoreStripCat});
   cl::ParseCommandLineOptions(argc, argv);
 
-  auto input = check_fopen(InputFilename.c_str(), "rb");
+  auto *input = check_fopen(InputFilename.c_str(), "rb");
 
   std::fseek(input, 0, SEEK_END);
   auto file_size = std::ftell(input);
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
     std::fclose(input);
   } else {
     auto tmp_file = temporary_file("tmp.strip.XXXXXXXXXX");
-    auto file_pointer = tmp_file.file_pointer("wb");
+    auto *file_pointer = tmp_file.file_pointer("wb");
 
     std::fwrite(buffer.data(), sizeof(uint8_t), result_size, file_pointer);
     std::fflush(file_pointer);

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -112,6 +112,7 @@ void initialize_llvm() {
 
 } // namespace
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 int main(int argc, char **argv) {
   initialize_llvm();
 

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
   auto kompiled_dir = fs::absolute(Definition.getValue()).parent_path();
   addKompiledDirSymbol(Context, kompiled_dir, mod.get(), Debug);
 
-  for (auto axiom : definition->getAxioms()) {
+  for (auto *axiom : definition->getAxioms()) {
     makeSideConditionFunction(axiom, definition.get(), mod.get());
     if (!axiom->isTopAxiom()) {
       makeApplyRuleFunction(axiom, definition.get(), mod.get());
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
       auto match_filename
           = dt_dir() / fmt::format("match_{}.yaml", axiom->getOrdinal());
       if (fs::exists(match_filename)) {
-        auto dt = parseYamlDecisionTree(
+        auto *dt = parseYamlDecisionTree(
             mod.get(), match_filename, definition->getAllSymbols(),
             definition->getHookedSorts());
         makeMatchReasonFunction(definition.get(), mod.get(), axiom, dt);
@@ -165,28 +165,28 @@ int main(int argc, char **argv) {
 
   emitConfigParserFunctions(definition.get(), mod.get());
 
-  auto dt = parseYamlDecisionTree(
+  auto *dt = parseYamlDecisionTree(
       mod.get(), DecisionTree, definition->getAllSymbols(),
       definition->getHookedSorts());
   makeStepFunction(definition.get(), mod.get(), dt, false);
-  auto dtSearch = parseYamlDecisionTree(
+  auto *dtSearch = parseYamlDecisionTree(
       mod.get(), dt_dir() / "dt-search.yaml", definition->getAllSymbols(),
       definition->getHookedSorts());
   makeStepFunction(definition.get(), mod.get(), dtSearch, true);
 
   auto index = read_index_file();
-  for (auto &entry : definition->getSymbols()) {
-    auto symbol = entry.second;
-    auto decl = definition->getSymbolDeclarations().at(symbol->getName());
+  for (const auto &entry : definition->getSymbols()) {
+    auto *symbol = entry.second;
+    auto *decl = definition->getSymbolDeclarations().at(symbol->getName());
     if (decl->getAttributes().count("function") && !decl->isHooked()) {
       auto filename = get_indexed_filename(index, decl);
-      auto funcDt = parseYamlDecisionTree(
+      auto *funcDt = parseYamlDecisionTree(
           mod.get(), filename, definition->getAllSymbols(),
           definition->getHookedSorts());
       makeEvalFunction(decl->getSymbol(), definition.get(), mod.get(), funcDt);
     } else if (decl->isAnywhere()) {
       auto filename = get_indexed_filename(index, decl);
-      auto funcDt = parseYamlDecisionTree(
+      auto *funcDt = parseYamlDecisionTree(
           mod.get(), filename, definition->getAllSymbols(),
           definition->getHookedSorts());
 

--- a/tools/llvm-kompile-gc-stats/main.cpp
+++ b/tools/llvm-kompile-gc-stats/main.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <cstring>
 
+// NOLINTNEXTLINE(*-cognitive-complexity)
 int main(int argc, char **argv) {
   const char *usage = "usage: %s [dump|analyze|generation|count] <file>"
                       " [<lower_bound> <upper_bound>]\n";

--- a/tools/llvm-kompile-gc-stats/main.cpp
+++ b/tools/llvm-kompile-gc-stats/main.cpp
@@ -61,8 +61,9 @@ int main(int argc, char **argv) {
     //
     // frame[2048] contains the total number of bytes that survived
     // at least 2048 collection cycles that are alive at that point in time.
-    if (ret < 2049)
+    if (ret < 2049) {
       break;
+    }
     if (dump) {
       printf("Collection %zd\n", step);
       for (int i = 0; i < 2048; i++) {


### PR DESCRIPTION
This is another PR in my ongoing series to enable more clang-tidy checks for the codebase. As previously, each commit in this PR fixes the issues flagged by a single check, and can / should be reviewed independently.

As ever, I'm happy to bikeshed any of the specific changes in this PR. Note that for [`readability-function-cognitive-complexity`](https://github.com/runtimeverification/llvm-backend/pull/936/commits/c2b0de149776d1af54a519e81ecf53923dfd1ec1), I've not actually refactored any existing code in the interest of keeping this diff minimal, but the check will prevent us from introducing new code that exceeds the complexity threshold.