### PR TITLE
Follow rv-tools Nixpkgs version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -154,17 +154,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1707490693,
+        "lastModified": 1707492220,
         "narHash": "sha256-KRndaUPzUumDlNcKF7KzA8F/EZKLYCvurh7Z13sw2PI=",
         "owner": "runtimeverification",
         "repo": "rv-nix-tools",
-        "rev": "f3e8bab938db9800044a94b94e59c5eba25977bc",
+        "rev": "abf86805a623948c941e603e2fc4c26a06ea6eb6",
         "type": "github"
       },
       "original": {
         "owner": "runtimeverification",
         "repo": "rv-nix-tools",
-        "rev": "f3e8bab938db9800044a94b94e59c5eba25977bc",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -95,6 +95,7 @@
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
+        "rev": "e2ffefe304d941bb98989847944f3b58e0adcdd5",
         "type": "github"
       }
     },
@@ -138,10 +139,33 @@
         "fmt-src": "fmt-src",
         "immer-src": "immer-src",
         "mavenix": "mavenix",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": [
+          "rv-utils",
+          "nixpkgs"
+        ],
         "pybind11-src": "pybind11-src",
         "rapidjson-src": "rapidjson-src",
+        "rv-utils": "rv-utils",
         "utils": "utils_2"
+      }
+    },
+    "rv-utils": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1707490693,
+        "narHash": "sha256-KRndaUPzUumDlNcKF7KzA8F/EZKLYCvurh7Z13sw2PI=",
+        "owner": "runtimeverification",
+        "repo": "rv-nix-tools",
+        "rev": "f3e8bab938db9800044a94b94e59c5eba25977bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "rv-nix-tools",
+        "rev": "f3e8bab938db9800044a94b94e59c5eba25977bc",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,9 @@
 
   inputs = {
     utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:nixos/nixpkgs";
+    rv-utils.url = "github:runtimeverification/rv-nix-tools/f3e8bab938db9800044a94b94e59c5eba25977bc";
+    nixpkgs.follows = "rv-utils/nixpkgs";
+
     fmt-src.url =
       "github:fmtlib/fmt/9.1.0";
     fmt-src.flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     utils.url = "github:numtide/flake-utils";
-    rv-utils.url = "github:runtimeverification/rv-nix-tools/f3e8bab938db9800044a94b94e59c5eba25977bc";
+    rv-utils.url = "github:runtimeverification/rv-nix-tools";
     nixpkgs.follows = "rv-utils/nixpkgs";
 
     fmt-src.url =


### PR DESCRIPTION
As discussed; the version pinned here is actually the version already being used by the backend.