### PR TITLE
Support Java 17 in `matching`

### DIFF
--- a/matching/pom.xml
+++ b/matching/pom.xml
@@ -92,6 +92,12 @@
             <arg>-language:implicitConversions</arg>
             <arg>-language:postfixOps</arg>
           </args>
+	  <javacArgs>
+            <javacArg>-source</javacArg>
+            <javacArg>${java.version}</javacArg>
+            <javacArg>-target</javacArg>
+            <javacArg>${java.version}</javacArg>
+          </javacArgs>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This PR sets the Java version for `scala-maven-plugin` based on the parent POM.

Blocked on runtimeverification/k#4032