### PR TITLE
update to python 3.10

### DIFF
--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -1,11 +1,11 @@
 { lib, src, cmake, flex, fmt, pkgconfig, llvm, libllvm, libcxxabi, stdenv, boost, gmp
-, jemalloc, libffi, libiconv, libyaml, mpfr, ncurses, python39, unixtools,
+, jemalloc, libffi, libiconv, libyaml, mpfr, ncurses, python310, unixtools,
 # Runtime dependencies:
 host,
 # Options:
 cmakeBuildType ? "FastBuild" # optimized release build, currently: LTO
 }:
-let python-env = (python39.withPackages (ps: with ps; [ pybind11 ])); in
+let python-env = (python310.withPackages (ps: with ps; [ pybind11 ])); in
 stdenv.mkDerivation {
   pname = "llvm-backend";
   version = "0";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -60,10 +60,10 @@ let
   # lib/python directory directly causes a provenance error when reading the
   # pyproject file.
   kllvm = prev.poetry2nix.mkPoetryApplication {
-    python = prev.python39;
+    python = prev.python310;
     projectDir = ../bindings/python/package;
     postInstall = ''
-      cp ${llvm-backend}/lib/python/kllvm/* $out/lib/python3.9/site-packages/kllvm/
+      cp ${llvm-backend}/lib/python/kllvm/* $out/lib/python3.10/site-packages/kllvm/
     '';
   };
 


### PR DESCRIPTION
In order to support seamless integration between the llvm backend and pyk on nix, we need to build the llvm backend with the same version of python that we use at runtime. The version we use at runtime, according to pyk's `pyproject.toml` file, is 3.10, so we update the version of python we use in the nix derivation for the llvm backend.