### PR TITLE
Removing emission of side condition hints

### DIFF
--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -370,7 +370,7 @@ void bind_proof_trace(py::module_ &m) {
 
   [[maybe_unused]] auto llvm_side_condition_event = py::class_<
       LLVMSideConditionEvent, std::shared_ptr<LLVMSideConditionEvent>>(
-      proof_trace, "LLVMSideConditionEvent", llvm_rewrite_event);
+      proof_trace, "LLVMSideConditionEvent", llvm_step_event);
 
   py::class_<LLVMFunctionEvent, std::shared_ptr<LLVMFunctionEvent>>(
       proof_trace, "LLVMFunctionEvent", llvm_step_event)

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -80,15 +80,14 @@ public:
   virtual void print(std::ostream &Out, unsigned indent = 0u) const override;
 };
 
-class LLVMSideConditionEvent : public LLVMRewriteEvent {
+class LLVMSideConditionEvent : public LLVMStepEvent {
 private:
-  LLVMSideConditionEvent(uint64_t _ruleOrdinal)
-      : LLVMRewriteEvent(_ruleOrdinal) { }
+  LLVMSideConditionEvent()
+      : LLVMStepEvent() { }
 
 public:
-  static sptr<LLVMSideConditionEvent> Create(uint64_t _ruleOrdinal) {
-    return sptr<LLVMSideConditionEvent>(
-        new LLVMSideConditionEvent(_ruleOrdinal));
+  static sptr<LLVMSideConditionEvent> Create() {
+    return sptr<LLVMSideConditionEvent>(new LLVMSideConditionEvent());
   }
 
   virtual void print(std::ostream &Out, unsigned indent = 0u) const override;
@@ -479,23 +478,7 @@ private:
       return nullptr;
     }
 
-    uint64_t ordinal;
-    if (!parse_ordinal(ptr, end, ordinal)) {
-      return nullptr;
-    }
-
-    uint64_t arity;
-    if (!parse_arity(ptr, end, arity)) {
-      return nullptr;
-    }
-
-    auto event = LLVMSideConditionEvent::Create(ordinal);
-
-    for (auto i = 0; i < arity; i++) {
-      if (!parse_variable(ptr, end, event)) {
-        return nullptr;
-      }
-    }
+    auto event = LLVMSideConditionEvent::Create();
 
     return event;
   }

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -121,9 +121,8 @@ public:
   [[nodiscard]] llvm::BasicBlock *
   functionEvent_post(llvm::BasicBlock *current_block);
 
-  [[nodiscard]] llvm::BasicBlock *sideConditionEvent(
-      KOREAxiomDeclaration *axiom, std::vector<llvm::Value *> const &args,
-      llvm::BasicBlock *current_block);
+  [[nodiscard]] llvm::BasicBlock *
+  sideConditionEvent(llvm::BasicBlock *current_block);
 
 public:
   ProofEvent(KOREDefinition *Definition, llvm::Module *Module)

--- a/lib/binary/ProofTraceParser.cpp
+++ b/lib/binary/ProofTraceParser.cpp
@@ -23,9 +23,7 @@ void LLVMRuleEvent::print(std::ostream &Out, unsigned indent) const {
 
 void LLVMSideConditionEvent::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent * indent_size, ' ');
-  Out << fmt::format(
-      "{}side condition: {} {}\n", Indent, ruleOrdinal, substitution.size());
-  printSubstitution(Out, indent + 1U);
+  Out << fmt::format("{}side condition\n", Indent);
 }
 
 void LLVMFunctionEvent::print(std::ostream &Out, unsigned indent) const {

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -427,9 +427,7 @@ void FunctionNode::codegen(Decision *d) {
 
   if (isSideCondition) {
     ProofEvent p(d->Definition, d->Module);
-    size_t ordinal = std::stoll(function.substr(15));
-    KOREAxiomDeclaration *axiom = d->Definition->getAxiomByOrdinal(ordinal);
-    d->CurrentBlock = p.sideConditionEvent(axiom, args, d->CurrentBlock);
+    d->CurrentBlock = p.sideConditionEvent(d->CurrentBlock);
   }
 
   CreateTerm creator(

--- a/test/output/imp-proof.out.diff
+++ b/test/output/imp-proof.out.diff
@@ -95,8 +95,7 @@ rule: 2914 5
   VarS1 = kore[139]
   VarS2 = kore[140]
 config: kore[1311]
-side condition: 2912 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -126,8 +125,7 @@ hook: MAP.concat (0:0:1:0)
     arg: kore[150]
 hook result: kore[242]
 config: kore[1235]
-side condition: 2912 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -165,8 +163,7 @@ rule: 2892 6
   VarB = kore[207]
   VarS = kore[482]
 config: kore[1605]
-side condition: 2915 1
-  VarHOLE = kore[207]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -186,8 +183,7 @@ rule: 2915 6
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1701]
-side condition: 2894 1
-  VarHOLE = kore[154]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -205,8 +201,7 @@ rule: 2894 4
   Var'Unds'DotVar2 = kore[1237]
   VarHOLE = kore[154]
 config: kore[1774]
-side condition: 2909 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -233,8 +228,7 @@ rule: 2893 6
   VarI = kore[51]
   VarX = kore[23]
 config: kore[1851]
-side condition: 2888 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -251,8 +245,7 @@ rule: 2888 6
   VarHOLE = kore[50]
   VarK1 = kore[49]
 config: kore[1769]
-side condition: 2909 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -264,9 +257,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2910 2
-  VarHOLE = kore[49]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -298,8 +289,7 @@ hook: INT.le (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[68]
 config: kore[1719]
-side condition: 2880 1
-  Var'Unds'Gen3 = kore[55]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -315,8 +305,7 @@ rule: 2880 5
   Var'Unds'Gen3 = kore[55]
   VarHOLE = kore[54]
 config: kore[1668]
-side condition: 2894 1
-  VarHOLE = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -337,8 +326,7 @@ hook: BOOL.not (0:0:0:0:0:0)
   arg: kore[68]
 hook result: kore[67]
 config: kore[1634]
-side condition: 2891 1
-  Var'Unds'Gen3 = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -356,8 +344,7 @@ rule: 2891 7
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1569]
-side condition: 2915 1
-  VarHOLE = kore[53]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -402,8 +389,7 @@ rule: 2914 5
   VarS1 = kore[227]
   VarS2 = kore[267]
 config: kore[1378]
-side condition: 2912 1
-  VarHOLE = kore[145]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -422,8 +408,7 @@ rule: 2912 5
   VarHOLE = kore[145]
   VarK0 = kore[25]
 config: kore[1500]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -450,8 +435,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[25]
 config: kore[1588]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -468,8 +452,7 @@ rule: 2884 6
   VarHOLE = kore[49]
   VarK1 = kore[48]
 config: kore[1502]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -481,9 +464,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[48]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -518,8 +499,7 @@ rule: 2893 6
   VarI = kore[51]
   VarX = kore[23]
 config: kore[1585]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -536,8 +516,7 @@ rule: 2885 6
   VarHOLE = kore[50]
   VarK0 = kore[49]
 config: kore[1498]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -549,9 +528,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[50]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -583,8 +560,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[64]
 hook result: kore[64]
 config: kore[1446]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -601,8 +577,7 @@ rule: 2890 6
   VarHOLE = kore[50]
   VarK0 = kore[25]
 config: kore[1343]
-side condition: 2912 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -632,8 +607,7 @@ hook: MAP.concat (0:0:1:0)
     arg: kore[149]
 hook result: kore[240]
 config: kore[1261]
-side condition: 2912 1
-  VarHOLE = kore[185]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -652,8 +626,7 @@ rule: 2912 5
   VarHOLE = kore[185]
   VarK0 = kore[23]
 config: kore[1384]
-side condition: 2903 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -680,8 +653,7 @@ rule: 2893 6
   VarI = kore[51]
   VarX = kore[23]
 config: kore[1483]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -698,8 +670,7 @@ rule: 2884 6
   VarHOLE = kore[50]
   VarK1 = kore[73]
 config: kore[1383]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -711,9 +682,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[73]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -751,8 +720,7 @@ hook: INT.sub (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1475]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -769,8 +737,7 @@ rule: 2885 6
   VarHOLE = kore[50]
   VarK0 = kore[50]
 config: kore[1389]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -782,9 +749,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[50]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -816,8 +781,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[64]
 hook result: kore[63]
 config: kore[1334]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -834,8 +798,7 @@ rule: 2890 6
   VarHOLE = kore[49]
   VarK0 = kore[23]
 config: kore[1233]
-side condition: 2912 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -873,8 +836,7 @@ rule: 2892 6
   VarB = kore[207]
   VarS = kore[482]
 config: kore[1605]
-side condition: 2915 1
-  VarHOLE = kore[207]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -894,8 +856,7 @@ rule: 2915 6
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1701]
-side condition: 2894 1
-  VarHOLE = kore[154]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -913,8 +874,7 @@ rule: 2894 4
   Var'Unds'DotVar2 = kore[1237]
   VarHOLE = kore[154]
 config: kore[1774]
-side condition: 2909 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -941,8 +901,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1851]
-side condition: 2888 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -959,8 +918,7 @@ rule: 2888 6
   VarHOLE = kore[49]
   VarK1 = kore[49]
 config: kore[1769]
-side condition: 2909 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -972,9 +930,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2910 2
-  VarHOLE = kore[49]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -1006,8 +962,7 @@ hook: INT.le (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[68]
 config: kore[1719]
-side condition: 2880 1
-  Var'Unds'Gen3 = kore[55]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1023,8 +978,7 @@ rule: 2880 5
   Var'Unds'Gen3 = kore[55]
   VarHOLE = kore[54]
 config: kore[1668]
-side condition: 2894 1
-  VarHOLE = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1045,8 +999,7 @@ hook: BOOL.not (0:0:0:0:0:0)
   arg: kore[68]
 hook result: kore[67]
 config: kore[1634]
-side condition: 2891 1
-  Var'Unds'Gen3 = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1064,8 +1017,7 @@ rule: 2891 7
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1569]
-side condition: 2915 1
-  VarHOLE = kore[53]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1110,8 +1062,7 @@ rule: 2914 5
   VarS1 = kore[227]
   VarS2 = kore[267]
 config: kore[1378]
-side condition: 2912 1
-  VarHOLE = kore[145]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1130,8 +1081,7 @@ rule: 2912 5
   VarHOLE = kore[145]
   VarK0 = kore[25]
 config: kore[1500]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1158,8 +1108,7 @@ rule: 2893 6
   VarI = kore[51]
   VarX = kore[25]
 config: kore[1588]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1176,8 +1125,7 @@ rule: 2884 6
   VarHOLE = kore[50]
   VarK1 = kore[48]
 config: kore[1502]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1189,9 +1137,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[48]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -1226,8 +1172,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1585]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1244,8 +1189,7 @@ rule: 2885 6
   VarHOLE = kore[49]
   VarK0 = kore[50]
 config: kore[1498]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1257,9 +1201,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[49]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -1291,8 +1233,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1447]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1309,8 +1250,7 @@ rule: 2890 6
   VarHOLE = kore[50]
   VarK0 = kore[25]
 config: kore[1344]
-side condition: 2912 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1340,8 +1280,7 @@ hook: MAP.concat (0:0:1:0)
     arg: kore[148]
 hook result: kore[242]
 config: kore[1262]
-side condition: 2912 1
-  VarHOLE = kore[185]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1360,8 +1299,7 @@ rule: 2912 5
   VarHOLE = kore[185]
   VarK0 = kore[23]
 config: kore[1385]
-side condition: 2903 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1388,8 +1326,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1483]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1406,8 +1343,7 @@ rule: 2884 6
   VarHOLE = kore[49]
   VarK1 = kore[73]
 config: kore[1383]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1419,9 +1355,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[73]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -1459,8 +1393,7 @@ hook: INT.sub (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1475]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1477,8 +1410,7 @@ rule: 2885 6
   VarHOLE = kore[50]
   VarK0 = kore[49]
 config: kore[1389]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1490,9 +1422,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[50]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -1524,8 +1454,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[64]
 hook result: kore[63]
 config: kore[1335]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1542,8 +1471,7 @@ rule: 2890 6
   VarHOLE = kore[49]
   VarK0 = kore[23]
 config: kore[1234]
-side condition: 2912 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1581,8 +1509,7 @@ rule: 2892 6
   VarB = kore[207]
   VarS = kore[482]
 config: kore[1605]
-side condition: 2915 1
-  VarHOLE = kore[207]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1602,8 +1529,7 @@ rule: 2915 6
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1701]
-side condition: 2894 1
-  VarHOLE = kore[154]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1621,8 +1547,7 @@ rule: 2894 4
   Var'Unds'DotVar2 = kore[1237]
   VarHOLE = kore[154]
 config: kore[1774]
-side condition: 2909 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1649,8 +1574,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1851]
-side condition: 2888 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1667,8 +1591,7 @@ rule: 2888 6
   VarHOLE = kore[49]
   VarK1 = kore[49]
 config: kore[1769]
-side condition: 2909 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1680,9 +1603,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2910 2
-  VarHOLE = kore[49]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -1714,8 +1635,7 @@ hook: INT.le (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[68]
 config: kore[1719]
-side condition: 2880 1
-  Var'Unds'Gen3 = kore[55]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1731,8 +1651,7 @@ rule: 2880 5
   Var'Unds'Gen3 = kore[55]
   VarHOLE = kore[54]
 config: kore[1668]
-side condition: 2894 1
-  VarHOLE = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1753,8 +1672,7 @@ hook: BOOL.not (0:0:0:0:0:0)
   arg: kore[68]
 hook result: kore[67]
 config: kore[1634]
-side condition: 2891 1
-  Var'Unds'Gen3 = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1772,8 +1690,7 @@ rule: 2891 7
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1569]
-side condition: 2915 1
-  VarHOLE = kore[53]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1818,8 +1735,7 @@ rule: 2914 5
   VarS1 = kore[227]
   VarS2 = kore[267]
 config: kore[1378]
-side condition: 2912 1
-  VarHOLE = kore[145]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1838,8 +1754,7 @@ rule: 2912 5
   VarHOLE = kore[145]
   VarK0 = kore[25]
 config: kore[1500]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1866,8 +1781,7 @@ rule: 2893 6
   VarI = kore[51]
   VarX = kore[25]
 config: kore[1588]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1884,8 +1798,7 @@ rule: 2884 6
   VarHOLE = kore[50]
   VarK1 = kore[48]
 config: kore[1502]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1897,9 +1810,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[48]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -1934,8 +1845,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1585]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -1952,8 +1862,7 @@ rule: 2885 6
   VarHOLE = kore[49]
   VarK0 = kore[50]
 config: kore[1498]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -1965,9 +1874,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[49]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -1999,8 +1906,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1447]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2017,8 +1923,7 @@ rule: 2890 6
   VarHOLE = kore[50]
   VarK0 = kore[25]
 config: kore[1344]
-side condition: 2912 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2048,8 +1953,7 @@ hook: MAP.concat (0:0:1:0)
     arg: kore[148]
 hook result: kore[242]
 config: kore[1262]
-side condition: 2912 1
-  VarHOLE = kore[185]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2068,8 +1972,7 @@ rule: 2912 5
   VarHOLE = kore[185]
   VarK0 = kore[23]
 config: kore[1385]
-side condition: 2903 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2096,8 +1999,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1483]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2114,8 +2016,7 @@ rule: 2884 6
   VarHOLE = kore[49]
   VarK1 = kore[73]
 config: kore[1383]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2127,9 +2028,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[73]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -2167,8 +2066,7 @@ hook: INT.sub (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1475]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2185,8 +2083,7 @@ rule: 2885 6
   VarHOLE = kore[50]
   VarK0 = kore[49]
 config: kore[1389]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2198,9 +2095,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[50]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -2232,8 +2127,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[64]
 hook result: kore[63]
 config: kore[1335]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2250,8 +2144,7 @@ rule: 2890 6
   VarHOLE = kore[49]
   VarK0 = kore[23]
 config: kore[1234]
-side condition: 2912 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2289,8 +2182,7 @@ rule: 2892 6
   VarB = kore[207]
   VarS = kore[482]
 config: kore[1605]
-side condition: 2915 1
-  VarHOLE = kore[207]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2310,8 +2202,7 @@ rule: 2915 6
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1701]
-side condition: 2894 1
-  VarHOLE = kore[154]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2329,8 +2220,7 @@ rule: 2894 4
   Var'Unds'DotVar2 = kore[1237]
   VarHOLE = kore[154]
 config: kore[1774]
-side condition: 2909 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2357,8 +2247,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1851]
-side condition: 2888 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2375,8 +2264,7 @@ rule: 2888 6
   VarHOLE = kore[49]
   VarK1 = kore[49]
 config: kore[1769]
-side condition: 2909 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2388,9 +2276,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2910 2
-  VarHOLE = kore[49]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -2422,8 +2308,7 @@ hook: INT.le (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[68]
 config: kore[1719]
-side condition: 2880 1
-  Var'Unds'Gen3 = kore[55]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2439,8 +2324,7 @@ rule: 2880 5
   Var'Unds'Gen3 = kore[55]
   VarHOLE = kore[54]
 config: kore[1668]
-side condition: 2894 1
-  VarHOLE = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2461,8 +2345,7 @@ hook: BOOL.not (0:0:0:0:0:0)
   arg: kore[68]
 hook result: kore[67]
 config: kore[1634]
-side condition: 2891 1
-  Var'Unds'Gen3 = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2480,8 +2363,7 @@ rule: 2891 7
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1569]
-side condition: 2915 1
-  VarHOLE = kore[53]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2526,8 +2408,7 @@ rule: 2914 5
   VarS1 = kore[227]
   VarS2 = kore[267]
 config: kore[1378]
-side condition: 2912 1
-  VarHOLE = kore[145]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2546,8 +2427,7 @@ rule: 2912 5
   VarHOLE = kore[145]
   VarK0 = kore[25]
 config: kore[1500]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2574,8 +2454,7 @@ rule: 2893 6
   VarI = kore[51]
   VarX = kore[25]
 config: kore[1588]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2592,8 +2471,7 @@ rule: 2884 6
   VarHOLE = kore[50]
   VarK1 = kore[48]
 config: kore[1502]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2605,9 +2483,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[48]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -2642,8 +2518,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1585]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2660,8 +2535,7 @@ rule: 2885 6
   VarHOLE = kore[49]
   VarK0 = kore[50]
 config: kore[1498]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2673,9 +2547,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[49]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -2707,8 +2579,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1447]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2725,8 +2596,7 @@ rule: 2890 6
   VarHOLE = kore[50]
   VarK0 = kore[25]
 config: kore[1344]
-side condition: 2912 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2756,8 +2626,7 @@ hook: MAP.concat (0:0:1:0)
     arg: kore[148]
 hook result: kore[242]
 config: kore[1262]
-side condition: 2912 1
-  VarHOLE = kore[185]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2776,8 +2645,7 @@ rule: 2912 5
   VarHOLE = kore[185]
   VarK0 = kore[23]
 config: kore[1385]
-side condition: 2903 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2804,8 +2672,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1483]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2822,8 +2689,7 @@ rule: 2884 6
   VarHOLE = kore[49]
   VarK1 = kore[73]
 config: kore[1383]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2835,9 +2701,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[73]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -2875,8 +2739,7 @@ hook: INT.sub (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1475]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2893,8 +2756,7 @@ rule: 2885 6
   VarHOLE = kore[50]
   VarK0 = kore[49]
 config: kore[1389]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2906,9 +2768,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[50]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -2940,8 +2800,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[64]
 hook result: kore[63]
 config: kore[1335]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -2958,8 +2817,7 @@ rule: 2890 6
   VarHOLE = kore[49]
   VarK0 = kore[23]
 config: kore[1234]
-side condition: 2912 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -2997,8 +2855,7 @@ rule: 2892 6
   VarB = kore[207]
   VarS = kore[482]
 config: kore[1605]
-side condition: 2915 1
-  VarHOLE = kore[207]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3018,8 +2875,7 @@ rule: 2915 6
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1701]
-side condition: 2894 1
-  VarHOLE = kore[154]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3037,8 +2893,7 @@ rule: 2894 4
   Var'Unds'DotVar2 = kore[1237]
   VarHOLE = kore[154]
 config: kore[1774]
-side condition: 2909 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3065,8 +2920,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1851]
-side condition: 2888 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -3083,8 +2937,7 @@ rule: 2888 6
   VarHOLE = kore[49]
   VarK1 = kore[49]
 config: kore[1769]
-side condition: 2909 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3096,9 +2949,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2910 2
-  VarHOLE = kore[49]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -3130,8 +2981,7 @@ hook: INT.le (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[68]
 config: kore[1719]
-side condition: 2880 1
-  Var'Unds'Gen3 = kore[55]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -3147,8 +2997,7 @@ rule: 2880 5
   Var'Unds'Gen3 = kore[55]
   VarHOLE = kore[54]
 config: kore[1668]
-side condition: 2894 1
-  VarHOLE = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3169,8 +3018,7 @@ hook: BOOL.not (0:0:0:0:0:0)
   arg: kore[68]
 hook result: kore[67]
 config: kore[1634]
-side condition: 2891 1
-  Var'Unds'Gen3 = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -3188,8 +3036,7 @@ rule: 2891 7
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1569]
-side condition: 2915 1
-  VarHOLE = kore[53]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3234,8 +3081,7 @@ rule: 2914 5
   VarS1 = kore[227]
   VarS2 = kore[267]
 config: kore[1378]
-side condition: 2912 1
-  VarHOLE = kore[145]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3254,8 +3100,7 @@ rule: 2912 5
   VarHOLE = kore[145]
   VarK0 = kore[25]
 config: kore[1500]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3282,8 +3127,7 @@ rule: 2893 6
   VarI = kore[51]
   VarX = kore[25]
 config: kore[1588]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -3300,8 +3144,7 @@ rule: 2884 6
   VarHOLE = kore[50]
   VarK1 = kore[48]
 config: kore[1502]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3313,9 +3156,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[48]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -3350,8 +3191,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1585]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -3368,8 +3208,7 @@ rule: 2885 6
   VarHOLE = kore[49]
   VarK0 = kore[50]
 config: kore[1498]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3381,9 +3220,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[49]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -3415,8 +3252,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1447]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -3433,8 +3269,7 @@ rule: 2890 6
   VarHOLE = kore[50]
   VarK0 = kore[25]
 config: kore[1344]
-side condition: 2912 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3464,8 +3299,7 @@ hook: MAP.concat (0:0:1:0)
     arg: kore[148]
 hook result: kore[242]
 config: kore[1262]
-side condition: 2912 1
-  VarHOLE = kore[185]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3484,8 +3318,7 @@ rule: 2912 5
   VarHOLE = kore[185]
   VarK0 = kore[23]
 config: kore[1385]
-side condition: 2903 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3512,8 +3345,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1483]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -3530,8 +3362,7 @@ rule: 2884 6
   VarHOLE = kore[49]
   VarK1 = kore[73]
 config: kore[1383]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3543,9 +3374,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[73]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -3583,8 +3412,7 @@ hook: INT.sub (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1475]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -3601,8 +3429,7 @@ rule: 2885 6
   VarHOLE = kore[50]
   VarK0 = kore[49]
 config: kore[1389]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3614,9 +3441,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[50]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -3648,8 +3473,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[64]
 hook result: kore[63]
 config: kore[1335]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -3666,8 +3490,7 @@ rule: 2890 6
   VarHOLE = kore[49]
   VarK0 = kore[23]
 config: kore[1234]
-side condition: 2912 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3705,8 +3528,7 @@ rule: 2892 6
   VarB = kore[207]
   VarS = kore[482]
 config: kore[1605]
-side condition: 2915 1
-  VarHOLE = kore[207]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3726,8 +3548,7 @@ rule: 2915 6
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1701]
-side condition: 2894 1
-  VarHOLE = kore[154]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3745,8 +3566,7 @@ rule: 2894 4
   Var'Unds'DotVar2 = kore[1237]
   VarHOLE = kore[154]
 config: kore[1774]
-side condition: 2909 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3773,8 +3593,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1851]
-side condition: 2888 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -3791,8 +3610,7 @@ rule: 2888 6
   VarHOLE = kore[49]
   VarK1 = kore[49]
 config: kore[1769]
-side condition: 2909 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3804,9 +3622,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2910 2
-  VarHOLE = kore[49]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -3838,8 +3654,7 @@ hook: INT.le (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[68]
 config: kore[1719]
-side condition: 2880 1
-  Var'Unds'Gen3 = kore[55]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -3855,8 +3670,7 @@ rule: 2880 5
   Var'Unds'Gen3 = kore[55]
   VarHOLE = kore[54]
 config: kore[1668]
-side condition: 2894 1
-  VarHOLE = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3877,8 +3691,7 @@ hook: BOOL.not (0:0:0:0:0:0)
   arg: kore[68]
 hook result: kore[67]
 config: kore[1634]
-side condition: 2891 1
-  Var'Unds'Gen3 = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -3896,8 +3709,7 @@ rule: 2891 7
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1569]
-side condition: 2915 1
-  VarHOLE = kore[53]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3942,8 +3754,7 @@ rule: 2914 5
   VarS1 = kore[227]
   VarS2 = kore[267]
 config: kore[1378]
-side condition: 2912 1
-  VarHOLE = kore[145]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3962,8 +3773,7 @@ rule: 2912 5
   VarHOLE = kore[145]
   VarK0 = kore[25]
 config: kore[1500]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -3990,8 +3800,7 @@ rule: 2893 6
   VarI = kore[51]
   VarX = kore[25]
 config: kore[1588]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4008,8 +3817,7 @@ rule: 2884 6
   VarHOLE = kore[50]
   VarK1 = kore[48]
 config: kore[1502]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4021,9 +3829,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[48]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -4058,8 +3864,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1585]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4076,8 +3881,7 @@ rule: 2885 6
   VarHOLE = kore[49]
   VarK0 = kore[50]
 config: kore[1498]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4089,9 +3893,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[49]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -4123,8 +3925,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1447]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4141,8 +3942,7 @@ rule: 2890 6
   VarHOLE = kore[50]
   VarK0 = kore[25]
 config: kore[1344]
-side condition: 2912 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4172,8 +3972,7 @@ hook: MAP.concat (0:0:1:0)
     arg: kore[148]
 hook result: kore[242]
 config: kore[1262]
-side condition: 2912 1
-  VarHOLE = kore[185]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4192,8 +3991,7 @@ rule: 2912 5
   VarHOLE = kore[185]
   VarK0 = kore[23]
 config: kore[1385]
-side condition: 2903 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4220,8 +4018,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1483]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4238,8 +4035,7 @@ rule: 2884 6
   VarHOLE = kore[49]
   VarK1 = kore[73]
 config: kore[1383]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4251,9 +4047,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[73]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -4291,8 +4085,7 @@ hook: INT.sub (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1475]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4309,8 +4102,7 @@ rule: 2885 6
   VarHOLE = kore[50]
   VarK0 = kore[49]
 config: kore[1389]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4322,9 +4114,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[50]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -4356,8 +4146,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[64]
 hook result: kore[63]
 config: kore[1335]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4374,8 +4163,7 @@ rule: 2890 6
   VarHOLE = kore[49]
   VarK0 = kore[23]
 config: kore[1234]
-side condition: 2912 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4413,8 +4201,7 @@ rule: 2892 6
   VarB = kore[207]
   VarS = kore[482]
 config: kore[1605]
-side condition: 2915 1
-  VarHOLE = kore[207]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4434,8 +4221,7 @@ rule: 2915 6
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1701]
-side condition: 2894 1
-  VarHOLE = kore[154]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4453,8 +4239,7 @@ rule: 2894 4
   Var'Unds'DotVar2 = kore[1237]
   VarHOLE = kore[154]
 config: kore[1774]
-side condition: 2909 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4481,8 +4266,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1851]
-side condition: 2888 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4499,8 +4283,7 @@ rule: 2888 6
   VarHOLE = kore[49]
   VarK1 = kore[49]
 config: kore[1769]
-side condition: 2909 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4512,9 +4295,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2910 2
-  VarHOLE = kore[49]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -4546,8 +4327,7 @@ hook: INT.le (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[68]
 config: kore[1719]
-side condition: 2880 1
-  Var'Unds'Gen3 = kore[55]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4563,8 +4343,7 @@ rule: 2880 5
   Var'Unds'Gen3 = kore[55]
   VarHOLE = kore[54]
 config: kore[1668]
-side condition: 2894 1
-  VarHOLE = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4585,8 +4364,7 @@ hook: BOOL.not (0:0:0:0:0:0)
   arg: kore[68]
 hook result: kore[67]
 config: kore[1634]
-side condition: 2891 1
-  Var'Unds'Gen3 = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4604,8 +4382,7 @@ rule: 2891 7
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1569]
-side condition: 2915 1
-  VarHOLE = kore[53]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4650,8 +4427,7 @@ rule: 2914 5
   VarS1 = kore[227]
   VarS2 = kore[267]
 config: kore[1378]
-side condition: 2912 1
-  VarHOLE = kore[145]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4670,8 +4446,7 @@ rule: 2912 5
   VarHOLE = kore[145]
   VarK0 = kore[25]
 config: kore[1500]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4698,8 +4473,7 @@ rule: 2893 6
   VarI = kore[51]
   VarX = kore[25]
 config: kore[1588]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4716,8 +4490,7 @@ rule: 2884 6
   VarHOLE = kore[50]
   VarK1 = kore[48]
 config: kore[1502]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4729,9 +4502,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[48]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -4766,8 +4537,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1585]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4784,8 +4554,7 @@ rule: 2885 6
   VarHOLE = kore[49]
   VarK0 = kore[50]
 config: kore[1498]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4797,9 +4566,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[49]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -4831,8 +4598,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1447]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4849,8 +4615,7 @@ rule: 2890 6
   VarHOLE = kore[50]
   VarK0 = kore[25]
 config: kore[1344]
-side condition: 2912 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4880,8 +4645,7 @@ hook: MAP.concat (0:0:1:0)
     arg: kore[148]
 hook result: kore[242]
 config: kore[1262]
-side condition: 2912 1
-  VarHOLE = kore[185]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4900,8 +4664,7 @@ rule: 2912 5
   VarHOLE = kore[185]
   VarK0 = kore[23]
 config: kore[1385]
-side condition: 2903 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4928,8 +4691,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1483]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -4946,8 +4708,7 @@ rule: 2884 6
   VarHOLE = kore[49]
   VarK1 = kore[73]
 config: kore[1383]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -4959,9 +4720,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[73]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -4999,8 +4758,7 @@ hook: INT.sub (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1475]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5017,8 +4775,7 @@ rule: 2885 6
   VarHOLE = kore[50]
   VarK0 = kore[49]
 config: kore[1389]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5030,9 +4787,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[50]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -5064,8 +4819,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[64]
 hook result: kore[63]
 config: kore[1335]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5082,8 +4836,7 @@ rule: 2890 6
   VarHOLE = kore[49]
   VarK0 = kore[23]
 config: kore[1234]
-side condition: 2912 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5121,8 +4874,7 @@ rule: 2892 6
   VarB = kore[207]
   VarS = kore[482]
 config: kore[1605]
-side condition: 2915 1
-  VarHOLE = kore[207]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5142,8 +4894,7 @@ rule: 2915 6
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1701]
-side condition: 2894 1
-  VarHOLE = kore[154]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5161,8 +4912,7 @@ rule: 2894 4
   Var'Unds'DotVar2 = kore[1237]
   VarHOLE = kore[154]
 config: kore[1774]
-side condition: 2909 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5189,8 +4939,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1851]
-side condition: 2888 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5207,8 +4956,7 @@ rule: 2888 6
   VarHOLE = kore[49]
   VarK1 = kore[49]
 config: kore[1769]
-side condition: 2909 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5220,9 +4968,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2910 2
-  VarHOLE = kore[49]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -5254,8 +5000,7 @@ hook: INT.le (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[68]
 config: kore[1719]
-side condition: 2880 1
-  Var'Unds'Gen3 = kore[55]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5271,8 +5016,7 @@ rule: 2880 5
   Var'Unds'Gen3 = kore[55]
   VarHOLE = kore[54]
 config: kore[1668]
-side condition: 2894 1
-  VarHOLE = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5293,8 +5037,7 @@ hook: BOOL.not (0:0:0:0:0:0)
   arg: kore[68]
 hook result: kore[67]
 config: kore[1634]
-side condition: 2891 1
-  Var'Unds'Gen3 = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5312,8 +5055,7 @@ rule: 2891 7
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1569]
-side condition: 2915 1
-  VarHOLE = kore[53]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5358,8 +5100,7 @@ rule: 2914 5
   VarS1 = kore[227]
   VarS2 = kore[267]
 config: kore[1378]
-side condition: 2912 1
-  VarHOLE = kore[145]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5378,8 +5119,7 @@ rule: 2912 5
   VarHOLE = kore[145]
   VarK0 = kore[25]
 config: kore[1500]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5406,8 +5146,7 @@ rule: 2893 6
   VarI = kore[51]
   VarX = kore[25]
 config: kore[1588]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5424,8 +5163,7 @@ rule: 2884 6
   VarHOLE = kore[50]
   VarK1 = kore[48]
 config: kore[1502]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5437,9 +5175,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[48]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -5474,8 +5210,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1585]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5492,8 +5227,7 @@ rule: 2885 6
   VarHOLE = kore[49]
   VarK0 = kore[50]
 config: kore[1498]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5505,9 +5239,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[49]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -5539,8 +5271,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1447]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5557,8 +5288,7 @@ rule: 2890 6
   VarHOLE = kore[50]
   VarK0 = kore[25]
 config: kore[1344]
-side condition: 2912 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5588,8 +5318,7 @@ hook: MAP.concat (0:0:1:0)
     arg: kore[148]
 hook result: kore[242]
 config: kore[1262]
-side condition: 2912 1
-  VarHOLE = kore[185]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5608,8 +5337,7 @@ rule: 2912 5
   VarHOLE = kore[185]
   VarK0 = kore[23]
 config: kore[1385]
-side condition: 2903 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5636,8 +5364,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1483]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5654,8 +5381,7 @@ rule: 2884 6
   VarHOLE = kore[49]
   VarK1 = kore[73]
 config: kore[1383]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5667,9 +5393,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[73]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -5707,8 +5431,7 @@ hook: INT.sub (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1475]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5725,8 +5448,7 @@ rule: 2885 6
   VarHOLE = kore[50]
   VarK0 = kore[49]
 config: kore[1389]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5738,9 +5460,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[50]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -5772,8 +5492,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[64]
 hook result: kore[63]
 config: kore[1335]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5790,8 +5509,7 @@ rule: 2890 6
   VarHOLE = kore[49]
   VarK0 = kore[23]
 config: kore[1234]
-side condition: 2912 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5829,8 +5547,7 @@ rule: 2892 6
   VarB = kore[207]
   VarS = kore[482]
 config: kore[1605]
-side condition: 2915 1
-  VarHOLE = kore[207]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5850,8 +5567,7 @@ rule: 2915 6
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1701]
-side condition: 2894 1
-  VarHOLE = kore[154]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5869,8 +5585,7 @@ rule: 2894 4
   Var'Unds'DotVar2 = kore[1237]
   VarHOLE = kore[154]
 config: kore[1774]
-side condition: 2909 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5897,8 +5612,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1851]
-side condition: 2888 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5915,8 +5629,7 @@ rule: 2888 6
   VarHOLE = kore[49]
   VarK1 = kore[49]
 config: kore[1769]
-side condition: 2909 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -5928,9 +5641,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2910 2
-  VarHOLE = kore[49]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -5962,8 +5673,7 @@ hook: INT.le (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[68]
 config: kore[1719]
-side condition: 2880 1
-  Var'Unds'Gen3 = kore[55]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -5979,8 +5689,7 @@ rule: 2880 5
   Var'Unds'Gen3 = kore[55]
   VarHOLE = kore[54]
 config: kore[1668]
-side condition: 2894 1
-  VarHOLE = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6001,8 +5710,7 @@ hook: BOOL.not (0:0:0:0:0:0)
   arg: kore[68]
 hook result: kore[67]
 config: kore[1634]
-side condition: 2891 1
-  Var'Unds'Gen3 = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6020,8 +5728,7 @@ rule: 2891 7
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1569]
-side condition: 2915 1
-  VarHOLE = kore[53]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6066,8 +5773,7 @@ rule: 2914 5
   VarS1 = kore[227]
   VarS2 = kore[267]
 config: kore[1378]
-side condition: 2912 1
-  VarHOLE = kore[145]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6086,8 +5792,7 @@ rule: 2912 5
   VarHOLE = kore[145]
   VarK0 = kore[25]
 config: kore[1500]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6114,8 +5819,7 @@ rule: 2893 6
   VarI = kore[51]
   VarX = kore[25]
 config: kore[1588]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6132,8 +5836,7 @@ rule: 2884 6
   VarHOLE = kore[50]
   VarK1 = kore[48]
 config: kore[1502]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6145,9 +5848,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[48]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -6182,8 +5883,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1585]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6200,8 +5900,7 @@ rule: 2885 6
   VarHOLE = kore[49]
   VarK0 = kore[50]
 config: kore[1498]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6213,9 +5912,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[49]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -6247,8 +5944,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1447]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6265,8 +5961,7 @@ rule: 2890 6
   VarHOLE = kore[50]
   VarK0 = kore[25]
 config: kore[1344]
-side condition: 2912 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6296,8 +5991,7 @@ hook: MAP.concat (0:0:1:0)
     arg: kore[148]
 hook result: kore[242]
 config: kore[1262]
-side condition: 2912 1
-  VarHOLE = kore[185]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6316,8 +6010,7 @@ rule: 2912 5
   VarHOLE = kore[185]
   VarK0 = kore[23]
 config: kore[1385]
-side condition: 2903 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6344,8 +6037,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1483]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6362,8 +6054,7 @@ rule: 2884 6
   VarHOLE = kore[49]
   VarK1 = kore[73]
 config: kore[1383]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6375,9 +6066,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[73]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -6415,8 +6104,7 @@ hook: INT.sub (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1475]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6433,8 +6121,7 @@ rule: 2885 6
   VarHOLE = kore[50]
   VarK0 = kore[49]
 config: kore[1389]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6446,9 +6133,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[50]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -6480,8 +6165,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[64]
 hook result: kore[63]
 config: kore[1335]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6498,8 +6182,7 @@ rule: 2890 6
   VarHOLE = kore[49]
   VarK0 = kore[23]
 config: kore[1234]
-side condition: 2912 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6537,8 +6220,7 @@ rule: 2892 6
   VarB = kore[207]
   VarS = kore[482]
 config: kore[1605]
-side condition: 2915 1
-  VarHOLE = kore[207]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6558,8 +6240,7 @@ rule: 2915 6
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1701]
-side condition: 2894 1
-  VarHOLE = kore[154]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6577,8 +6258,7 @@ rule: 2894 4
   Var'Unds'DotVar2 = kore[1237]
   VarHOLE = kore[154]
 config: kore[1774]
-side condition: 2909 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6605,8 +6285,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1851]
-side condition: 2888 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6623,8 +6302,7 @@ rule: 2888 6
   VarHOLE = kore[49]
   VarK1 = kore[49]
 config: kore[1769]
-side condition: 2909 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6636,9 +6314,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2910 2
-  VarHOLE = kore[49]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -6670,8 +6346,7 @@ hook: INT.le (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[68]
 config: kore[1719]
-side condition: 2880 1
-  Var'Unds'Gen3 = kore[55]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6687,8 +6362,7 @@ rule: 2880 5
   Var'Unds'Gen3 = kore[55]
   VarHOLE = kore[54]
 config: kore[1668]
-side condition: 2894 1
-  VarHOLE = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6709,8 +6383,7 @@ hook: BOOL.not (0:0:0:0:0:0)
   arg: kore[68]
 hook result: kore[67]
 config: kore[1634]
-side condition: 2891 1
-  Var'Unds'Gen3 = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6728,8 +6401,7 @@ rule: 2891 7
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1569]
-side condition: 2915 1
-  VarHOLE = kore[53]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6774,8 +6446,7 @@ rule: 2914 5
   VarS1 = kore[227]
   VarS2 = kore[267]
 config: kore[1378]
-side condition: 2912 1
-  VarHOLE = kore[145]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6794,8 +6465,7 @@ rule: 2912 5
   VarHOLE = kore[145]
   VarK0 = kore[25]
 config: kore[1500]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6822,8 +6492,7 @@ rule: 2893 6
   VarI = kore[51]
   VarX = kore[25]
 config: kore[1588]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6840,8 +6509,7 @@ rule: 2884 6
   VarHOLE = kore[50]
   VarK1 = kore[48]
 config: kore[1502]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6853,9 +6521,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[48]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -6890,8 +6556,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1585]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6908,8 +6573,7 @@ rule: 2885 6
   VarHOLE = kore[49]
   VarK0 = kore[50]
 config: kore[1498]
-side condition: 2903 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -6921,9 +6585,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[49]
-  VarK0 = kore[50]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -6955,8 +6617,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1447]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -6973,8 +6634,7 @@ rule: 2890 6
   VarHOLE = kore[50]
   VarK0 = kore[25]
 config: kore[1344]
-side condition: 2912 1
-  VarHOLE = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -7004,8 +6664,7 @@ hook: MAP.concat (0:0:1:0)
     arg: kore[148]
 hook result: kore[242]
 config: kore[1262]
-side condition: 2912 1
-  VarHOLE = kore[185]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -7024,8 +6683,7 @@ rule: 2912 5
   VarHOLE = kore[185]
   VarK0 = kore[23]
 config: kore[1385]
-side condition: 2903 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -7052,8 +6710,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1482]
-side condition: 2884 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -7070,8 +6727,7 @@ rule: 2884 6
   VarHOLE = kore[49]
   VarK1 = kore[73]
 config: kore[1382]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -7083,9 +6739,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[73]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -7123,8 +6777,7 @@ hook: INT.sub (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[64]
 config: kore[1475]
-side condition: 2885 1
-  Var'Unds'Gen3 = kore[51]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -7141,8 +6794,7 @@ rule: 2885 6
   VarHOLE = kore[50]
   VarK0 = kore[49]
 config: kore[1389]
-side condition: 2903 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -7154,9 +6806,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2904 2
-  VarHOLE = kore[50]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -7188,8 +6838,7 @@ hook: INT.add (0:0:0:0:0:0)
     arg: kore[64]
 hook result: kore[63]
 config: kore[1335]
-side condition: 2890 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -7206,8 +6855,7 @@ rule: 2890 6
   VarHOLE = kore[49]
   VarK0 = kore[23]
 config: kore[1234]
-side condition: 2912 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -7245,8 +6893,7 @@ rule: 2892 6
   VarB = kore[207]
   VarS = kore[482]
 config: kore[1605]
-side condition: 2915 1
-  VarHOLE = kore[207]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -7266,8 +6913,7 @@ rule: 2915 6
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1701]
-side condition: 2894 1
-  VarHOLE = kore[154]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -7285,8 +6931,7 @@ rule: 2894 4
   Var'Unds'DotVar2 = kore[1237]
   VarHOLE = kore[154]
 config: kore[1774]
-side condition: 2909 1
-  VarHOLE = kore[48]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -7313,8 +6958,7 @@ rule: 2893 6
   VarI = kore[50]
   VarX = kore[23]
 config: kore[1850]
-side condition: 2888 1
-  Var'Unds'Gen3 = kore[50]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -7331,8 +6975,7 @@ rule: 2888 6
   VarHOLE = kore[49]
   VarK1 = kore[49]
 config: kore[1768]
-side condition: 2909 1
-  VarHOLE = kore[49]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -7344,9 +6987,7 @@ hook: BOOL.and (0)
   hook result: kore[68]
   arg: kore[68]
 hook result: kore[68]
-side condition: 2910 2
-  VarHOLE = kore[49]
-  VarK0 = kore[49]
+side condition
 hook: BOOL.and (0)
   hook: BOOL.and (0:0)
     function: LblisKResult{} (0:0:0)
@@ -7378,8 +7019,7 @@ hook: INT.le (0:0:0:0:0:0)
     arg: kore[63]
 hook result: kore[67]
 config: kore[1718]
-side condition: 2880 1
-  Var'Unds'Gen3 = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -7395,8 +7035,7 @@ rule: 2880 5
   Var'Unds'Gen3 = kore[54]
   VarHOLE = kore[53]
 config: kore[1667]
-side condition: 2894 1
-  VarHOLE = kore[53]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)
@@ -7417,8 +7056,7 @@ hook: BOOL.not (0:0:0:0:0:0)
   arg: kore[67]
 hook result: kore[68]
 config: kore[1635]
-side condition: 2891 1
-  Var'Unds'Gen3 = kore[55]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   function: LblisKResult{} (0:1)
@@ -7436,8 +7074,7 @@ rule: 2891 7
   VarK1 = kore[991]
   VarK2 = kore[44]
 config: kore[1570]
-side condition: 2915 1
-  VarHOLE = kore[54]
+side condition
 hook: BOOL.and (0)
   arg: kore[67]
   hook: BOOL.not (0:1)


### PR DESCRIPTION
This PR removes all the information previously carried by side condition events from the proof hint trace  because it has been determined that said information is redundant. It also bumps the proof hint trace version to 4. This is done according to the discussion in #957 .