### PR TITLE
Replace usages of `priorities`, `require`, and `import`

### DIFF
--- a/test/defn/k-files/lambda-anywhere.k
+++ b/test/defn/k-files/lambda-anywhere.k
@@ -1,6 +1,6 @@
 // Copyright (c) K Team. All Rights Reserved.
 
-require "substitution.md"
+requires "substitution.md"
 
 module LAMBDA-SYNTAX
   imports DOMAINS-SYNTAX

--- a/test/defn/k-files/lambda.md
+++ b/test/defn/k-files/lambda.md
@@ -51,7 +51,7 @@ below.  Then we should make sure we import its module called SUBSTITUTION
 in our LAMBDA module below.
 
 ```k
-require "substitution.md"
+requires "substitution.md"
 
 module LAMBDA-SYNTAX
   imports DOMAINS-SYNTAX

--- a/test/defn/k-files/test21.md
+++ b/test/defn/k-files/test21.md
@@ -18,7 +18,7 @@ for arithmetic and Boolean expressions, and variable assignment,
 conditional, while loop and sequential composition constructs for statements.
 
 ```k
-require "ffi.md"
+requires "ffi.md"
 module TEST-SYNTAX
   imports DOMAINS-SYNTAX
   imports BASIC-K

--- a/test/defn/k-files/wasm-maps.k
+++ b/test/defn/k-files/wasm-maps.k
@@ -31,7 +31,7 @@ module MAP-INT-TO-INT
 
   syntax MapIntToInt ::= MapIntToInt "[" key: WrappedInt "<-" value: WrappedInt "]" [function, total, klabel(MapInt2Int:update), symbol, hook(MAP.update), prefer]
 
-  syntax priorities _Int2Int|->_ > _MapIntToInt_ .MapIntToInt
+  syntax priority _Int2Int|->_ > _MapIntToInt_ .MapIntToInt
   syntax non-assoc _Int2Int|->_
 
   syntax MapIntToInt ::= MapIntToInt "{{" key: Int "<-" value: Int "}}"
@@ -61,7 +61,7 @@ module MAP-INT-TO-VAL
 
   syntax MapIntToVal ::= MapIntToVal "[" key: WrappedInt "<-" value: Val "]" [function, total, klabel(MapInt2Val:update), symbol, hook(MAP.update), prefer]
 
-  syntax priorities _Int2Val|->_ > _MapIntToVal_ .MapIntToVal
+  syntax priority _Int2Val|->_ > _MapIntToVal_ .MapIntToVal
   syntax non-assoc _Int2Val|->_
 
   syntax MapIntToVal ::= MapIntToVal "{{" key: Int "<-" value: Val "}}"


### PR DESCRIPTION
Part of runtimeverification/k#4009

Replace usages of deprecated tokens:

- `syntax priorities` with `syntax priority`
- `require` with `requires`
- `import` with `imports`