### PR TITLE
Precompute serialized symbols 

### DIFF
--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -354,6 +354,8 @@ char const *getReturnSortForTag(uint32_t tag);
 char const **getArgumentSortsForTag(uint32_t tag);
 char const *topSort(void);
 
+bool symbolIsInstantiation(uint32_t tag);
+
 typedef struct {
   void (*visitConfig)(writer *, block *, char const *, bool, void *);
   void (*visitMap)(

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -1315,6 +1315,29 @@ static void emitReturnSortTable(KOREDefinition *def, llvm::Module *mod) {
       getCharPtrDebugType(), def, mod, getter);
 }
 
+/*
+ * Emit a table that records whether the symbol corresponding to a particular
+ * tag has instantiated sort parameters. For example:
+ *
+ *   tag_of(inj{SortA{}, SortKItem{}}) |-> true
+ *   tag_of(someSymbol{})              |-> false
+ */
+static void emitSymbolIsInstantiation(KOREDefinition *def, llvm::Module *mod) {
+  auto getter = [](KOREDefinition *definition, llvm::Module *module,
+                   KORESymbol *symbol) -> llvm::Constant * {
+    auto &ctx = module->getContext();
+
+    auto *bool_ty = llvm::Type::getInt1Ty(ctx);
+
+    return llvm::ConstantInt::get(
+        bool_ty, !symbol->getFormalArguments().empty());
+  };
+
+  emitDataTableForSymbol(
+      "symbolIsInstantiation", llvm::Type::getInt1Ty(mod->getContext()),
+      getBoolDebugType(), def, mod, getter);
+}
+
 void emitConfigParserFunctions(
     KOREDefinition *definition, llvm::Module *module) {
   emitGetTagForSymbolName(definition, module);
@@ -1337,6 +1360,7 @@ void emitConfigParserFunctions(
 
   emitSortTable(definition, module);
   emitReturnSortTable(definition, module);
+  emitSymbolIsInstantiation(definition, module);
 }
 
 } // namespace kllvm


### PR DESCRIPTION
When a symbol has no formal sort parameters, we can directly look up its name in the interpreter's data tables and use a faster path for serialization (instead of parsing every symbol and doing a lookup in a hash table to get the sort arguments and name).

Fixes https://github.com/runtimeverification/llvm-backend/issues/974