### PR TITLE
Set `%option 8bit` in `KOREScanner.l`

### DIFF
--- a/lib/parser/KOREScanner.l
+++ b/lib/parser/KOREScanner.l
@@ -20,6 +20,7 @@ using namespace kllvm::parser;
 %option noyywrap
 %option nounput
 %option reentrant
+%option 8bit
 
 /* Flex macros */
 ident @?[a-zA-Z][a-zA-Z0-9'-]*
@@ -72,11 +73,11 @@ yyin = in;
 }
 
 "\""            { stringBuffer.clear(); BEGIN(STR);           }
-<STR>[^\"\n\\]* { stringBuffer.append(yytext);                }
-<STR>"\\n"       { stringBuffer.push_back('\n'); loc->lines(); }
-<STR>"\\r"       { stringBuffer.push_back('\r'); loc->lines(); }
-<STR>"\\t"       { stringBuffer.push_back('\t'); loc->lines(); }
-<STR>"\\f"       { stringBuffer.push_back('\f'); loc->lines(); }
+<STR>([\x20-\x7E]{-}[\"\\])* { stringBuffer.append(yytext);   }
+<STR>"\\n"      { stringBuffer.push_back('\n'); loc->lines(); }
+<STR>"\\r"      { stringBuffer.push_back('\r'); loc->lines(); }
+<STR>"\\t"      { stringBuffer.push_back('\t'); loc->lines(); }
+<STR>"\\f"      { stringBuffer.push_back('\f'); loc->lines(); }
 <STR>"\\\""     { stringBuffer.push_back('\"');               }
 <STR>"\\\\"     { stringBuffer.push_back('\\');               }
 <STR>\\[0-9]{3} { stringBuffer.push_back((yytext[1] - '0') * 64 + (yytext[2] - '0') * 8 + yytext[3] - '0'); }


### PR DESCRIPTION
Fixes #948

Flex does not directly support Unicode, but it does support `%option 8bit` where every 8-bit byte in the input stream is treated as a separate character. To fix #948, rather than escaping in the frontend then, we can just accept any byte sequence inside comments (in practice always UTF-8), allowing the original source text to be passed through unmodified.

However, 8-bit mode also makes it so that `.` and negated character classes `[^bar]` accept non-ASCII bytes, which we sometime want to disallow, e.g., in string literals, so we need to update every such regex accordingly. 