### PR TITLE
Fix formatting to use `clang-format` 15 rather than 17

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,6 +20,5 @@ SpaceBeforeCpp11BracedList: false
 DerivePointerAlignment: false
 PointerAlignment: Right
 ReflowComments: false
-QualifierAlignment: Custom
-QualifierOrder: ['static', 'constexpr', 'inline', 'friend', 'type', 'const', 'volatile', 'restrict']
+QualifierAlignment: Right
 ...

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -15,7 +15,7 @@ jobs:
       uses: jidicula/clang-format-action@v4.11.0
       with:
         exclude-regex: '(build|config|deps)'
-        clang-format-version: 17
+        clang-format-version: 15
 
   shell-check:
     name: Shell check

--- a/tools/k-rule-apply/auxiliar.h
+++ b/tools/k-rule-apply/auxiliar.h
@@ -65,8 +65,9 @@ void *printMatchResult(
   if (funcPtr == NULL) {
     return NULL;
   }
-  auto f = reinterpret_cast<void *(*)(std::ostream &, MatchLog *, size_t,
-                                      std::string const &)>(funcPtr);
+  auto f = reinterpret_cast<
+      void *(*)(std::ostream &, MatchLog *, size_t, std::string const &)>(
+      funcPtr);
   return f(os, log, logSize, dir);
 }
 


### PR DESCRIPTION
One of the options we were using is not supported on version 15; this PR drops back to an older version of the same option and updates the CI script that checks formatting.