### PR TITLE
Switch out serializer backing storage vector for a `std::string`

### DIFF
--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -1010,7 +1010,7 @@ struct header_byte_t;
 #define VARIANT_HEADER(C, V)                                                   \
   template <>                                                                  \
   struct header_byte_t<C> {                                                    \
-    static constexpr std::byte value = std::byte(V);                           \
+    static constexpr char value = V;                                           \
   }
 
 VARIANT_HEADER(KORECompositePattern, 0x4);
@@ -1030,7 +1030,7 @@ VARIANT_HEADER(KOREVariable, 0xD);
  * header bytes.
  */
 template <typename T>
-constexpr inline std::byte header_byte = detail::header_byte_t<T>::value;
+constexpr inline char header_byte = detail::header_byte_t<T>::value;
 
 } // end namespace kllvm
 

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -219,8 +219,7 @@ private:
   // stream before peeking
   template <typename It>
   uint64_t peek_word(It const &it) {
-    return detail::from_bytes<uint64_t>(
-        reinterpret_cast<std::byte const *>(&*it));
+    return detail::from_bytes<uint64_t>(reinterpret_cast<char const *>(&*it));
   }
 
   template <typename It>
@@ -502,8 +501,7 @@ private:
 
   template <typename It>
   bool parse_argument(It &ptr, It end, LLVMEvent &event) {
-    if (std::distance(ptr, end) >= 1u
-        && detail::peek(ptr) == std::byte('\x7F')) {
+    if (std::distance(ptr, end) >= 1u && detail::peek(ptr) == '\x7F') {
       uint64_t pattern_len;
       auto kore_term = parse_kore_term(ptr, end, pattern_len);
       if (!kore_term) {

--- a/include/kllvm/binary/deserializer.h
+++ b/include/kllvm/binary/deserializer.h
@@ -16,17 +16,17 @@ namespace kllvm {
 namespace detail {
 
 template <typename It>
-std::byte peek(It const &it) {
-  return std::byte(*it);
+char peek(It const &it) {
+  return *it;
 }
 
 template <typename T>
-constexpr T from_bytes(std::byte const *ptr) {
+constexpr T from_bytes(char const *ptr) {
   auto ret = T{};
 
   if (is_big_endian()) {
     for (auto i = 0; i < sizeof(T); ++i) {
-      reinterpret_cast<std::byte *>(&ret)[sizeof(T) - i - 1] = ptr[i];
+      reinterpret_cast<char *>(&ret)[sizeof(T) - i - 1] = ptr[i];
     }
   } else {
     std::memcpy(&ret, ptr, sizeof(T));
@@ -39,7 +39,7 @@ template <typename T, typename It>
 T read(It &ptr, It end) {
   assert(ptr + sizeof(T) <= end);
 
-  auto val = from_bytes<T>(reinterpret_cast<std::byte const *>(&*ptr));
+  auto val = from_bytes<T>(reinterpret_cast<char const *>(&*ptr));
   ptr += sizeof(T);
   return val;
 }
@@ -87,7 +87,7 @@ uint64_t read_length(It &ptr, It end, binary_version version, int v1_bytes) {
       assert(steps < 9 && "No terminating byte in variable-length field");
 
       auto chunk = peek(ptr);
-      auto cont_bit = std::byte(0x80);
+      auto cont_bit = uint8_t{0x80};
       should_continue = static_cast<bool>(chunk & cont_bit);
 
       chunk = chunk & ~cont_bit;

--- a/include/kllvm/binary/serializer.h
+++ b/include/kllvm/binary/serializer.h
@@ -19,12 +19,12 @@ namespace detail {
 bool is_big_endian();
 
 template <typename T>
-std::array<std::byte, sizeof(T)> to_bytes(T val) {
-  auto bytes = std::array<std::byte, sizeof(T)>{};
+std::array<char, sizeof(T)> to_bytes(T val) {
+  auto bytes = std::array<char, sizeof(T)>{};
 
   if (is_big_endian()) {
     for (auto i = 0; i < sizeof(T); ++i) {
-      bytes[i] = reinterpret_cast<std::byte *>(&val)[sizeof(T) - i - 1];
+      bytes[i] = reinterpret_cast<char *>(&val)[sizeof(T) - i - 1];
     }
   } else {
     std::memcpy(bytes.data(), &val, sizeof(T));
@@ -61,7 +61,7 @@ public:
    * fundamental type. Any more complex types should be decomposed before being
    * written to the buffer.
    */
-  void emit(std::byte b);
+  void emit(char b);
 
   template <typename It>
   void emit(It begin, It end);
@@ -92,7 +92,7 @@ public:
    */
   void correct_emitted_size();
 
-  std::vector<std::byte> const &data() { return buffer_; }
+  std::string const &data() { return buffer_; }
 
   /**
    * Return a copy of the bytes currently stored by this serializer as a string,
@@ -117,9 +117,9 @@ private:
   bool use_header_;
   bool use_arity_;
 
-  std::vector<std::byte> buffer_;
-  std::byte direct_string_prefix_;
-  std::byte backref_string_prefix_;
+  std::string buffer_;
+  char direct_string_prefix_;
+  char backref_string_prefix_;
 
   uint64_t next_idx_;
   std::unordered_map<std::string, uint64_t> intern_table_;

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -50,7 +50,7 @@ void serializer::reset_arity_flag() {
 
 void serializer::emit_header_and_version() {
   for (auto b : magic_header) {
-    emit(std::byte(b));
+    emit(b);
   }
 
   emit(version.v_major);
@@ -72,7 +72,7 @@ void serializer::correct_emitted_size() {
   std::copy(bytes.begin(), bytes.end(), buffer_.begin() + header_prefix_length);
 }
 
-void serializer::emit(std::byte b) {
+void serializer::emit(char b) {
   buffer_.push_back(b);
   next_idx_++;
 }
@@ -128,7 +128,7 @@ void serializer::emit_direct_string(std::string const &s) {
   emit_length(s.size());
 
   for (auto c : s) {
-    emit(std::byte(c));
+    emit(c);
   }
 }
 

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -390,7 +390,7 @@ void serializeConfigurations(
 
   auto buf_size = state.instance.data().size();
   auto *buf = static_cast<char *>(malloc(buf_size));
-  std::memcpy(buf, state.instance.data().data(), buf_size);
+  std::copy_n(state.instance.data().begin(), buf_size, buf);
   fwrite(buf, 1, buf_size, file);
 
   free(buf);
@@ -424,7 +424,7 @@ void serializeConfiguration(
 
   auto size = state.instance.data().size();
   auto *buf = static_cast<char *>(malloc(size));
-  std::memcpy(buf, state.instance.data().data(), size);
+  std::copy_n(state.instance.data().begin(), size, buf);
 
   *data_out = buf;
   *size_out = size;


### PR DESCRIPTION
We would rather have a string here than a vector as it will allow for more efficient expansion and bulk copying when required (`std::vector` has to default-initialize when reserving capacity, while a string doesn't).