### PR TITLE
Hotfix for byte escaping issues

### DIFF
--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -662,7 +662,9 @@ std::string enquote(const std::string &str) {
       if ((unsigned char)c >= 32 && (unsigned char)c < 127) {
         result.push_back(c);
       } else {
-        fmt::format_to(std::back_inserter(result), "\\x{:02x}", c);
+        fmt::format_to(
+            std::back_inserter(result), "\\x{:02x}",
+            static_cast<unsigned char>(c));
       }
       break;
     }
@@ -1887,7 +1889,9 @@ static std::string escapeString(const std::string &str) {
 
   for (char c : str) {
     if (c == '"' || c == '\\' || !isprint(c)) {
-      fmt::format_to(std::back_inserter(result), "\\x{:02x}", c);
+      fmt::format_to(
+          std::back_inserter(result), "\\x{:02x}",
+          static_cast<unsigned char>(c));
     } else {
       result.push_back(c);
     }


### PR DESCRIPTION
The frontend test suite catches a bug introduced in #933, where byte literal values that overflow a signed character are printed incorrectly. I took a look at the best place to test this (i.e. whether it was worth backporting the relevant test into the backend test suite), and it is indeed in the frontend because of the way that we provide test cases in each project.

I have run the downstream K test suite and verified that it passes with this fix applied.

Fixes: https://github.com/runtimeverification/k/pull/3883