### PR TITLE
Implement type-safe attributes

### DIFF
--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -125,11 +125,16 @@ void bind_ast(py::module_ &m) {
                 &KOREDeclaration::addObjectSortVariable)
             .def_property_readonly(
                 "object_sort_variables",
-                &KOREDeclaration::getObjectSortVariables);
-  // FIXME.ATT
-  /* .def("add_attribute", &KOREDeclaration::addAttribute) */
-  /* .def_property_readonly( */
-  /*     "attributes", &KOREDeclaration::getAttributes); */
+                &KOREDeclaration::getObjectSortVariables)
+            .def(
+                "add_attribute",
+                [](KOREDeclaration &decl,
+                   std::shared_ptr<KORECompositePattern> const &arg) {
+                  decl.attributes().add(arg);
+                })
+            .def_property_readonly("attributes", [](KOREDeclaration &decl) {
+              return decl.attributes().underlying();
+            });
 
   py::class_<
       KORECompositeSortDeclaration,
@@ -186,21 +191,31 @@ void bind_ast(py::module_ &m) {
       .def("__repr__", print_repr_adapter<KOREModule>())
       .def_property_readonly("name", &KOREModule::getName)
       .def("add_declaration", &KOREModule::addDeclaration)
-      .def_property_readonly("declarations", &KOREModule::getDeclarations);
-
-  // FIXME.ATT
-  /* .def("add_attribute", &KOREModule::addAttribute) */
-  /* .def_property_readonly("attributes", &KOREModule::getAttributes); */
+      .def_property_readonly("declarations", &KOREModule::getDeclarations)
+      .def(
+          "add_attribute",
+          [](KOREModule &decl,
+             std::shared_ptr<KORECompositePattern> const &arg) {
+            decl.attributes().add(arg);
+          })
+      .def_property_readonly("attributes", [](KOREModule &decl) {
+        return decl.attributes().underlying();
+      });
 
   py::class_<KOREDefinition, std::shared_ptr<KOREDefinition>>(ast, "Definition")
       .def(py::init(&KOREDefinition::Create))
       .def("__repr__", print_repr_adapter<KOREDefinition>())
       .def("add_module", &KOREDefinition::addModule)
-      .def_property_readonly("modules", &KOREDefinition::getModules);
-
-  // FIXME.ATT
-  /* .def("add_attribute", &KOREDefinition::addAttribute) */
-  /* .def_property_readonly("attributes", &KOREDefinition::getAttributes); */
+      .def_property_readonly("modules", &KOREDefinition::getModules)
+      .def(
+          "add_attribute",
+          [](KOREDefinition &decl,
+             std::shared_ptr<KORECompositePattern> const &arg) {
+            decl.attributes().add(arg);
+          })
+      .def_property_readonly("attributes", [](KOREDefinition &decl) {
+        return decl.attributes().underlying();
+      });
 
   /* Data Types */
 

--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -125,10 +125,11 @@ void bind_ast(py::module_ &m) {
                 &KOREDeclaration::addObjectSortVariable)
             .def_property_readonly(
                 "object_sort_variables",
-                &KOREDeclaration::getObjectSortVariables)
-            .def("add_attribute", &KOREDeclaration::addAttribute)
-            .def_property_readonly(
-                "attributes", &KOREDeclaration::getAttributes);
+                &KOREDeclaration::getObjectSortVariables);
+  // FIXME.ATT
+  /* .def("add_attribute", &KOREDeclaration::addAttribute) */
+  /* .def_property_readonly( */
+  /*     "attributes", &KOREDeclaration::getAttributes); */
 
   py::class_<
       KORECompositeSortDeclaration,
@@ -185,17 +186,21 @@ void bind_ast(py::module_ &m) {
       .def("__repr__", print_repr_adapter<KOREModule>())
       .def_property_readonly("name", &KOREModule::getName)
       .def("add_declaration", &KOREModule::addDeclaration)
-      .def_property_readonly("declarations", &KOREModule::getDeclarations)
-      .def("add_attribute", &KOREModule::addAttribute)
-      .def_property_readonly("attributes", &KOREModule::getAttributes);
+      .def_property_readonly("declarations", &KOREModule::getDeclarations);
+
+  // FIXME.ATT
+  /* .def("add_attribute", &KOREModule::addAttribute) */
+  /* .def_property_readonly("attributes", &KOREModule::getAttributes); */
 
   py::class_<KOREDefinition, std::shared_ptr<KOREDefinition>>(ast, "Definition")
       .def(py::init(&KOREDefinition::Create))
       .def("__repr__", print_repr_adapter<KOREDefinition>())
       .def("add_module", &KOREDefinition::addModule)
-      .def_property_readonly("modules", &KOREDefinition::getModules)
-      .def("add_attribute", &KOREDefinition::addAttribute)
-      .def_property_readonly("attributes", &KOREDefinition::getAttributes);
+      .def_property_readonly("modules", &KOREDefinition::getModules);
+
+  // FIXME.ATT
+  /* .def("add_attribute", &KOREDefinition::addAttribute) */
+  /* .def_property_readonly("attributes", &KOREDefinition::getAttributes); */
 
   /* Data Types */
 

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -1,6 +1,8 @@
 #ifndef AST_H
 #define AST_H
 
+#include <kllvm/ast/attribute_set.h>
+
 #include <boost/container_hash/extensions.hpp>
 
 #include <cassert>
@@ -671,17 +673,21 @@ private:
 // KOREDeclaration
 class KOREDeclaration {
 protected:
-  std::unordered_map<std::string, sptr<KORECompositePattern>> attributes;
+  attribute_set attributes_;
+  std::unordered_map<std::string, sptr<KORECompositePattern>> old_attributes;
   std::vector<sptr<KORESortVariable>> objectSortVariables;
 
 public:
+  attribute_set &attributes() { return attributes_; }
+  attribute_set const &attributes() const { return attributes_; }
+
   void addAttribute(sptr<KORECompositePattern> Attribute);
   void addObjectSortVariable(sptr<KORESortVariable> const &SortVariable);
   virtual void print(std::ostream &Out, unsigned indent = 0) const = 0;
 
   std::unordered_map<std::string, sptr<KORECompositePattern>> const &
   getAttributes() const {
-    return attributes;
+    return old_attributes;
   }
   std::vector<sptr<KORESortVariable>> const &getObjectSortVariables() const {
     return objectSortVariables;
@@ -834,12 +840,16 @@ class KOREModule {
 private:
   std::string name;
   std::vector<sptr<KOREDeclaration>> declarations;
-  std::unordered_map<std::string, sptr<KORECompositePattern>> attributes;
+  attribute_set attributes_;
+  std::unordered_map<std::string, sptr<KORECompositePattern>> old_attributes;
 
 public:
   static ptr<KOREModule> Create(std::string const &Name) {
     return ptr<KOREModule>(new KOREModule(Name));
   }
+
+  attribute_set &attributes() { return attributes_; }
+  attribute_set const &attributes() const { return attributes_; }
 
   void addAttribute(sptr<KORECompositePattern> Attribute);
   void addDeclaration(sptr<KOREDeclaration> Declaration);
@@ -848,7 +858,7 @@ public:
   std::string const &getName() const { return name; }
   std::unordered_map<std::string, sptr<KORECompositePattern>> const &
   getAttributes() const {
-    return attributes;
+    return old_attributes;
   }
   std::vector<sptr<KOREDeclaration>> const &getDeclarations() const {
     return declarations;
@@ -902,7 +912,9 @@ private:
   KOREAxiomMapType ordinals;
 
   std::vector<sptr<KOREModule>> modules;
-  std::unordered_map<std::string, sptr<KORECompositePattern>> attributes;
+  std::unordered_map<std::string, sptr<KORECompositePattern>> old_attributes;
+  attribute_set attributes_;
+
   /* an automatically computed list of all the axioms in the definition */
   std::list<KOREAxiomDeclaration *> axioms;
 
@@ -929,6 +941,9 @@ public:
      * sets the tag and layout fields on all the KORESymbols declared by the
      user in the definition. */
   void preprocess();
+
+  attribute_set &attributes() { return attributes_; }
+  attribute_set const &attributes() const { return attributes_; }
 
   void addModule(sptr<KOREModule> Module);
   void addAttribute(sptr<KORECompositePattern> Attribute);
@@ -988,7 +1003,7 @@ public:
   }
   std::unordered_map<std::string, sptr<KORECompositePattern>> const &
   getAttributes() const {
-    return attributes;
+    return old_attributes;
   }
   KORESymbolStringMapType const &getFreshFunctions() const {
     return freshFunctions;

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -690,8 +690,6 @@ public:
   }
   virtual ~KOREDeclaration() = default;
 
-  std::string getStringAttribute(std::string const &name) const;
-
 protected:
   void printSortVariables(std::ostream &Out) const;
 };

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -685,10 +685,6 @@ public:
   void addObjectSortVariable(sptr<KORESortVariable> const &SortVariable);
   virtual void print(std::ostream &Out, unsigned indent = 0) const = 0;
 
-  std::unordered_map<std::string, sptr<KORECompositePattern>> const &
-  getAttributes() const {
-    return old_attributes;
-  }
   std::vector<sptr<KORESortVariable>> const &getObjectSortVariables() const {
     return objectSortVariables;
   }
@@ -856,10 +852,6 @@ public:
   void print(std::ostream &Out, unsigned indent = 0) const;
 
   std::string const &getName() const { return name; }
-  std::unordered_map<std::string, sptr<KORECompositePattern>> const &
-  getAttributes() const {
-    return old_attributes;
-  }
   std::vector<sptr<KOREDeclaration>> const &getDeclarations() const {
     return declarations;
   }
@@ -1001,10 +993,6 @@ public:
   KOREAxiomDeclaration *getAxiomByOrdinal(size_t ordinal) const {
     return ordinals.at(ordinal);
   }
-  std::unordered_map<std::string, sptr<KORECompositePattern>> const &
-  getAttributes() const {
-    return old_attributes;
-  }
   KORESymbolStringMapType const &getFreshFunctions() const {
     return freshFunctions;
   }
@@ -1013,7 +1001,7 @@ public:
 
 void readMultimap(
     std::string const &, KORESymbolDeclaration *,
-    std::map<std::string, std::set<std::string>> &, std::string const &);
+    std::map<std::string, std::set<std::string>> &, attribute_set::key);
 
 sptr<KOREPattern> stripRawTerm(sptr<KOREPattern> const &term);
 

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -674,14 +674,12 @@ private:
 class KOREDeclaration {
 protected:
   attribute_set attributes_;
-  std::unordered_map<std::string, sptr<KORECompositePattern>> old_attributes;
   std::vector<sptr<KORESortVariable>> objectSortVariables;
 
 public:
   attribute_set &attributes() { return attributes_; }
   attribute_set const &attributes() const { return attributes_; }
 
-  void addAttribute(sptr<KORECompositePattern> Attribute);
   void addObjectSortVariable(sptr<KORESortVariable> const &SortVariable);
   virtual void print(std::ostream &Out, unsigned indent = 0) const = 0;
 
@@ -835,7 +833,6 @@ private:
   std::string name;
   std::vector<sptr<KOREDeclaration>> declarations;
   attribute_set attributes_;
-  std::unordered_map<std::string, sptr<KORECompositePattern>> old_attributes;
 
 public:
   static ptr<KOREModule> Create(std::string const &Name) {
@@ -845,7 +842,6 @@ public:
   attribute_set &attributes() { return attributes_; }
   attribute_set const &attributes() const { return attributes_; }
 
-  void addAttribute(sptr<KORECompositePattern> Attribute);
   void addDeclaration(sptr<KOREDeclaration> Declaration);
   void print(std::ostream &Out, unsigned indent = 0) const;
 
@@ -902,7 +898,6 @@ private:
   KOREAxiomMapType ordinals;
 
   std::vector<sptr<KOREModule>> modules;
-  std::unordered_map<std::string, sptr<KORECompositePattern>> old_attributes;
   attribute_set attributes_;
 
   /* an automatically computed list of all the axioms in the definition */
@@ -936,7 +931,6 @@ public:
   attribute_set const &attributes() const { return attributes_; }
 
   void addModule(sptr<KOREModule> Module);
-  void addAttribute(sptr<KORECompositePattern> Attribute);
   void print(std::ostream &Out, unsigned indent = 0) const;
 
   /*

--- a/include/kllvm/ast/attribute_set.h
+++ b/include/kllvm/ast/attribute_set.h
@@ -42,6 +42,8 @@ public:
     subsort,
     overload,
     fresh_generator,
+    priority,
+    terminals,
   };
 
   attribute_set() = default;

--- a/include/kllvm/ast/attribute_set.h
+++ b/include/kllvm/ast/attribute_set.h
@@ -104,7 +104,7 @@ public:
    *
    *   key_name{}("string data")
    *
-   * and extract the 
+   * and extract the string data in the pattern's argument.
    */
   std::string get_string(key k) const;
 

--- a/include/kllvm/ast/attribute_set.h
+++ b/include/kllvm/ast/attribute_set.h
@@ -14,7 +14,35 @@ class KORECompositePattern;
  */
 class attribute_set {
 public:
-  enum class key { hook };
+  enum class key {
+    source,
+    location,
+    hook,
+    function,
+    format,
+    assoc,
+    comm,
+    colors,
+    bracket,
+    anywhere,
+    binder,
+    concat,
+    unit,
+    element,
+    sort_injection,
+    label,
+    nat,
+    macro,
+    macro_rec,
+    alias,
+    alias_rec,
+    left,
+    right,
+    priorities,
+    subsort,
+    overload,
+    fresh_generator,
+  };
 
   attribute_set() = default;
 

--- a/include/kllvm/ast/attribute_set.h
+++ b/include/kllvm/ast/attribute_set.h
@@ -63,7 +63,8 @@ public:
    * The constructor name (`key_name` here) is parsed into a value of the `key`
    * enum; any unknown attribute names will be rejected.
    */
-  key add(std::shared_ptr<KORECompositePattern> att);
+  std::optional<attribute_set::key>
+  add(std::shared_ptr<KORECompositePattern> att);
 
   /**
    * Returns true if there is any attribute with the given key; the arguments of
@@ -89,8 +90,8 @@ public:
   std::string get_string(key k) const;
 
 private:
-  std::unordered_map<key, std::shared_ptr<KORECompositePattern>> attribute_map_
-      = {};
+  std::unordered_map<std::string, std::shared_ptr<KORECompositePattern>>
+      attribute_map_ = {};
 };
 
 } // namespace kllvm

--- a/include/kllvm/ast/attribute_set.h
+++ b/include/kllvm/ast/attribute_set.h
@@ -44,6 +44,13 @@ public:
     fresh_generator,
     priority,
     terminals,
+    idem,
+    functional,
+    constructor,
+    total,
+    ceil,
+    non_executable,
+    simplification,
   };
 
   attribute_set() = default;

--- a/include/kllvm/ast/attribute_set.h
+++ b/include/kllvm/ast/attribute_set.h
@@ -1,0 +1,61 @@
+#ifndef KLLVM_ATTRIBUTES_H
+#define KLLVM_ATTRIBUTES_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace kllvm {
+
+class KORECompositePattern;
+
+/**
+ * Type-safe wrapper around a set of KORE attribute patterns.
+ */
+class attribute_set {
+public:
+  enum class key { hook };
+
+  attribute_set() = default;
+
+  /**
+   * Accepts a composite pattern of the form:
+   *
+   *   key_name{}(args, ...)
+   *
+   * The constructor name (`key_name` here) is parsed into a value of the `key`
+   * enum; any unknown attribute names will be rejected.
+   */
+  key add(std::shared_ptr<KORECompositePattern> att);
+
+  /**
+   * Returns true if there is any attribute with the given key; the arguments of
+   * that attribute are not considered.
+   */
+  bool contains(key k) const;
+
+  /**
+   * Look up the attribute pattern with the specified key.
+   *
+   * This lookup is unchecked; use `.contains(k)` first if the attribute may not
+   * be present.
+   */
+  std::shared_ptr<KORECompositePattern> const &get(key k) const;
+
+  /**
+   * Look up an attribute with the specified key that has the form:
+   *
+   *   key_name{}("string data")
+   *
+   * and extract the 
+   */
+  std::string get_string(key k) const;
+
+private:
+  std::unordered_map<key, std::shared_ptr<KORECompositePattern>> attribute_map_
+      = {};
+};
+
+} // namespace kllvm
+
+#endif

--- a/include/kllvm/ast/attribute_set.h
+++ b/include/kllvm/ast/attribute_set.h
@@ -2,6 +2,7 @@
 #define KLLVM_ATTRIBUTES_H
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 

--- a/include/kllvm/codegen/Debug.h
+++ b/include/kllvm/codegen/Debug.h
@@ -17,9 +17,6 @@
 
 namespace kllvm {
 
-extern std::string SOURCE_ATT;
-extern std::string LOCATION_ATT;
-
 void initDebugInfo(llvm::Module *module, std::string const &filename);
 void finalizeDebugInfo(void);
 

--- a/include/kllvm/codegen/Debug.h
+++ b/include/kllvm/codegen/Debug.h
@@ -28,8 +28,7 @@ void initDebugFunction(
     llvm::DISubroutineType *type, KOREDefinition *definition,
     llvm::Function *func);
 
-void initDebugAxiom(
-    std::unordered_map<std::string, sptr<KORECompositePattern>> const &att);
+void initDebugAxiom(attribute_set const &att);
 void initDebugParam(
     llvm::Function *func, unsigned argNo, std::string const &name,
     ValueType type, std::string const &typeName);

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1269,14 +1269,6 @@ void KOREDeclaration::addObjectSortVariable(
   objectSortVariables.push_back(SortVariable);
 }
 
-std::string KOREDeclaration::getStringAttribute(std::string const &name) const {
-  KORECompositePattern *attr = old_attributes.at(name).get();
-  assert(attr->getArguments().size() == 1);
-  auto *strPattern
-      = dynamic_cast<KOREStringPattern *>(attr->getArguments()[0].get());
-  return strPattern->getContents();
-}
-
 void KOREAxiomDeclaration::addPattern(sptr<KOREPattern> Pattern) {
   pattern = std::move(Pattern);
 }

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1261,7 +1261,7 @@ bool KOREStringPattern::matches(
 
 void KOREDeclaration::addAttribute(sptr<KORECompositePattern> Attribute) {
   std::string name = Attribute->getConstructor()->getName();
-  attributes.insert({name, std::move(Attribute)});
+  old_attributes.insert({name, std::move(Attribute)});
 }
 
 void KOREDeclaration::addObjectSortVariable(
@@ -1270,7 +1270,7 @@ void KOREDeclaration::addObjectSortVariable(
 }
 
 std::string KOREDeclaration::getStringAttribute(std::string const &name) const {
-  KORECompositePattern *attr = attributes.at(name).get();
+  KORECompositePattern *attr = old_attributes.at(name).get();
   assert(attr->getArguments().size() == 1);
   auto *strPattern
       = dynamic_cast<KOREStringPattern *>(attr->getArguments()[0].get());
@@ -1294,12 +1294,13 @@ static std::string const NON_EXECUTABLE = "non-executable";
 static std::string const SIMPLIFICATION = "simplification";
 
 bool KOREAxiomDeclaration::isRequired() const {
-  return !attributes.count(ASSOC) && !attributes.count(COMM)
-         && !attributes.count(IDEM) && !attributes.count(UNIT)
-         && !attributes.count(FUNCTIONAL) && !attributes.count(CONSTRUCTOR)
-         && !attributes.count(TOTAL) && !attributes.count(SUBSORT)
-         && !attributes.count(CEIL) && !attributes.count(NON_EXECUTABLE)
-         && !attributes.count(SIMPLIFICATION);
+  return !old_attributes.count(ASSOC) && !old_attributes.count(COMM)
+         && !old_attributes.count(IDEM) && !old_attributes.count(UNIT)
+         && !old_attributes.count(FUNCTIONAL)
+         && !old_attributes.count(CONSTRUCTOR) && !old_attributes.count(TOTAL)
+         && !old_attributes.count(SUBSORT) && !old_attributes.count(CEIL)
+         && !old_attributes.count(NON_EXECUTABLE)
+         && !old_attributes.count(SIMPLIFICATION);
 }
 
 bool KOREAxiomDeclaration::isTopAxiom() const {
@@ -1355,7 +1356,7 @@ bool KORESymbolDeclaration::isAnywhere() const {
 
 void KOREModule::addAttribute(sptr<KORECompositePattern> Attribute) {
   std::string name = Attribute->getConstructor()->getName();
-  attributes.insert({name, std::move(Attribute)});
+  old_attributes.insert({name, std::move(Attribute)});
 }
 
 void KOREModule::addDeclaration(sptr<KOREDeclaration> Declaration) {
@@ -1488,7 +1489,7 @@ void KORECompositeSortDeclaration::print(
   Out << Indent << (_isHooked ? "hooked-sort " : "sort ") << sortName;
   printSortVariables(Out);
   Out << " ";
-  printAttributeList(Out, attributes);
+  printAttributeList(Out, old_attributes);
 }
 
 void KORESymbolDeclaration::print(std::ostream &Out, unsigned indent) const {
@@ -1508,7 +1509,7 @@ void KORESymbolDeclaration::print(std::ostream &Out, unsigned indent) const {
   Out << ") : ";
   symbol->getSort()->print(Out);
   Out << " ";
-  printAttributeList(Out, attributes);
+  printAttributeList(Out, old_attributes);
 }
 
 void KOREAliasDeclaration::print(std::ostream &Out, unsigned indent) const {
@@ -1531,7 +1532,7 @@ void KOREAliasDeclaration::print(std::ostream &Out, unsigned indent) const {
   Out << " := ";
   pattern->print(Out);
   Out << " ";
-  printAttributeList(Out, attributes);
+  printAttributeList(Out, old_attributes);
 }
 
 void KOREAxiomDeclaration::print(std::ostream &Out, unsigned indent) const {
@@ -1540,7 +1541,7 @@ void KOREAxiomDeclaration::print(std::ostream &Out, unsigned indent) const {
   printSortVariables(Out);
   pattern->print(Out);
   Out << " ";
-  printAttributeList(Out, attributes);
+  printAttributeList(Out, old_attributes);
 }
 
 void KOREModuleImportDeclaration::print(
@@ -1548,7 +1549,7 @@ void KOREModuleImportDeclaration::print(
   std::string Indent(indent, ' ');
   Out << Indent << "import " << moduleName;
   Out << " ";
-  printAttributeList(Out, attributes);
+  printAttributeList(Out, old_attributes);
 }
 
 void KOREModule::print(std::ostream &Out, unsigned indent) const {
@@ -1564,11 +1565,11 @@ void KOREModule::print(std::ostream &Out, unsigned indent) const {
     isFirst = false;
   }
   Out << Indent << "endmodule\n";
-  printAttributeList(Out, attributes, indent);
+  printAttributeList(Out, old_attributes, indent);
 }
 
 void KOREDefinition::print(std::ostream &Out, unsigned indent) const {
-  printAttributeList(Out, attributes, indent);
+  printAttributeList(Out, old_attributes, indent);
   Out << "\n";
   for (auto const &Module : modules) {
     Out << "\n";

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1430,18 +1430,17 @@ void KOREStringPattern::print(std::ostream &Out, unsigned indent) const {
 static void printAttributeList(
     std::ostream &Out, attribute_set const &attributes, unsigned indent = 0) {
 
-  // FIXME.ATT
-  /* std::string Indent(indent, ' '); */
-  /* Out << Indent << "["; */
-  /* bool isFirst = true; */
-  /* for (auto const &Pattern : attributes) { */
-  /*   if (!isFirst) { */
-  /*     Out << ","; */
-  /*   } */
-  /*   Pattern.second->print(Out); */
-  /*   isFirst = false; */
-  /* } */
-  /* Out << "]"; */
+  std::string Indent(indent, ' ');
+  Out << Indent << "[";
+  bool isFirst = true;
+  for (auto const &[name, pattern] : attributes) {
+    if (!isFirst) {
+      Out << ",";
+    }
+    pattern->print(Out);
+    isFirst = false;
+  }
+  Out << "]";
 }
 
 void KOREDeclaration::printSortVariables(std::ostream &Out) const {

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -162,8 +162,8 @@ ValueType KORECompositeSort::getCategory(KOREDefinition *definition) {
     if (auto *param = dynamic_cast<KORECompositeSort *>(arguments[0].get())) {
       auto const &att = definition->getSortDeclarations()
                             .at(param->getName())
-                            ->getAttributes();
-      auto const &natAtt = att.at("nat");
+                            ->attributes();
+      auto const &natAtt = att.get(attribute_set::key::nat);
       assert(natAtt->getArguments().size() == 1);
       auto *strPattern
           = dynamic_cast<KOREStringPattern *>(natAtt->getArguments()[0].get());
@@ -179,11 +179,11 @@ ValueType KORECompositeSort::getCategory(KOREDefinition *definition) {
 
 std::string KORECompositeSort::getHook(KOREDefinition *definition) const {
   auto const &att
-      = definition->getSortDeclarations().at(this->getName())->getAttributes();
-  if (!att.count("hook")) {
+      = definition->getSortDeclarations().at(this->getName())->attributes();
+  if (!att.contains(attribute_set::key::hook)) {
     return "STRING.String";
   }
-  auto const &hookAtt = att.at("hook");
+  auto const &hookAtt = att.get(attribute_set::key::hook);
   assert(hookAtt->getArguments().size() == 1);
   auto *strPattern
       = dynamic_cast<KOREStringPattern *>(hookAtt->getArguments()[0].get());
@@ -1130,8 +1130,8 @@ sptr<KOREPattern> KORECompositePattern::expandMacros(
 
   size_t i = 0;
   for (auto const &decl : macros) {
-    if ((decl->getAttributes().count("macro")
-         || decl->getAttributes().count("macro-rec"))
+    if ((decl->attributes().contains(attribute_set::key::macro)
+         || decl->attributes().contains(attribute_set::key::macro_rec))
         && reverse) {
       i++;
       continue;
@@ -1144,8 +1144,8 @@ sptr<KOREPattern> KORECompositePattern::expandMacros(
     substitution subst;
     bool matches = lhs->matches(subst, subsorts, overloads, applied);
     if (matches
-        && (decl->getAttributes().count("macro-rec")
-            || decl->getAttributes().count("alias-rec")
+        && (decl->attributes().contains(attribute_set::key::macro_rec)
+            || decl->attributes().contains(attribute_set::key::alias_rec)
             || !appliedRules.count(i))) {
       std::set<size_t> oldAppliedRules = appliedRules;
       appliedRules.insert(i);
@@ -1351,7 +1351,7 @@ KOREAliasDeclaration::getSubstitution(KORECompositePattern *subject) {
 }
 
 bool KORESymbolDeclaration::isAnywhere() const {
-  return getAttributes().count("anywhere");
+  return attributes().contains(attribute_set::key::anywhere);
 }
 
 void KOREModule::addAttribute(sptr<KORECompositePattern> Attribute) {
@@ -1641,9 +1641,9 @@ void KOREVariable::serialize_to(serializer &s) const {
 void kllvm::readMultimap(
     std::string const &name, KORESymbolDeclaration *decl,
     std::map<std::string, std::set<std::string>> &output,
-    std::string const &attName) {
-  if (decl->getAttributes().count(attName)) {
-    KORECompositePattern *att = decl->getAttributes().at(attName).get();
+    attribute_set::key attName) {
+  if (decl->attributes().contains(attName)) {
+    KORECompositePattern *att = decl->attributes().get(attName).get();
     for (auto const &pat : att->getArguments()) {
       auto *child = dynamic_cast<KORECompositePattern *>(pat.get());
       output[name].insert(child->getConstructor()->getName());

--- a/lib/ast/CMakeLists.txt
+++ b/lib/ast/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(AST
   AST.cpp
+  attribute_set.cpp
   pattern_matching.cpp
   definition.cpp
 )

--- a/lib/ast/attribute_set.cpp
+++ b/lib/ast/attribute_set.cpp
@@ -10,7 +10,7 @@ namespace {
 std::unordered_map<attribute_set::key, std::string> const &attribute_table() {
   static std::unordered_map<attribute_set::key, std::string> table = {
       {attribute_set::key::alias, "alias"},
-      {attribute_set::key::alias_rec, "alias_rec"},
+      {attribute_set::key::alias_rec, "alias-rec"},
       {attribute_set::key::anywhere, "anywhere"},
       {attribute_set::key::assoc, "assoc"},
       {attribute_set::key::binder, "binder"},
@@ -32,7 +32,7 @@ std::unordered_map<attribute_set::key, std::string> const &attribute_table() {
       {attribute_set::key::location,
        "org'Stop'kframework'Stop'attributes'Stop'Location"},
       {attribute_set::key::macro, "macro"},
-      {attribute_set::key::macro_rec, "macro_rec"},
+      {attribute_set::key::macro_rec, "macro-rec"},
       {attribute_set::key::nat, "nat"},
       {attribute_set::key::non_executable, "non-executable"},
       {attribute_set::key::overload, "overload"},

--- a/lib/ast/attribute_set.cpp
+++ b/lib/ast/attribute_set.cpp
@@ -7,7 +7,35 @@ namespace {
 
 attribute_set::key key_from_string(std::string const &str) {
   static std::unordered_map<std::string, attribute_set::key> table = {
+      {"org'Stop'kframework'Stop'attributes'Stop'Source",
+       attribute_set::key::source},
+      {"org'Stop'kframework'Stop'attributes'Stop'Location",
+       attribute_set::key::location},
       {"hook", attribute_set::key::hook},
+      {"function", attribute_set::key::function},
+      {"format", attribute_set::key::format},
+      {"assoc", attribute_set::key::assoc},
+      {"comm", attribute_set::key::comm},
+      {"colors", attribute_set::key::colors},
+      {"bracket", attribute_set::key::bracket},
+      {"anywhere", attribute_set::key::anywhere},
+      {"binder", attribute_set::key::binder},
+      {"concat", attribute_set::key::concat},
+      {"unit", attribute_set::key::unit},
+      {"element", attribute_set::key::element},
+      {"sortInjection", attribute_set::key::sort_injection},
+      {"label", attribute_set::key::label},
+      {"nat", attribute_set::key::nat},
+      {"macro", attribute_set::key::macro},
+      {"macro_rec", attribute_set::key::macro_rec},
+      {"alias", attribute_set::key::alias},
+      {"alias_rec", attribute_set::key::alias_rec},
+      {"left", attribute_set::key::left},
+      {"right", attribute_set::key::right},
+      {"priorities", attribute_set::key::priorities},
+      {"subsort", attribute_set::key::subsort},
+      {"overload", attribute_set::key::overload},
+      {"freshGenerator", attribute_set::key::fresh_generator},
   };
 
   return table.at(str);

--- a/lib/ast/attribute_set.cpp
+++ b/lib/ast/attribute_set.cpp
@@ -1,0 +1,44 @@
+#include <kllvm/ast/AST.h>
+#include <kllvm/ast/attribute_set.h>
+
+namespace kllvm {
+
+namespace {
+
+attribute_set::key key_from_string(std::string const &str) {
+  static std::unordered_map<std::string, attribute_set::key> table = {
+      {"hook", attribute_set::key::hook},
+  };
+
+  return table.at(str);
+}
+
+} // namespace
+
+attribute_set::key
+attribute_set::add(std::shared_ptr<KORECompositePattern> att) {
+  auto key = key_from_string(att->getConstructor()->getName());
+  attribute_map_.emplace(key, std::move(att));
+  return key;
+}
+
+bool attribute_set::contains(attribute_set::key k) const {
+  return attribute_map_.find(k) != attribute_map_.end();
+}
+
+std::shared_ptr<KORECompositePattern> const &
+attribute_set::get(attribute_set::key k) const {
+  return attribute_map_.at(k);
+}
+
+std::string attribute_set::get_string(attribute_set::key k) const {
+  auto const &attribute_pattern = get(k);
+  assert(attribute_pattern->getArguments().size() == 1);
+
+  auto const &string_arg = std::dynamic_pointer_cast<KOREStringPattern>(
+      attribute_pattern->getArguments()[0]);
+
+  return string_arg->getContents();
+}
+
+} // namespace kllvm

--- a/lib/ast/attribute_set.cpp
+++ b/lib/ast/attribute_set.cpp
@@ -38,6 +38,13 @@ attribute_set::key key_from_string(std::string const &str) {
       {"freshGenerator", attribute_set::key::fresh_generator},
       {"priority", attribute_set::key::priority},
       {"terminals", attribute_set::key::terminals},
+      {"idem", attribute_set::key::idem},
+      {"functional", attribute_set::key::functional},
+      {"constructor", attribute_set::key::constructor},
+      {"total", attribute_set::key::total},
+      {"ceil", attribute_set::key::ceil},
+      {"non-executable", attribute_set::key::non_executable},
+      {"simplification", attribute_set::key::simplification},
   };
 
   return table.at(str);

--- a/lib/ast/attribute_set.cpp
+++ b/lib/ast/attribute_set.cpp
@@ -9,44 +9,44 @@ namespace {
 
 std::unordered_map<attribute_set::key, std::string> const &attribute_table() {
   static std::unordered_map<attribute_set::key, std::string> table = {
-      {attribute_set::key::source,
-       "org'Stop'kframework'Stop'attributes'Stop'Source"},
-      {attribute_set::key::location,
-       "org'Stop'kframework'Stop'attributes'Stop'Location"},
-      {attribute_set::key::hook, "hook"},
-      {attribute_set::key::function, "function"},
-      {attribute_set::key::format, "format"},
-      {attribute_set::key::assoc, "assoc"},
-      {attribute_set::key::comm, "comm"},
-      {attribute_set::key::colors, "colors"},
-      {attribute_set::key::bracket, "bracket"},
-      {attribute_set::key::anywhere, "anywhere"},
-      {attribute_set::key::binder, "binder"},
-      {attribute_set::key::concat, "concat"},
-      {attribute_set::key::unit, "unit"},
-      {attribute_set::key::element, "element"},
-      {attribute_set::key::sort_injection, "sortInjection"},
-      {attribute_set::key::label, "label"},
-      {attribute_set::key::nat, "nat"},
-      {attribute_set::key::macro, "macro"},
-      {attribute_set::key::macro_rec, "macro_rec"},
       {attribute_set::key::alias, "alias"},
       {attribute_set::key::alias_rec, "alias_rec"},
-      {attribute_set::key::left, "left"},
-      {attribute_set::key::right, "right"},
-      {attribute_set::key::priorities, "priorities"},
-      {attribute_set::key::subsort, "subsort"},
-      {attribute_set::key::overload, "overload"},
-      {attribute_set::key::fresh_generator, "freshGenerator"},
-      {attribute_set::key::priority, "priority"},
-      {attribute_set::key::terminals, "terminals"},
-      {attribute_set::key::idem, "idem"},
-      {attribute_set::key::functional, "functional"},
-      {attribute_set::key::constructor, "constructor"},
-      {attribute_set::key::total, "total"},
+      {attribute_set::key::anywhere, "anywhere"},
+      {attribute_set::key::assoc, "assoc"},
+      {attribute_set::key::binder, "binder"},
+      {attribute_set::key::bracket, "bracket"},
       {attribute_set::key::ceil, "ceil"},
+      {attribute_set::key::colors, "colors"},
+      {attribute_set::key::comm, "comm"},
+      {attribute_set::key::concat, "concat"},
+      {attribute_set::key::constructor, "constructor"},
+      {attribute_set::key::element, "element"},
+      {attribute_set::key::format, "format"},
+      {attribute_set::key::fresh_generator, "freshGenerator"},
+      {attribute_set::key::function, "function"},
+      {attribute_set::key::functional, "functional"},
+      {attribute_set::key::hook, "hook"},
+      {attribute_set::key::idem, "idem"},
+      {attribute_set::key::label, "label"},
+      {attribute_set::key::left, "left"},
+      {attribute_set::key::location,
+       "org'Stop'kframework'Stop'attributes'Stop'Location"},
+      {attribute_set::key::macro, "macro"},
+      {attribute_set::key::macro_rec, "macro_rec"},
+      {attribute_set::key::nat, "nat"},
       {attribute_set::key::non_executable, "non-executable"},
+      {attribute_set::key::overload, "overload"},
+      {attribute_set::key::priorities, "priorities"},
+      {attribute_set::key::priority, "priority"},
+      {attribute_set::key::right, "right"},
       {attribute_set::key::simplification, "simplification"},
+      {attribute_set::key::sort_injection, "sortInjection"},
+      {attribute_set::key::source,
+       "org'Stop'kframework'Stop'attributes'Stop'Source"},
+      {attribute_set::key::subsort, "subsort"},
+      {attribute_set::key::terminals, "terminals"},
+      {attribute_set::key::total, "total"},
+      {attribute_set::key::unit, "unit"},
   };
   return table;
 }
@@ -97,6 +97,18 @@ std::string attribute_set::get_string(attribute_set::key k) const {
       attribute_pattern->getArguments()[0]);
 
   return string_arg->getContents();
+}
+
+attribute_set::storage_t const &attribute_set::underlying() const {
+  return attribute_map_;
+}
+
+attribute_set::storage_t::const_iterator attribute_set::begin() const {
+  return attribute_map_.cbegin();
+}
+
+attribute_set::storage_t::const_iterator attribute_set::end() const {
+  return attribute_map_.cend();
 }
 
 } // namespace kllvm

--- a/lib/ast/attribute_set.cpp
+++ b/lib/ast/attribute_set.cpp
@@ -1,71 +1,92 @@
 #include <kllvm/ast/AST.h>
 #include <kllvm/ast/attribute_set.h>
 
+#include <optional>
+
 namespace kllvm {
 
 namespace {
 
-attribute_set::key key_from_string(std::string const &str) {
-  static std::unordered_map<std::string, attribute_set::key> table = {
-      {"org'Stop'kframework'Stop'attributes'Stop'Source",
-       attribute_set::key::source},
-      {"org'Stop'kframework'Stop'attributes'Stop'Location",
-       attribute_set::key::location},
-      {"hook", attribute_set::key::hook},
-      {"function", attribute_set::key::function},
-      {"format", attribute_set::key::format},
-      {"assoc", attribute_set::key::assoc},
-      {"comm", attribute_set::key::comm},
-      {"colors", attribute_set::key::colors},
-      {"bracket", attribute_set::key::bracket},
-      {"anywhere", attribute_set::key::anywhere},
-      {"binder", attribute_set::key::binder},
-      {"concat", attribute_set::key::concat},
-      {"unit", attribute_set::key::unit},
-      {"element", attribute_set::key::element},
-      {"sortInjection", attribute_set::key::sort_injection},
-      {"label", attribute_set::key::label},
-      {"nat", attribute_set::key::nat},
-      {"macro", attribute_set::key::macro},
-      {"macro_rec", attribute_set::key::macro_rec},
-      {"alias", attribute_set::key::alias},
-      {"alias_rec", attribute_set::key::alias_rec},
-      {"left", attribute_set::key::left},
-      {"right", attribute_set::key::right},
-      {"priorities", attribute_set::key::priorities},
-      {"subsort", attribute_set::key::subsort},
-      {"overload", attribute_set::key::overload},
-      {"freshGenerator", attribute_set::key::fresh_generator},
-      {"priority", attribute_set::key::priority},
-      {"terminals", attribute_set::key::terminals},
-      {"idem", attribute_set::key::idem},
-      {"functional", attribute_set::key::functional},
-      {"constructor", attribute_set::key::constructor},
-      {"total", attribute_set::key::total},
-      {"ceil", attribute_set::key::ceil},
-      {"non-executable", attribute_set::key::non_executable},
-      {"simplification", attribute_set::key::simplification},
+std::unordered_map<attribute_set::key, std::string> const &attribute_table() {
+  static std::unordered_map<attribute_set::key, std::string> table = {
+      {attribute_set::key::source,
+       "org'Stop'kframework'Stop'attributes'Stop'Source"},
+      {attribute_set::key::location,
+       "org'Stop'kframework'Stop'attributes'Stop'Location"},
+      {attribute_set::key::hook, "hook"},
+      {attribute_set::key::function, "function"},
+      {attribute_set::key::format, "format"},
+      {attribute_set::key::assoc, "assoc"},
+      {attribute_set::key::comm, "comm"},
+      {attribute_set::key::colors, "colors"},
+      {attribute_set::key::bracket, "bracket"},
+      {attribute_set::key::anywhere, "anywhere"},
+      {attribute_set::key::binder, "binder"},
+      {attribute_set::key::concat, "concat"},
+      {attribute_set::key::unit, "unit"},
+      {attribute_set::key::element, "element"},
+      {attribute_set::key::sort_injection, "sortInjection"},
+      {attribute_set::key::label, "label"},
+      {attribute_set::key::nat, "nat"},
+      {attribute_set::key::macro, "macro"},
+      {attribute_set::key::macro_rec, "macro_rec"},
+      {attribute_set::key::alias, "alias"},
+      {attribute_set::key::alias_rec, "alias_rec"},
+      {attribute_set::key::left, "left"},
+      {attribute_set::key::right, "right"},
+      {attribute_set::key::priorities, "priorities"},
+      {attribute_set::key::subsort, "subsort"},
+      {attribute_set::key::overload, "overload"},
+      {attribute_set::key::fresh_generator, "freshGenerator"},
+      {attribute_set::key::priority, "priority"},
+      {attribute_set::key::terminals, "terminals"},
+      {attribute_set::key::idem, "idem"},
+      {attribute_set::key::functional, "functional"},
+      {attribute_set::key::constructor, "constructor"},
+      {attribute_set::key::total, "total"},
+      {attribute_set::key::ceil, "ceil"},
+      {attribute_set::key::non_executable, "non-executable"},
+      {attribute_set::key::simplification, "simplification"},
   };
+  return table;
+}
 
-  return table.at(str);
+std::string key_to_string(attribute_set::key key) {
+  return attribute_table().at(key);
+}
+
+std::optional<attribute_set::key> string_to_key(std::string const &name) {
+  static std::unordered_map<std::string, attribute_set::key> table = {};
+  if (table.empty()) {
+    auto const &reverse = attribute_table();
+    for (auto const &[k, str] : reverse) {
+      table.emplace(str, k);
+    }
+  }
+
+  if (table.find(name) != table.end()) {
+    return table.at(name);
+  }
+
+  return std::nullopt;
 }
 
 } // namespace
 
-attribute_set::key
+std::optional<attribute_set::key>
 attribute_set::add(std::shared_ptr<KORECompositePattern> att) {
-  auto key = key_from_string(att->getConstructor()->getName());
-  attribute_map_.emplace(key, std::move(att));
-  return key;
+  auto name = att->getConstructor()->getName();
+  attribute_map_.emplace(name, std::move(att));
+  return string_to_key(name);
 }
 
 bool attribute_set::contains(attribute_set::key k) const {
-  return attribute_map_.find(k) != attribute_map_.end();
+  return attribute_map_.find(key_to_string(k)) != attribute_map_.end();
 }
 
 std::shared_ptr<KORECompositePattern> const &
 attribute_set::get(attribute_set::key k) const {
-  return attribute_map_.at(k);
+  return attribute_map_.at(key_to_string(k));
 }
 
 std::string attribute_set::get_string(attribute_set::key k) const {

--- a/lib/ast/attribute_set.cpp
+++ b/lib/ast/attribute_set.cpp
@@ -36,6 +36,8 @@ attribute_set::key key_from_string(std::string const &str) {
       {"subsort", attribute_set::key::subsort},
       {"overload", attribute_set::key::overload},
       {"freshGenerator", attribute_set::key::fresh_generator},
+      {"priority", attribute_set::key::priority},
+      {"terminals", attribute_set::key::terminals},
   };
 
   return table.at(str);

--- a/lib/ast/definition.cpp
+++ b/lib/ast/definition.cpp
@@ -66,11 +66,6 @@ void KOREDefinition::addModule(sptr<KOREModule> Module) {
   modules.push_back(std::move(Module));
 }
 
-void KOREDefinition::addAttribute(sptr<KORECompositePattern> Attribute) {
-  std::string name = Attribute->getConstructor()->getName();
-  old_attributes.insert({name, std::move(Attribute)});
-}
-
 void KOREDefinition::insertReservedSymbols() {
   auto mod = KOREModule::Create("K-RAW-TERM");
   auto decl = KORESymbolDeclaration::Create("rawTerm", true);

--- a/lib/ast/definition.cpp
+++ b/lib/ast/definition.cpp
@@ -67,7 +67,7 @@ void KOREDefinition::addModule(sptr<KOREModule> Module) {
 
 void KOREDefinition::addAttribute(sptr<KORECompositePattern> Attribute) {
   std::string name = Attribute->getConstructor()->getName();
-  attributes.insert({name, std::move(Attribute)});
+  old_attributes.insert({name, std::move(Attribute)});
 }
 
 void KOREDefinition::insertReservedSymbols() {

--- a/lib/ast/definition.cpp
+++ b/lib/ast/definition.cpp
@@ -36,7 +36,8 @@ KOREDefinition::getSortsHookedTo(std::string const &hookName) const {
 
   for (auto const &[name, decl] : getSortDeclarations()) {
     if (decl->isHooked()) {
-      if (auto hook = decl->getStringAttribute("hook"); hook == hookName) {
+      if (auto hook = decl->attributes().get_string(attribute_set::key::hook);
+          hook == hookName) {
         ret.insert(name);
       }
     }

--- a/lib/ast/definition.cpp
+++ b/lib/ast/definition.cpp
@@ -86,8 +86,8 @@ SubsortMap KOREDefinition::getSubsorts() const {
   auto subsorts = SubsortMap{};
 
   for (auto *axiom : axioms) {
-    if (axiom->getAttributes().count("subsort")) {
-      auto const &att = axiom->getAttributes().at("subsort");
+    if (axiom->attributes().contains(attribute_set::key::subsort)) {
+      auto const &att = axiom->attributes().get(attribute_set::key::subsort);
       auto const &innerSort = att->getConstructor()->getFormalArguments()[0];
       auto const &outerSort = att->getConstructor()->getFormalArguments()[1];
       subsorts[innerSort.get()].insert(outerSort.get());
@@ -101,8 +101,8 @@ SymbolMap KOREDefinition::getOverloads() const {
   auto overloads = SymbolMap{};
 
   for (auto *axiom : axioms) {
-    if (axiom->getAttributes().count("overload")) {
-      auto const &att = axiom->getAttributes().at("overload");
+    if (axiom->attributes().contains(attribute_set::key::overload)) {
+      auto const &att = axiom->attributes().get(attribute_set::key::overload);
       auto *innerSymbol = std::dynamic_pointer_cast<KORECompositePattern>(
                               att->getArguments()[1])
                               ->getConstructor();
@@ -126,7 +126,8 @@ void KOREDefinition::preprocess() {
   auto symbols = std::map<std::string, std::vector<KORESymbol *>>{};
   unsigned nextOrdinal = 0;
   for (auto const &decl : symbolDeclarations) {
-    if (decl.second->getAttributes().count("freshGenerator")) {
+    if (decl.second->attributes().contains(
+            attribute_set::key::fresh_generator)) {
       auto sort = decl.second->getSymbol()->getSort();
       if (sort->isConcrete()) {
         freshFunctions[dynamic_cast<KORECompositeSort *>(sort.get())->getName()]
@@ -213,7 +214,7 @@ void KOREDefinition::preprocess() {
           symbol->firstTag = range.first;
           symbol->lastTag = range.second;
           auto *decl = symbolDeclarations.at(symbol->getName());
-          if (decl->getAttributes().count("sortInjection")) {
+          if (decl->attributes().contains(attribute_set::key::sort_injection)) {
             injSymbol = symbol;
           }
         }

--- a/lib/codegen/CreateStaticTerm.cpp
+++ b/lib/codegen/CreateStaticTerm.cpp
@@ -107,7 +107,7 @@ CreateStaticTerm::operator()(KOREPattern *pattern) {
     }
     KORESymbolDeclaration *symbolDecl
         = Definition->getSymbolDeclarations().at(symbol->getName());
-    if (symbolDecl->getAttributes().count("sortInjection")
+    if (symbolDecl->attributes().contains(attribute_set::key::sort_injection)
         && dynamic_cast<KORECompositeSort *>(symbol->getArguments()[0].get())
                    ->getCategory(Definition)
                    .cat

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -885,7 +885,6 @@ std::pair<llvm::Value *, bool> CreateTerm::createAllocation(
         auto *strPattern = dynamic_cast<KOREStringPattern *>(
             symbolDecl->attributes()
                 .get(attribute_set::key::hook)
-                .get()
                 ->getArguments()[0]
                 .get());
         std::string name = strPattern->getContents();

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1033,7 +1033,8 @@ bool makeFunction(
   /* initDebugAxiom(axiom->getAttributes()); */ // FIXME.ATT
   std::string debugName = name;
   if (axiom->attributes().contains(attribute_set::key::label)) {
-    debugName = axiom->getStringAttribute("label") + postfix;
+    debugName
+        = axiom->attributes().get_string(attribute_set::key::label) + postfix;
   }
   initDebugFunction(
       debugName, debugName,

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1030,7 +1030,7 @@ bool makeFunction(
   llvm::FunctionType *funcType
       = llvm::FunctionType::get(returnType, paramTypes, false);
   llvm::Function *applyRule = getOrInsertFunction(Module, name, funcType);
-  /* initDebugAxiom(axiom->getAttributes()); */ // FIXME.ATT
+  initDebugAxiom(axiom->attributes());
   std::string debugName = name;
   if (axiom->attributes().contains(attribute_set::key::label)) {
     debugName
@@ -1144,7 +1144,7 @@ std::string makeApplyRuleFunction(
       false, true, axiom, ".rhs");
 
   llvm::Function *applyRule = getOrInsertFunction(Module, name, funcType);
-  /* initDebugAxiom(axiom->getAttributes()); */ // FIXME.ATT
+  initDebugAxiom(axiom->attributes());
   initDebugFunction(
       name, name,
       getDebugFunctionType(

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -20,9 +20,6 @@
 
 namespace kllvm {
 
-std::string SOURCE_ATT = "org'Stop'kframework'Stop'attributes'Stop'Source";
-std::string LOCATION_ATT = "org'Stop'kframework'Stop'attributes'Stop'Location";
-
 static llvm::DIBuilder *Dbg;
 static llvm::DICompileUnit *DbgCU;
 static llvm::DIFile *DbgFile;

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -101,25 +101,25 @@ void initDebugGlobal(
   var->addDebugInfo(DbgExp);
 }
 
-void initDebugAxiom(
-    std::unordered_map<std::string, sptr<KORECompositePattern>> const &att) {
+void initDebugAxiom(attribute_set const &att) {
   if (!Dbg) {
     return;
   }
-  if (!att.count(SOURCE_ATT)) {
+  if (!att.contains(attribute_set::key::source)) {
     resetDebugLoc();
     return;
   }
-  KORECompositePattern *sourceAtt = att.at(SOURCE_ATT).get();
+  KORECompositePattern *sourceAtt = att.get(attribute_set::key::source).get();
   assert(sourceAtt->getArguments().size() == 1);
   auto *strPattern
       = dynamic_cast<KOREStringPattern *>(sourceAtt->getArguments()[0].get());
   std::string source = strPattern->getContents();
-  if (!att.count(LOCATION_ATT)) {
+  if (!att.contains(attribute_set::key::location)) {
     resetDebugLoc();
     return;
   }
-  KORECompositePattern *locationAtt = att.at(LOCATION_ATT).get();
+  KORECompositePattern *locationAtt
+      = att.get(attribute_set::key::location).get();
   assert(locationAtt->getArguments().size() == 1);
   auto *strPattern2
       = dynamic_cast<KOREStringPattern *>(locationAtt->getArguments()[0].get());

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -269,7 +269,7 @@ void SwitchNode::codegen(Decision *d) {
         auto *BlockPtr
             = llvm::PointerType::getUnqual(llvm::StructType::getTypeByName(
                 d->Module->getContext(), BLOCK_STRUCT));
-        if (symbolDecl->getAttributes().count("binder")) {
+        if (symbolDecl->attributes().contains(attribute_set::key::binder)) {
           if (offset == 0) {
             Renamed = llvm::CallInst::Create(
                 getOrInsertFunction(
@@ -446,7 +446,7 @@ void FunctionNode::codegen(Decision *d) {
     } else if (isSideCondition) {
       size_t ordinal = std::stoll(function.substr(15));
       KOREAxiomDeclaration *axiom = d->Definition->getAxiomByOrdinal(ordinal);
-      if (axiom->getAttributes().count("label")) {
+      if (axiom->attributes().contains(attribute_set::key::label)) {
         debugName = axiom->getStringAttribute("label") + ".sc";
       }
     }
@@ -757,9 +757,9 @@ void makeEvalOrAnywhereFunction(
       = llvm::FunctionType::get(returnType, args, false);
   std::string name = fmt::format("eval_{}", ast_to_string(*function, 0, false));
   llvm::Function *matchFunc = getOrInsertFunction(module, name, funcType);
-  KORESymbolDeclaration *symbolDecl
+  [[maybe_unused]] KORESymbolDeclaration *symbolDecl
       = definition->getSymbolDeclarations().at(function->getName());
-  initDebugAxiom(symbolDecl->getAttributes());
+  /* initDebugAxiom(symbolDecl->getAttributes()); */ // FIXME.ATT
   initDebugFunction(
       function->getName(), name,
       getDebugFunctionType(debugReturnType, debugArgs), definition, matchFunc);
@@ -1141,7 +1141,7 @@ void makeMatchReasonFunctionWrapper(
   llvm::Function *matchFunc
       = getOrInsertFunction(module, wrapperName, funcType);
   std::string debugName = name;
-  if (axiom->getAttributes().count("label")) {
+  if (axiom->attributes().contains(attribute_set::key::label)) {
     debugName = axiom->getStringAttribute("label") + "_tailcc_" + ".match";
   }
   auto *debugType
@@ -1171,7 +1171,7 @@ void makeMatchReasonFunction(
   std::string name = "intern_match_" + std::to_string(axiom->getOrdinal());
   llvm::Function *matchFunc = getOrInsertFunction(module, name, funcType);
   std::string debugName = name;
-  if (axiom->getAttributes().count("label")) {
+  if (axiom->attributes().contains(attribute_set::key::label)) {
     debugName = axiom->getStringAttribute("label") + ".match";
   }
   auto *debugType

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -447,7 +447,8 @@ void FunctionNode::codegen(Decision *d) {
       size_t ordinal = std::stoll(function.substr(15));
       KOREAxiomDeclaration *axiom = d->Definition->getAxiomByOrdinal(ordinal);
       if (axiom->attributes().contains(attribute_set::key::label)) {
-        debugName = axiom->getStringAttribute("label") + ".sc";
+        debugName
+            = axiom->attributes().get_string(attribute_set::key::label) + ".sc";
       }
     }
     std::vector<llvm::Value *> functionArgs;
@@ -1142,7 +1143,8 @@ void makeMatchReasonFunctionWrapper(
       = getOrInsertFunction(module, wrapperName, funcType);
   std::string debugName = name;
   if (axiom->attributes().contains(attribute_set::key::label)) {
-    debugName = axiom->getStringAttribute("label") + "_tailcc_" + ".match";
+    debugName = axiom->attributes().get_string(attribute_set::key::label)
+                + "_tailcc_" + ".match";
   }
   auto *debugType
       = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
@@ -1172,7 +1174,8 @@ void makeMatchReasonFunction(
   llvm::Function *matchFunc = getOrInsertFunction(module, name, funcType);
   std::string debugName = name;
   if (axiom->attributes().contains(attribute_set::key::label)) {
-    debugName = axiom->getStringAttribute("label") + ".match";
+    debugName
+        = axiom->attributes().get_string(attribute_set::key::label) + ".match";
   }
   auto *debugType
       = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -760,7 +760,7 @@ void makeEvalOrAnywhereFunction(
   llvm::Function *matchFunc = getOrInsertFunction(module, name, funcType);
   [[maybe_unused]] KORESymbolDeclaration *symbolDecl
       = definition->getSymbolDeclarations().at(function->getName());
-  /* initDebugAxiom(symbolDecl->getAttributes()); */ // FIXME.ATT
+  initDebugAxiom(symbolDecl->attributes());
   initDebugFunction(
       function->getName(), name,
       getDebugFunctionType(debugReturnType, debugArgs), definition, matchFunc);

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -195,8 +195,8 @@ static void emitDataForSymbol(
     uint32_t tag = entry.first;
     auto *symbol = entry.second;
     auto *decl = definition->getSymbolDeclarations().at(symbol->getName());
-    bool isFunc = decl->getAttributes().count("function")
-                  || decl->getAttributes().count("anywhere");
+    bool isFunc = decl->attributes().contains(attribute_set::key::function)
+                  || decl->attributes().contains(attribute_set::key::anywhere);
     if (isEval && !isFunc) {
       continue;
     }
@@ -234,8 +234,8 @@ static std::pair<llvm::Value *, llvm::BasicBlock *> getFunction(
     KOREDefinition *def, llvm::Module *mod, KORESymbol *symbol,
     llvm::Instruction *inst) {
   auto *decl = def->getSymbolDeclarations().at(symbol->getName());
-  bool res = decl->getAttributes().count("function")
-             || decl->getAttributes().count("anywhere");
+  bool res = decl->attributes().contains(attribute_set::key::function)
+             || decl->attributes().contains(attribute_set::key::anywhere);
   return std::make_pair(
       llvm::ConstantInt::get(llvm::Type::getInt1Ty(mod->getContext()), res),
       inst->getParent());
@@ -250,7 +250,7 @@ static void emitIsSymbolAFunction(KOREDefinition *def, llvm::Module *mod) {
 static llvm::Constant *
 getBinder(KOREDefinition *def, llvm::Module *mod, KORESymbol *symbol) {
   auto *decl = def->getSymbolDeclarations().at(symbol->getName());
-  bool res = decl->getAttributes().count("binder");
+  bool res = decl->attributes().contains(attribute_set::key::binder);
   return llvm::ConstantInt::get(llvm::Type::getInt1Ty(mod->getContext()), res);
 }
 
@@ -875,22 +875,22 @@ static void visitCollection(
   auto *sortDecl
       = definition->getSortDeclarations().at(compositeSort->getName());
   llvm::Constant *concatPtr = nullptr;
-  if (sortDecl->getAttributes().count("concat")) {
-    auto *concat = (KORECompositePattern *)sortDecl->getAttributes()
-                       .at("concat")
+  if (sortDecl->attributes().contains(attribute_set::key::concat)) {
+    auto *concat = (KORECompositePattern *)sortDecl->attributes()
+                       .get(attribute_set::key::concat)
                        ->getArguments()[0]
                        .get();
     concatPtr = getSymbolNamePtr(concat->getConstructor(), nullptr, module);
   } else {
     concatPtr = llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(Ctx));
   }
-  auto *unit = (KORECompositePattern *)sortDecl->getAttributes()
-                   .at("unit")
+  auto *unit = (KORECompositePattern *)sortDecl->attributes()
+                   .get(attribute_set::key::unit)
                    ->getArguments()[0]
                    .get();
   auto *unitPtr = getSymbolNamePtr(unit->getConstructor(), nullptr, module);
-  auto *element = (KORECompositePattern *)sortDecl->getAttributes()
-                      .at("element")
+  auto *element = (KORECompositePattern *)sortDecl->attributes()
+                      .get(attribute_set::key::element)
                       ->getArguments()[0]
                       .get();
   auto *elementPtr

--- a/lib/parser/KOREParser.cpp
+++ b/lib/parser/KOREParser.cpp
@@ -105,11 +105,11 @@ void KOREParser::attributes(Node *node) {
 template <typename Node>
 void KOREParser::attributesNE(Node *node) {
   auto pat = _applicationPattern();
-  node->addAttribute(std::move(pat));
+  node->attributes().add(std::move(pat));
   while (peek() == token::COMMA) {
     consume(token::COMMA);
     pat = _applicationPattern();
-    node->addAttribute(std::move(pat));
+    node->attributes().add(std::move(pat));
   }
 }
 

--- a/lib/printer/printer.cpp
+++ b/lib/printer/printer.cpp
@@ -260,8 +260,10 @@ PreprocessedPrintData getPrintData(
     std::string name = entry.first;
 
     if (entry.second->attributes().contains(attribute_set::key::format)) {
-      formats[name] = entry.second->getStringAttribute("format");
-      terminals[name] = entry.second->getStringAttribute("terminals");
+      formats[name]
+          = entry.second->attributes().get_string(attribute_set::key::format);
+      terminals[name] = entry.second->attributes().get_string(
+          attribute_set::key::terminals);
 
       if (entry.second->attributes().contains(attribute_set::key::assoc)) {
         assocs.insert(name);
@@ -271,7 +273,8 @@ PreprocessedPrintData getPrintData(
       }
 
       if (entry.second->attributes().contains(attribute_set::key::colors)) {
-        std::string colorAtt = entry.second->getStringAttribute("colors");
+        std::string colorAtt
+            = entry.second->attributes().get_string(attribute_set::key::colors);
         std::vector<std::string> color;
         size_t idx = 0;
         do {
@@ -302,7 +305,8 @@ PreprocessedPrintData getPrintData(
   for (auto const &entry : def->getSortDeclarations()) {
     std::string name = entry.first;
     if (entry.second->attributes().contains(attribute_set::key::hook)) {
-      hooks[name] = entry.second->getStringAttribute("hook");
+      hooks[name]
+          = entry.second->attributes().get_string(attribute_set::key::hook);
     }
   }
 

--- a/lib/printer/printer.cpp
+++ b/lib/printer/printer.cpp
@@ -259,18 +259,18 @@ PreprocessedPrintData getPrintData(
   for (auto const &entry : def->getSymbolDeclarations()) {
     std::string name = entry.first;
 
-    if (entry.second->getAttributes().count("format")) {
+    if (entry.second->attributes().contains(attribute_set::key::format)) {
       formats[name] = entry.second->getStringAttribute("format");
       terminals[name] = entry.second->getStringAttribute("terminals");
 
-      if (entry.second->getAttributes().count("assoc")) {
+      if (entry.second->attributes().contains(attribute_set::key::assoc)) {
         assocs.insert(name);
       }
-      if (entry.second->getAttributes().count("comm")) {
+      if (entry.second->attributes().contains(attribute_set::key::comm)) {
         comms.insert(name);
       }
 
-      if (entry.second->getAttributes().count("colors")) {
+      if (entry.second->attributes().contains(attribute_set::key::colors)) {
         std::string colorAtt = entry.second->getStringAttribute("colors");
         std::vector<std::string> color;
         size_t idx = 0;
@@ -287,20 +287,21 @@ PreprocessedPrintData getPrintData(
         colors[name] = color;
       }
 
-      if (entry.second->getAttributes().count("bracket")) {
+      if (entry.second->attributes().contains(attribute_set::key::bracket)) {
         brackets[entry.second->getSymbol()->getSort().get()].push_back(
             entry.second->getSymbol());
       }
 
-      readMultimap(name, entry.second, leftAssoc, "left");
-      readMultimap(name, entry.second, rightAssoc, "right");
-      readMultimap(name, entry.second, priorities, "priorities");
+      readMultimap(name, entry.second, leftAssoc, attribute_set::key::left);
+      readMultimap(name, entry.second, rightAssoc, attribute_set::key::right);
+      readMultimap(
+          name, entry.second, priorities, attribute_set::key::priorities);
     }
   }
 
   for (auto const &entry : def->getSortDeclarations()) {
     std::string name = entry.first;
-    if (entry.second->getAttributes().count("hook")) {
+    if (entry.second->attributes().contains(attribute_set::key::hook)) {
       hooks[name] = entry.second->getStringAttribute("hook");
     }
   }

--- a/tools/k-rule-apply/main.cpp
+++ b/tools/k-rule-apply/main.cpp
@@ -32,7 +32,8 @@ std::optional<std::string> getMatchFunctionName() {
     // Check if the current axiom has the attribute label.
     if (axiom->attributes().contains(attribute_set::key::label)) {
       // Compare the axiom's label with the given rule label.
-      if (RuleLabel == axiom->getStringAttribute("label")) {
+      if (RuleLabel
+          == axiom->attributes().get_string(attribute_set::key::label)) {
         return "intern_match_" + std::to_string(axiom->getOrdinal());
       }
     }

--- a/tools/k-rule-apply/main.cpp
+++ b/tools/k-rule-apply/main.cpp
@@ -29,15 +29,11 @@ std::optional<std::string> getMatchFunctionName() {
 
   // Iterate through axioms and return the one with the give rulen label if exits.
   for (auto *axiom : kore_ast.get()->getAxioms()) {
-    if (!axiom->getAttributes().empty()) {
-      // Check if the current axiom has the attribute label.
-      auto attr = axiom->getAttributes().find("label");
-
-      if (attr != axiom->getAttributes().end()) {
-        // Compare the axiom's label with the given rule label.
-        if (RuleLabel == axiom->getStringAttribute("label")) {
-          return "intern_match_" + std::to_string(axiom->getOrdinal());
-        }
+    // Check if the current axiom has the attribute label.
+    if (axiom->attributes().contains(attribute_set::key::label)) {
+      // Compare the axiom's label with the given rule label.
+      if (RuleLabel == axiom->getStringAttribute("label")) {
+        return "intern_match_" + std::to_string(axiom->getOrdinal());
       }
     }
   }

--- a/tools/k-rule-find/main.cpp
+++ b/tools/k-rule-find/main.cpp
@@ -117,7 +117,8 @@ int main(int argc, char **argv) {
       if (source.find(loc.filename) != std::string::npos) {
         auto source_loc = getLocation(axiom);
         if (checkRanges(loc, source_loc, loc.start_column != -1)) {
-          rule_labels.push_back(axiom->getStringAttribute("label"));
+          rule_labels.push_back(
+              axiom->attributes().get_string(attribute_set::key::label));
         }
       }
     }

--- a/tools/k-rule-find/main.cpp
+++ b/tools/k-rule-find/main.cpp
@@ -29,7 +29,7 @@ cl::opt<std::string> RuleLocation(
     cl::cat(KRuleCat));
 
 std::string getSource(KOREAxiomDeclaration *axiom) {
-  auto *sourceAtt = axiom->getAttributes().at(SOURCE_ATT).get();
+  auto *sourceAtt = axiom->attributes().get(attribute_set::key::source).get();
   assert(sourceAtt->getArguments().size() == 1);
 
   auto *strPattern
@@ -38,7 +38,8 @@ std::string getSource(KOREAxiomDeclaration *axiom) {
 }
 
 Location getLocation(KOREAxiomDeclaration *axiom) {
-  auto *locationAtt = axiom->getAttributes().at(LOCATION_ATT).get();
+  auto *locationAtt
+      = axiom->attributes().get(attribute_set::key::location).get();
   assert(locationAtt->getArguments().size() == 1);
 
   auto *strPattern
@@ -111,7 +112,7 @@ int main(int argc, char **argv) {
 
   // Iterate through axioms.
   for (auto *axiom : kore_ast.get()->getAxioms()) {
-    if (axiom->getAttributes().count(SOURCE_ATT)) {
+    if (axiom->attributes().contains(attribute_set::key::source)) {
       auto source = getSource(axiom);
       if (source.find(loc.filename) != std::string::npos) {
         auto source_loc = getLocation(axiom);

--- a/tools/kore-expand-macros/main.cpp
+++ b/tools/kore-expand-macros/main.cpp
@@ -34,8 +34,10 @@ int main(int argc, char **argv) {
   std::sort(
       axioms.begin(), axioms.end(),
       [](ptr<KOREDeclaration> const &l, ptr<KOREDeclaration> const &r) {
-        std::string lStr = l->getStringAttribute("priority");
-        std::string rStr = r->getStringAttribute("priority");
+        std::string lStr
+            = l->attributes().get_string(attribute_set::key::priority);
+        std::string rStr
+            = r->attributes().get_string(attribute_set::key::priority);
         int lInt = std::stoi(lStr);
         int rInt = std::stoi(rStr);
         return lInt < rInt;

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -198,7 +198,8 @@ int main(int argc, char **argv) {
   for (auto const &entry : definition->getSymbols()) {
     auto *symbol = entry.second;
     auto *decl = definition->getSymbolDeclarations().at(symbol->getName());
-    if (decl->getAttributes().count("function") && !decl->isHooked()) {
+    if (decl->attributes().contains(attribute_set::key::function)
+        && !decl->isHooked()) {
       auto filename = get_indexed_filename(index, decl);
       auto *funcDt = parseYamlDecisionTree(
           mod.get(), filename, definition->getAllSymbols(),


### PR DESCRIPTION
This PR implements a more limited version of the type-safe attribute infrastructure that we use in the K frontend; by doing so we can construct a canonical list of the attributes that we _actually_ use in the backend, and avoid working with string data when we don't need to be.

The core of the change is a new `attribute_set` structure that _accepts_ attributes permissively from the parser, but only allows key-value lookup via a limited set of whitelisted attribute keys. There are a couple of places in the code that need to access the full set of attributes, ignoring the whitelist:
* When pretty-printing via iteration over the set of stored attributes
* When returning the set of attributes to Pyk via the Python bindings

Both of these code paths have comments to make sure they are used cautiously.

The bulk of the changes are 1:1 and can be reviewed pretty easily in the split diff; there's only a small API change in code that consumes attributes in the backend.

There is a small papercut in that the syntax to reference an attribute key is quite verbose (`attribute_set::key::name`); when we upgrade to C++20 in the near future we get access to `using enum attribute_set::key;` which solves this problem and makes the code nicer to read.

I've tested the change upstream against the K integration test suite.