### PR TITLE
Enable fixes for memory leaks in bindings

### DIFF
--- a/bindings/python/runtime.cpp
+++ b/bindings/python/runtime.cpp
@@ -40,7 +40,8 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, raw_ptr<T>, true);
  */
 
 extern "C" {
-void initStaticObjects();
+void initStaticObjects(void);
+void freeAllKoreMem(void);
 block *take_steps(int64_t, block *);
 void *constructInitialConfiguration(const KOREPattern *initial);
 }
@@ -57,6 +58,9 @@ void bind_runtime(py::module_ &m) {
   m.def("return_sort_for_label", bindings::return_sort_for_label);
 
   m.def("evaluate_function", bindings::evaluate_function);
+
+  m.def("init_static_objects", initStaticObjects);
+  m.def("free_all_gc_memory", freeAllKoreMem);
 
   // This class can't be used directly from Python; the mutability semantics
   // that we get from the Pybind wrappers make it really easy to break things.
@@ -97,7 +101,5 @@ void bind_runtime(py::module_ &m) {
 }
 
 PYBIND11_MODULE(_kllvm_runtime, m) {
-  initStaticObjects();
-
   bind_runtime(m);
 }

--- a/test/python/test_steps.py
+++ b/test/python/test_steps.py
@@ -43,6 +43,8 @@ class TestSteps(unittest.TestCase):
         t.step(200)
         self.assertEqual(str(t), bar_output())
 
+        kllvm.runtime.free_all_gc_memory()
+
     def test_steps_2(self):
         t = kllvm.runtime.Term(start_pattern())
 
@@ -52,10 +54,14 @@ class TestSteps(unittest.TestCase):
         t.step(-1)
         self.assertEqual(str(t), bar_output())
 
+        kllvm.runtime.free_all_gc_memory()
+
     def test_steps_3(self):
         t = kllvm.runtime.Term(start_pattern())
         t.run()
         self.assertEqual(str(t), bar_output())
+
+        kllvm.runtime.free_all_gc_memory()
 
     def test_steps_to_pattern(self):
         t = kllvm.runtime.Term(start_pattern())
@@ -63,6 +69,9 @@ class TestSteps(unittest.TestCase):
         pat = t.to_pattern()
         self.assertEqual(str(pat), bar_output())
 
+        kllvm.runtime.free_all_gc_memory()
+
 
 if __name__ == "__main__":
+    kllvm.runtime.init_static_objects()
     unittest.main()


### PR DESCRIPTION
This PR fixes a long-standing issue in the backend's binding code, which is that the call to `initStaticObjects()` when the Python module is _bound_ does not affect the process that actually runs the backend interpreter. A consequence of this is that GMP is never told to use our GC'ed memory allocators, and so any code using integer operations ends up leaking lots of memory when it runs for a long time.

To fix Python code that uses the bindings:
* Call `init_static_objects` on application startup
* If an application _only_ does function evaluation or simplification, you may also want to call `free_all_gc_memory` occasionally as the backend will not do so autonomously unless a rewrite step is taken.

Relevant:
* #770
* #922 (has reproduction instructions)