### PR TITLE
Implement helper to collect sorts hooked to a particular implementation

### DIFF
--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -934,6 +934,19 @@ public:
   void addAttribute(sptr<KORECompositePattern> Attribute);
   void print(std::ostream &Out, unsigned indent = 0) const;
 
+  /*
+   * Return the set of sorts that are hooked to a particular hook name.
+   * Typically, the set returned will be the singleton set. For example:
+   *
+   *   getSortsHookedTo("BYTES.Bytes") -> { "SortBytes" }
+   *
+   * If user K code hooks sorts to K's internal implementations (e.g. to
+   * implement type-safe collections), those user sorts will be returned as
+   * well.
+   */
+  std::unordered_set<std::string>
+  getSortsHookedTo(std::string const &hookName) const;
+
   const std::vector<sptr<KOREModule>> &getModules() const { return modules; }
   const KORECompositeSortDeclarationMapType &getSortDeclarations() const {
     return sortDeclarations;

--- a/lib/ast/CMakeLists.txt
+++ b/lib/ast/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(AST
   AST.cpp
   pattern_matching.cpp
+  definition.cpp
 )
 
 target_link_libraries(AST

--- a/lib/ast/definition.cpp
+++ b/lib/ast/definition.cpp
@@ -1,0 +1,23 @@
+#include <kllvm/ast/AST.h>
+
+#include <string>
+#include <unordered_set>
+
+namespace kllvm {
+
+std::unordered_set<std::string>
+KOREDefinition::getSortsHookedTo(std::string const &hookName) const {
+  auto ret = std::unordered_set<std::string>{};
+
+  for (auto const &[name, decl] : getSortDeclarations()) {
+    if (decl->isHooked()) {
+      if (auto hook = decl->getStringAttribute("hook"); hook == hookName) {
+        ret.insert(name);
+      }
+    }
+  }
+
+  return ret;
+}
+
+} // namespace kllvm


### PR DESCRIPTION
The method implemented here collects all the sorts that are hooked to a particular implementation; typically this will be a singleton set, but it is possible in theory to have user code add additional sorts.

Motivated by @Scott-Guest's observation on #950 that it is not safe to assume `SortBytes` is the only sort on which byte hooks can be called; we instead need to compute the set of sorts greater than any sort hooked to `BYTES.Bytes` (using code in #951).