### PR TITLE
Use python rather than perl for profiling

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -7,7 +7,7 @@ profile=${profile:-false}
 
 
 time_now_ms () {
-  perl -MTime::HiRes=time -e 'printf "%d\n", time*1000'
+  python3 -c 'import time; print(time.time_ns() // 1_000_000)'
 }
 
 indented () {

--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -1,7 +1,7 @@
 { lib, src, cmake, flex, fmt, pkgconfig, llvm, libllvm, libcxxabi, stdenv, boost, gmp
 , jemalloc, libffi, libiconv, libyaml, mpfr, ncurses, python39, unixtools,
 # Runtime dependencies:
-host, perl,
+host,
 # Options:
 cmakeBuildType ? "FastBuild" # optimized release build, currently: LTO
 }:
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
       -e '2a export PATH="${lib.getBin host.clang}/bin:''${PATH}"'
 
     substituteInPlace bin/utils.sh \
-      --replace 'perl' '${perl}/bin/perl'
+      --replace 'python3' '${python-env.interpreter}'
 
     substituteInPlace bin/llvm-kompile \
       --replace 'python_cmd=python3' 'python_cmd="${python-env.interpreter}"' \


### PR DESCRIPTION
In https://github.com/runtimeverification/llvm-backend/pull/833 we changed from the built-in date command to perl for getting the system time in ms; this caused some weird interactions with the OS when installed via `kup`: https://github.com/runtimeverification/kup/issues/80

This PR drops our use of `perl` and instead uses an equivalent `python3` command, which we already depend on when building the backend.