### PR TITLE
Simplify nix overlay code

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -9,15 +9,7 @@ let
   llvmPackages =
     mkLlvmPackages prev."llvmPackages_${toString prev.llvm-version}";
 
-  clang = if !llvmPackages.stdenv.targetPlatform.isDarwin then
-    llvmPackages.clangNoLibcxx
-  else
-    llvmPackages.libcxxClang.overrideAttrs (old: {
-      # Hack from https://github.com/NixOS/nixpkgs/issues/166205 for macOS
-      postFixup = old.postFixup + ''
-        echo "-lc++abi" >> $out/nix-support/libcxx-ldflags
-      '';
-    });
+  clang = llvmPackages.clangNoLibcxx;
 
   llvm-backend = prev.callPackage ./llvm-backend.nix {
     inherit (llvmPackages) llvm libllvm libcxxabi;

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -17,15 +17,7 @@ let
       '';
     })
   else
-  # In llvmPackages_15/16, libcxx is broken, so we use clang 14 as our compiler
-  # for C code etc, but still use LLVM 15 to build the backend properly. This
-  # is a workaround until the underlying package is more stable on macOS.
-    let
-      clangPackages = if prev.llvm-version >= 15 then
-        mkLlvmPackages prev.llvmPackages_14
-      else
-        llvmPackages;
-    in clangPackages.libcxxClang.overrideAttrs (old: {
+    llvmPackages.libcxxClang.overrideAttrs (old: {
       # Hack from https://github.com/NixOS/nixpkgs/issues/166205 for macOS
       postFixup = old.postFixup + ''
         echo "-lc++abi" >> $out/nix-support/libcxx-ldflags

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -9,7 +9,15 @@ let
   llvmPackages =
     mkLlvmPackages prev."llvmPackages_${toString prev.llvm-version}";
 
-  clang = llvmPackages.clang;
+  clang = if !llvmPackages.stdenv.targetPlatform.isDarwin then
+    llvmPackages.clangNoLibcxx
+  else
+    llvmPackages.libcxxClang.overrideAttrs (old: {
+      # Hack from https://github.com/NixOS/nixpkgs/issues/166205 for macOS
+      postFixup = old.postFixup + ''
+        echo "-lc++abi" >> $out/nix-support/libcxx-ldflags
+      '';
+    });
 
   llvm-backend = prev.callPackage ./llvm-backend.nix {
     inherit (llvmPackages) llvm libllvm libcxxabi;


### PR DESCRIPTION
This PR cuts out a bunch of Nix code that we seemed to be using only for historical purposes related to old Nixpkgs bugs and older LLVM versions.