### PR TITLE
Run `clang-tidy` on headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,7 @@ Checks:
   -bugprone-exception-escape
   -bugprone-implicit-widening-of-multiplication-result
   -bugprone-unchecked-optional-access
+  -bugprone-lambda-function-name
   cppcoreguidelines-*
   -cppcoreguidelines-avoid-magic-numbers
   -cppcoreguidelines-avoid-non-const-global-variables

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -43,3 +43,5 @@ CheckOptions:
     value: true
   - key: 'cppcoreguidelines-macro-usage.CheckCapsOnly'
     value: true
+  - key: 'cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor'
+    value: true

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -103,22 +103,22 @@ public:
     return sptr<KORESortVariable>(new KORESortVariable(Name));
   }
 
-  virtual bool isConcrete() const override { return false; }
-  virtual sptr<KORESort> substitute(substitution const &subst) override {
+  bool isConcrete() const override { return false; }
+  sptr<KORESort> substitute(substitution const &subst) override {
     return subst.at(*this);
   }
 
-  virtual void print(std::ostream &Out, unsigned indent = 0) const override;
-  virtual void prettyPrint(std::ostream &Out) const override;
-  virtual void serialize_to(serializer &s) const override;
+  void print(std::ostream &Out, unsigned indent = 0) const override;
+  void prettyPrint(std::ostream &Out) const override;
+  void serialize_to(serializer &s) const override;
 
-  virtual bool operator==(KORESort const &other) const override;
+  bool operator==(KORESort const &other) const override;
 
   std::string const &getName() const { return name; }
 
 private:
-  KORESortVariable(std::string const &Name)
-      : name(Name) { }
+  KORESortVariable(std::string Name)
+      : name(std::move(Name)) { }
 };
 
 enum class SortCategory {
@@ -163,25 +163,25 @@ public:
     return sptr<KORECompositeSort>(new KORECompositeSort(Name, Cat));
   }
 
-  std::string const getName() const { return name; }
+  std::string getName() const { return name; }
   ValueType getCategory(KOREDefinition *definition);
   std::string getHook(KOREDefinition *definition) const;
   static ValueType getCategory(std::string const &hookName);
 
-  virtual bool isConcrete() const override;
-  virtual sptr<KORESort> substitute(substitution const &subst) override;
+  bool isConcrete() const override;
+  sptr<KORESort> substitute(substitution const &subst) override;
 
   void addArgument(sptr<KORESort> const &Argument);
-  virtual void print(std::ostream &Out, unsigned indent = 0) const override;
-  virtual void prettyPrint(std::ostream &out) const override;
-  virtual void serialize_to(serializer &s) const override;
-  virtual bool operator==(KORESort const &other) const override;
+  void print(std::ostream &Out, unsigned indent = 0) const override;
+  void prettyPrint(std::ostream &out) const override;
+  void serialize_to(serializer &s) const override;
+  bool operator==(KORESort const &other) const override;
 
   std::vector<sptr<KORESort>> const &getArguments() const { return arguments; }
 
 private:
-  KORECompositeSort(std::string const &Name, ValueType category)
-      : name(Name)
+  KORECompositeSort(std::string Name, ValueType category)
+      : name(std::move(Name))
       , category(category) { }
 };
 
@@ -211,14 +211,14 @@ private:
   /* the first integer in a continuous range representing the tags of all the
      polymorphic instantiations of this symbol. If the symbol has no parameters
      or its parameters are fully specified, firstTag == lastTag. */
-  uint32_t firstTag;
+  uint32_t firstTag{};
   /* the last integer in a continuous range representing the tags of all the
      polymorphic instantiations of this symbol. If the symbol has no parameters
      or its parameters are fully specified, firstTag == lastTag. */
-  uint32_t lastTag;
+  uint32_t lastTag{};
   /* A unique integer representing the layout of the symbol in memory.
      See CreateTerm.cpp for more information about the layout of K terms. */
-  uint16_t layout;
+  uint16_t layout{};
 
 public:
   static ptr<KORESymbol> Create(std::string const &Name) {
@@ -228,23 +228,23 @@ public:
   void addArgument(sptr<KORESort> const &Argument);
   void addFormalArgument(sptr<KORESort> const &Argument);
   void addSort(sptr<KORESort> Sort);
-  void initPatternArguments(void) { arguments.swap(formalArguments); }
+  void initPatternArguments() { arguments.swap(formalArguments); }
 
-  std::string const &getName() const { return name; }
-  std::vector<sptr<KORESort>> const &getArguments() const { return arguments; }
-  std::vector<sptr<KORESort>> const &getFormalArguments() const {
+  [[nodiscard]] std::string const &getName() const { return name; }
+  [[nodiscard]] std::vector<sptr<KORESort>> const &getArguments() const { return arguments; }
+  [[nodiscard]] std::vector<sptr<KORESort>> const &getFormalArguments() const {
     return formalArguments;
   }
-  sptr<KORESort> const getSort() const { return sort; }
+  [[nodiscard]] sptr<KORESort> getSort() const { return sort; }
   sptr<KORESort> getSort() { return sort; }
-  uint32_t getTag() const {
+  [[nodiscard]] uint32_t getTag() const {
     assert(firstTag == lastTag);
     return firstTag;
   }
-  uint32_t getFirstTag() const { return firstTag; }
-  uint32_t getLastTag() const { return lastTag; }
+  [[nodiscard]] uint32_t getFirstTag() const { return firstTag; }
+  [[nodiscard]] uint32_t getLastTag() const { return lastTag; }
   void setTag(uint32_t val) { firstTag = lastTag = val; }
-  uint16_t getLayout() const { return layout; }
+  [[nodiscard]] uint16_t getLayout() const { return layout; }
 
   void print(std::ostream &Out, unsigned indent = 0) const;
   void print(std::ostream &Out, unsigned indent, bool formal) const;
@@ -255,9 +255,9 @@ public:
 
   std::string layoutString(KOREDefinition *) const;
 
-  bool isConcrete() const;
-  bool isPolymorphic() const;
-  bool isBuiltin() const;
+  [[nodiscard]] bool isConcrete() const;
+  [[nodiscard]] bool isPolymorphic() const;
+  [[nodiscard]] bool isBuiltin() const;
 
   /* instantiates this symbol (which should be parsed from a pattern in an
      axiom) with the sorts corresponding to its actual sort parameters after
@@ -273,8 +273,8 @@ public:
   friend KOREDefinition;
 
 private:
-  KORESymbol(std::string const &Name)
-      : name(Name)
+  KORESymbol(std::string Name)
+      : name(std::move(Name))
       , sort(nullptr) { }
 };
 
@@ -282,7 +282,7 @@ struct HashSymbol {
   size_t operator()(kllvm::KORESymbol const &s) const noexcept {
     size_t hash = 0;
     boost::hash_combine(hash, s.name);
-    for (auto &arg : s.arguments) {
+    for (const auto &arg : s.arguments) {
       boost::hash_combine(hash, *arg);
     }
     return hash;
@@ -311,7 +311,7 @@ public:
     return ptr<KOREVariable>(new KOREVariable(Name));
   }
 
-  std::string getName() const;
+  [[nodiscard]] std::string getName() const;
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const;
   virtual void serialize_to(serializer &s) const;
@@ -319,8 +319,8 @@ public:
   virtual ~KOREVariable() = default;
 
 private:
-  KOREVariable(std::string const &Name)
-      : name(Name) { }
+  KOREVariable(std::string Name)
+      : name(std::move(Name)) { }
 };
 
 class KOREVariablePattern;
@@ -356,7 +356,7 @@ struct PrettyPrintData {
   std::set<std::string> comm;
   SubsortMap subsorts;
   // enable coloring
-  bool hasColor;
+  bool hasColor{};
 };
 
 class KOREDeclaration;
@@ -388,7 +388,7 @@ public:
   virtual void markVariables(std::map<std::string, KOREVariablePattern *> &)
       = 0;
 
-  virtual sptr<KORESort> getSort(void) const = 0;
+  virtual sptr<KORESort> getSort() const = 0;
 
   using substitution = std::unordered_map<std::string, sptr<KOREPattern>>;
 
@@ -398,12 +398,12 @@ public:
   virtual void prettyPrint(std::ostream &, PrettyPrintData const &data) const
       = 0;
   virtual sptr<KOREPattern> sortCollections(PrettyPrintData const &data) = 0;
-  std::set<std::string> gatherSingletonVars(void);
-  virtual std::map<std::string, int> gatherVarCounts(void) = 0;
+  std::set<std::string> gatherSingletonVars();
+  virtual std::map<std::string, int> gatherVarCounts() = 0;
   virtual sptr<KOREPattern> filterSubstitution(
       PrettyPrintData const &data, std::set<std::string> const &vars)
       = 0;
-  virtual sptr<KOREPattern> dedupeDisjuncts(void) = 0;
+  virtual sptr<KOREPattern> dedupeDisjuncts() = 0;
   virtual bool matches(
       substitution &subst, SubsortMap const &subsorts,
       SymbolMap const &overloads, sptr<KOREPattern> subject)
@@ -411,7 +411,7 @@ public:
   sptr<KOREPattern> expandMacros(
       SubsortMap const &subsorts, SymbolMap const &overloads,
       std::vector<ptr<KOREDeclaration>> const &axioms, bool reverse);
-  virtual sptr<KOREPattern> unflattenAndOr(void) = 0;
+  virtual sptr<KOREPattern> unflattenAndOr() = 0;
 
   /*
    * Recursively expands productions of the form:
@@ -454,62 +454,62 @@ public:
   Create(std::string const &Name, sptr<KORESort> sort) {
     ptr<KOREVariable> Var = KOREVariable::Create(Name);
     return ptr<KOREVariablePattern>(
-        new KOREVariablePattern(std::move(Var), sort));
+        new KOREVariablePattern(std::move(Var), std::move(sort)));
   }
 
   std::string getName() const;
-  virtual sptr<KORESort> getSort() const override { return sort; }
+  sptr<KORESort> getSort() const override { return sort; }
 
-  virtual void print(std::ostream &Out, unsigned indent = 0) const override;
-  virtual void serialize_to(serializer &s) const override;
+  void print(std::ostream &Out, unsigned indent = 0) const override;
+  void serialize_to(serializer &s) const override;
 
-  virtual void
+  void
   markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override { }
-  virtual void
+  void
   markVariables(std::map<std::string, KOREVariablePattern *> &map) override {
     map.insert({name->getName(), this});
   }
-  virtual sptr<KOREPattern> substitute(substitution const &subst) override {
+  sptr<KOREPattern> substitute(substitution const &subst) override {
     auto val = subst.find(name->getName());
     if (val == subst.end()) {
       return shared_from_this();
     }
     return val->second;
   }
-  virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override {
+  sptr<KOREPattern> expandAliases(KOREDefinition *) override {
     return shared_from_this();
   }
-  virtual sptr<KOREPattern>
+  sptr<KOREPattern>
   sortCollections(PrettyPrintData const &data) override {
     return shared_from_this();
   }
-  virtual sptr<KOREPattern> dedupeDisjuncts(void) override {
+  sptr<KOREPattern> dedupeDisjuncts() override {
     return shared_from_this();
   }
-  virtual std::map<std::string, int> gatherVarCounts(void) override {
+  std::map<std::string, int> gatherVarCounts() override {
     return std::map<std::string, int>{{name->getName(), 1}};
   }
-  virtual sptr<KOREPattern> filterSubstitution(
+  sptr<KOREPattern> filterSubstitution(
       PrettyPrintData const &data, std::set<std::string> const &vars) override {
     return shared_from_this();
   }
 
-  virtual sptr<KOREPattern> desugarAssociative() override {
+  sptr<KOREPattern> desugarAssociative() override {
     return shared_from_this();
   }
 
-  virtual sptr<KOREPattern> unflattenAndOr() override {
+  sptr<KOREPattern> unflattenAndOr() override {
     return shared_from_this();
   }
 
-  virtual bool matches(
+  bool matches(
       substitution &subst, SubsortMap const &, SymbolMap const &,
       sptr<KOREPattern> subject) override;
-  virtual void
+  void
   prettyPrint(std::ostream &out, PrettyPrintData const &data) const override;
 
 private:
-  virtual sptr<KOREPattern> expandMacros(
+  sptr<KOREPattern> expandMacros(
       SubsortMap const &, SymbolMap const &,
       std::vector<ptr<KOREDeclaration>> const &macros, bool reverse,
       std::set<size_t> &appliedRules,
@@ -517,10 +517,10 @@ private:
     return shared_from_this();
   }
 
-private:
+
   KOREVariablePattern(ptr<KOREVariable> Name, sptr<KORESort> Sort)
       : name(std::move(Name))
-      , sort(Sort) { }
+      , sort(std::move(std::move(Sort))) { }
 };
 
 void deallocateSPtrKorePattern(sptr<KOREPattern> pattern);
@@ -563,31 +563,31 @@ public:
 
   void addArgument(sptr<KOREPattern> const &Argument);
 
-  virtual void print(std::ostream &Out, unsigned indent = 0) const override;
-  virtual void serialize_to(serializer &s) const override;
+  void print(std::ostream &Out, unsigned indent = 0) const override;
+  void serialize_to(serializer &s) const override;
 
-  virtual void
+  void
   prettyPrint(std::ostream &out, PrettyPrintData const &data) const override;
-  virtual void
+  void
   markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override;
-  virtual void
+  void
   markVariables(std::map<std::string, KOREVariablePattern *> &) override;
-  virtual sptr<KOREPattern> substitute(substitution const &) override;
-  virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override;
-  virtual sptr<KOREPattern>
+  sptr<KOREPattern> substitute(substitution const &) override;
+  sptr<KOREPattern> expandAliases(KOREDefinition *) override;
+  sptr<KOREPattern>
   sortCollections(PrettyPrintData const &data) override;
-  virtual sptr<KOREPattern> dedupeDisjuncts(void) override;
-  virtual std::map<std::string, int> gatherVarCounts(void) override;
-  virtual sptr<KOREPattern> desugarAssociative() override;
-  virtual sptr<KOREPattern> unflattenAndOr() override;
-  virtual sptr<KOREPattern> filterSubstitution(
+  sptr<KOREPattern> dedupeDisjuncts() override;
+  std::map<std::string, int> gatherVarCounts() override;
+  sptr<KOREPattern> desugarAssociative() override;
+  sptr<KOREPattern> unflattenAndOr() override;
+  sptr<KOREPattern> filterSubstitution(
       PrettyPrintData const &data, std::set<std::string> const &vars) override;
-  virtual bool matches(
+  bool matches(
       substitution &, SubsortMap const &, SymbolMap const &,
       sptr<KOREPattern>) override;
 
 private:
-  virtual sptr<KOREPattern> expandMacros(
+  sptr<KOREPattern> expandMacros(
       SubsortMap const &, SymbolMap const &,
       std::vector<ptr<KOREDeclaration>> const &macros, bool reverse,
       std::set<size_t> &appliedRules,
@@ -595,7 +595,7 @@ private:
 
   friend void ::kllvm::deallocateSPtrKorePattern(sptr<KOREPattern> pattern);
 
-private:
+
   KORECompositePattern(ptr<KORESymbol> Constructor)
       : constructor(std::move(Constructor)) { }
 };
@@ -611,53 +611,53 @@ public:
 
   std::string getContents() { return contents; }
 
-  virtual void print(std::ostream &Out, unsigned indent = 0) const override;
-  virtual void serialize_to(serializer &s) const override;
-  virtual void
+  void print(std::ostream &Out, unsigned indent = 0) const override;
+  void serialize_to(serializer &s) const override;
+  void
   prettyPrint(std::ostream &out, PrettyPrintData const &data) const override {
     abort();
   }
 
-  virtual void
+  void
   markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override { }
-  virtual void
+  void
   markVariables(std::map<std::string, KOREVariablePattern *> &) override { }
-  virtual sptr<KORESort> getSort(void) const override { abort(); }
-  virtual sptr<KOREPattern> substitute(substitution const &) override {
+  sptr<KORESort> getSort() const override { abort(); }
+  sptr<KOREPattern> substitute(substitution const &) override {
     return shared_from_this();
   }
-  virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override {
+  sptr<KOREPattern> expandAliases(KOREDefinition *) override {
     return shared_from_this();
   }
-  virtual sptr<KOREPattern>
+  sptr<KOREPattern>
   sortCollections(PrettyPrintData const &data) override {
     return shared_from_this();
   }
-  virtual sptr<KOREPattern> dedupeDisjuncts(void) override {
+  sptr<KOREPattern> dedupeDisjuncts() override {
     return shared_from_this();
   }
-  virtual std::map<std::string, int> gatherVarCounts(void) override {
+  std::map<std::string, int> gatherVarCounts() override {
     return std::map<std::string, int>{};
   }
 
-  virtual sptr<KOREPattern> desugarAssociative() override {
+  sptr<KOREPattern> desugarAssociative() override {
     return shared_from_this();
   }
 
-  virtual sptr<KOREPattern> unflattenAndOr() override {
+  sptr<KOREPattern> unflattenAndOr() override {
     return shared_from_this();
   }
 
-  virtual sptr<KOREPattern> filterSubstitution(
+  sptr<KOREPattern> filterSubstitution(
       PrettyPrintData const &data, std::set<std::string> const &var) override {
     return shared_from_this();
   }
-  virtual bool matches(
+  bool matches(
       substitution &, SubsortMap const &, SymbolMap const &,
       sptr<KOREPattern> subject) override;
 
 private:
-  virtual sptr<KOREPattern> expandMacros(
+  sptr<KOREPattern> expandMacros(
       SubsortMap const &, SymbolMap const &,
       std::vector<ptr<KOREDeclaration>> const &macros, bool reverse,
       std::set<size_t> &appliedRules,
@@ -665,9 +665,9 @@ private:
     return shared_from_this();
   }
 
-private:
-  KOREStringPattern(std::string const &Contents)
-      : contents(Contents) { }
+
+  KOREStringPattern(std::string Contents)
+      : contents(std::move(Contents)) { }
 };
 
 // KOREDeclaration
@@ -678,12 +678,12 @@ protected:
 
 public:
   attribute_set &attributes() { return attributes_; }
-  attribute_set const &attributes() const { return attributes_; }
+  [[nodiscard]] attribute_set const &attributes() const { return attributes_; }
 
   void addObjectSortVariable(sptr<KORESortVariable> const &SortVariable);
   virtual void print(std::ostream &Out, unsigned indent = 0) const = 0;
 
-  std::vector<sptr<KORESortVariable>> const &getObjectSortVariables() const {
+  [[nodiscard]] std::vector<sptr<KORESortVariable>> const &getObjectSortVariables() const {
     return objectSortVariables;
   }
   virtual ~KOREDeclaration() = default;
@@ -704,15 +704,15 @@ public:
         new KORECompositeSortDeclaration(Name, isHooked));
   }
 
-  std::string getName() const { return sortName; }
-  bool isHooked() const { return _isHooked; }
+  [[nodiscard]] std::string getName() const { return sortName; }
+  [[nodiscard]] bool isHooked() const { return _isHooked; }
 
-  virtual void print(std::ostream &Out, unsigned indent = 0) const override;
+  void print(std::ostream &Out, unsigned indent = 0) const override;
 
 private:
-  KORECompositeSortDeclaration(std::string const &Name, bool _isHooked)
+  KORECompositeSortDeclaration(std::string Name, bool _isHooked)
       : _isHooked(_isHooked)
-      , sortName(Name) { }
+      , sortName(std::move(Name)) { }
 };
 
 class KORESymbolAliasDeclaration : public KOREDeclaration {
@@ -723,7 +723,7 @@ protected:
       : symbol(std::move(Symbol)) { }
 
 public:
-  KORESymbol *getSymbol() const { return symbol.get(); }
+  [[nodiscard]] KORESymbol *getSymbol() const { return symbol.get(); }
 };
 
 class KORESymbolDeclaration : public KORESymbolAliasDeclaration {
@@ -738,11 +738,11 @@ public:
         new KORESymbolDeclaration(std::move(Sym), isHooked));
   }
 
-  bool isHooked() const { return _isHooked; }
+  [[nodiscard]] bool isHooked() const { return _isHooked; }
 
-  bool isAnywhere() const;
+  [[nodiscard]] bool isAnywhere() const;
 
-  virtual void print(std::ostream &Out, unsigned indent = 0) const override;
+  void print(std::ostream &Out, unsigned indent = 0) const override;
 
 private:
   KORESymbolDeclaration(ptr<KORESymbol> Symbol, bool _isHooked)
@@ -764,11 +764,11 @@ public:
   void addVariables(sptr<KORECompositePattern> variables);
   void addPattern(sptr<KOREPattern> Pattern);
   KOREPattern::substitution getSubstitution(KORECompositePattern *subject);
-  KORECompositePattern *getBoundVariables() const {
+  [[nodiscard]] KORECompositePattern *getBoundVariables() const {
     return boundVariables.get();
   }
   sptr<KOREPattern> &getPattern() { return pattern; }
-  virtual void print(std::ostream &Out, unsigned indent = 0) const override;
+  void print(std::ostream &Out, unsigned indent = 0) const override;
 
 private:
   KOREAliasDeclaration(ptr<KORESymbol> Symbol)
@@ -778,7 +778,7 @@ private:
 class KOREAxiomDeclaration : public KOREDeclaration {
 private:
   sptr<KOREPattern> pattern;
-  unsigned ordinal;
+  unsigned ordinal{};
   bool _isClaim;
 
   KOREAxiomDeclaration(bool isClaim)
@@ -790,20 +790,20 @@ public:
   }
 
   void addPattern(sptr<KOREPattern> Pattern);
-  virtual void print(std::ostream &Out, unsigned indent = 0) const override;
+  void print(std::ostream &Out, unsigned indent = 0) const override;
 
   /* returns true if the axiom is actually required to be translated to llvm
      and false if it is an axiom pertaining to symbolic execution which is not
      required for concrete execution. Axioms that are not required are elided
      from the definition by KOREDefinition::preprocess. */
-  bool isRequired() const;
-  bool isTopAxiom() const;
-  bool isClaim() const { return _isClaim; }
-  KOREPattern *getRightHandSide() const;
-  std::vector<KOREPattern *> getLeftHandSide() const;
-  KOREPattern *getRequires() const;
-  sptr<KOREPattern> getPattern() const { return pattern; }
-  unsigned getOrdinal() const { return ordinal; }
+  [[nodiscard]] bool isRequired() const;
+  [[nodiscard]] bool isTopAxiom() const;
+  [[nodiscard]] bool isClaim() const { return _isClaim; }
+  [[nodiscard]] KOREPattern *getRightHandSide() const;
+  [[nodiscard]] std::vector<KOREPattern *> getLeftHandSide() const;
+  [[nodiscard]] KOREPattern *getRequires() const;
+  [[nodiscard]] sptr<KOREPattern> getPattern() const { return pattern; }
+  [[nodiscard]] unsigned getOrdinal() const { return ordinal; }
 
   friend KOREDefinition;
 };
@@ -818,13 +818,13 @@ public:
         new KOREModuleImportDeclaration(Name));
   }
 
-  std::string const &getModuleName() const { return moduleName; }
+  [[nodiscard]] std::string const &getModuleName() const { return moduleName; }
 
-  virtual void print(std::ostream &Out, unsigned indent = 0) const override;
+  void print(std::ostream &Out, unsigned indent = 0) const override;
 
 private:
-  KOREModuleImportDeclaration(std::string const &Name)
-      : moduleName(Name) { }
+  KOREModuleImportDeclaration(std::string Name)
+      : moduleName(std::move(Name)) { }
 };
 
 // KOREModule
@@ -840,19 +840,19 @@ public:
   }
 
   attribute_set &attributes() { return attributes_; }
-  attribute_set const &attributes() const { return attributes_; }
+  [[nodiscard]] attribute_set const &attributes() const { return attributes_; }
 
   void addDeclaration(sptr<KOREDeclaration> Declaration);
   void print(std::ostream &Out, unsigned indent = 0) const;
 
-  std::string const &getName() const { return name; }
-  std::vector<sptr<KOREDeclaration>> const &getDeclarations() const {
+  [[nodiscard]] std::string const &getName() const { return name; }
+  [[nodiscard]] std::vector<sptr<KOREDeclaration>> const &getDeclarations() const {
     return declarations;
   }
 
 private:
-  KOREModule(std::string const &Name)
-      : name(Name) { }
+  KOREModule(std::string Name)
+      : name(std::move(Name)) { }
 };
 
 // KOREDefinition
@@ -903,7 +903,7 @@ private:
   /* an automatically computed list of all the axioms in the definition */
   std::list<KOREAxiomDeclaration *> axioms;
 
-  KORESymbol *injSymbol;
+  KORESymbol *injSymbol{};
 
   /*
    * Insert symbols into this definition that have knowable labels, but cannot
@@ -914,7 +914,7 @@ private:
 
 public:
   static ptr<KOREDefinition> Create() {
-    return ptr<KOREDefinition>(new KOREDefinition());
+    return std::make_unique<KOREDefinition>();
   }
 
   /* Preprocesses the definition and prepares it for translation to llvm.
@@ -928,7 +928,7 @@ public:
   void preprocess();
 
   attribute_set &attributes() { return attributes_; }
-  attribute_set const &attributes() const { return attributes_; }
+  [[nodiscard]] attribute_set const &attributes() const { return attributes_; }
 
   void addModule(sptr<KOREModule> Module);
   void print(std::ostream &Out, unsigned indent = 0) const;
@@ -943,7 +943,7 @@ public:
    * implement type-safe collections), those user sorts will be returned as
    * well.
    */
-  std::unordered_set<std::string>
+  [[nodiscard]] std::unordered_set<std::string>
   getSortsHookedTo(std::string const &hookName) const;
 
   /*
@@ -954,7 +954,7 @@ public:
    *
    *   S |-> {T . S is a subsort of T}
    */
-  SubsortMap getSubsorts() const;
+  [[nodiscard]] SubsortMap getSubsorts() const;
 
   /*
    * Build this definition's overload relation from axioms that have the
@@ -964,28 +964,28 @@ public:
    *
    *  P |-> {Q . P is a more specific overload of Q}
    */
-  SymbolMap getOverloads() const;
+  [[nodiscard]] SymbolMap getOverloads() const;
 
-  std::vector<sptr<KOREModule>> const &getModules() const { return modules; }
-  KORECompositeSortDeclarationMapType const &getSortDeclarations() const {
+  [[nodiscard]] std::vector<sptr<KOREModule>> const &getModules() const { return modules; }
+  [[nodiscard]] KORECompositeSortDeclarationMapType const &getSortDeclarations() const {
     return sortDeclarations;
   }
-  KORESymbolDeclarationMapType const &getSymbolDeclarations() const {
+  [[nodiscard]] KORESymbolDeclarationMapType const &getSymbolDeclarations() const {
     return symbolDeclarations;
   }
-  KOREAliasDeclarationMapType const &getAliasDeclarations() const {
+  [[nodiscard]] KOREAliasDeclarationMapType const &getAliasDeclarations() const {
     return aliasDeclarations;
   }
-  KORESymbolMapType const &getSymbols() const { return objectSymbols; }
-  KORESymbolStringMapType const &getAllSymbols() const {
+  [[nodiscard]] KORESymbolMapType const &getSymbols() const { return objectSymbols; }
+  [[nodiscard]] KORESymbolStringMapType const &getAllSymbols() const {
     return allObjectSymbols;
   }
-  KORECompositeSortMapType const getHookedSorts() const { return hookedSorts; }
-  std::list<KOREAxiomDeclaration *> const &getAxioms() const { return axioms; }
-  KOREAxiomDeclaration *getAxiomByOrdinal(size_t ordinal) const {
+  [[nodiscard]] KORECompositeSortMapType getHookedSorts() const { return hookedSorts; }
+  [[nodiscard]] std::list<KOREAxiomDeclaration *> const &getAxioms() const { return axioms; }
+  [[nodiscard]] KOREAxiomDeclaration *getAxiomByOrdinal(size_t ordinal) const {
     return ordinals.at(ordinal);
   }
-  KORESymbolStringMapType const &getFreshFunctions() const {
+  [[nodiscard]] KORESymbolStringMapType const &getFreshFunctions() const {
     return freshFunctions;
   }
   KORESymbol *getInjSymbol() { return injSymbol; }

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -231,7 +231,9 @@ public:
   void initPatternArguments() { arguments.swap(formalArguments); }
 
   [[nodiscard]] std::string const &getName() const { return name; }
-  [[nodiscard]] std::vector<sptr<KORESort>> const &getArguments() const { return arguments; }
+  [[nodiscard]] std::vector<sptr<KORESort>> const &getArguments() const {
+    return arguments;
+  }
   [[nodiscard]] std::vector<sptr<KORESort>> const &getFormalArguments() const {
     return formalArguments;
   }
@@ -282,7 +284,7 @@ struct HashSymbol {
   size_t operator()(kllvm::KORESymbol const &s) const noexcept {
     size_t hash = 0;
     boost::hash_combine(hash, s.name);
-    for (const auto &arg : s.arguments) {
+    for (auto const &arg : s.arguments) {
       boost::hash_combine(hash, *arg);
     }
     return hash;
@@ -479,13 +481,10 @@ public:
   sptr<KOREPattern> expandAliases(KOREDefinition *) override {
     return shared_from_this();
   }
-  sptr<KOREPattern>
-  sortCollections(PrettyPrintData const &data) override {
+  sptr<KOREPattern> sortCollections(PrettyPrintData const &data) override {
     return shared_from_this();
   }
-  sptr<KOREPattern> dedupeDisjuncts() override {
-    return shared_from_this();
-  }
+  sptr<KOREPattern> dedupeDisjuncts() override { return shared_from_this(); }
   std::map<std::string, int> gatherVarCounts() override {
     return std::map<std::string, int>{{name->getName(), 1}};
   }
@@ -494,13 +493,9 @@ public:
     return shared_from_this();
   }
 
-  sptr<KOREPattern> desugarAssociative() override {
-    return shared_from_this();
-  }
+  sptr<KOREPattern> desugarAssociative() override { return shared_from_this(); }
 
-  sptr<KOREPattern> unflattenAndOr() override {
-    return shared_from_this();
-  }
+  sptr<KOREPattern> unflattenAndOr() override { return shared_from_this(); }
 
   bool matches(
       substitution &subst, SubsortMap const &, SymbolMap const &,
@@ -516,7 +511,6 @@ private:
       std::set<std::string> const &macroSymbols) override {
     return shared_from_this();
   }
-
 
   KOREVariablePattern(ptr<KOREVariable> Name, sptr<KORESort> Sort)
       : name(std::move(Name))
@@ -568,14 +562,11 @@ public:
 
   void
   prettyPrint(std::ostream &out, PrettyPrintData const &data) const override;
-  void
-  markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override;
-  void
-  markVariables(std::map<std::string, KOREVariablePattern *> &) override;
+  void markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override;
+  void markVariables(std::map<std::string, KOREVariablePattern *> &) override;
   sptr<KOREPattern> substitute(substitution const &) override;
   sptr<KOREPattern> expandAliases(KOREDefinition *) override;
-  sptr<KOREPattern>
-  sortCollections(PrettyPrintData const &data) override;
+  sptr<KOREPattern> sortCollections(PrettyPrintData const &data) override;
   sptr<KOREPattern> dedupeDisjuncts() override;
   std::map<std::string, int> gatherVarCounts() override;
   sptr<KOREPattern> desugarAssociative() override;
@@ -594,7 +585,6 @@ private:
       std::set<std::string> const &macroSymbols) override;
 
   friend void ::kllvm::deallocateSPtrKorePattern(sptr<KOREPattern> pattern);
-
 
   KORECompositePattern(ptr<KORESymbol> Constructor)
       : constructor(std::move(Constructor)) { }
@@ -620,8 +610,8 @@ public:
 
   void
   markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override { }
-  void
-  markVariables(std::map<std::string, KOREVariablePattern *> &) override { }
+  void markVariables(std::map<std::string, KOREVariablePattern *> &) override {
+  }
   sptr<KORESort> getSort() const override { abort(); }
   sptr<KOREPattern> substitute(substitution const &) override {
     return shared_from_this();
@@ -629,24 +619,17 @@ public:
   sptr<KOREPattern> expandAliases(KOREDefinition *) override {
     return shared_from_this();
   }
-  sptr<KOREPattern>
-  sortCollections(PrettyPrintData const &data) override {
+  sptr<KOREPattern> sortCollections(PrettyPrintData const &data) override {
     return shared_from_this();
   }
-  sptr<KOREPattern> dedupeDisjuncts() override {
-    return shared_from_this();
-  }
+  sptr<KOREPattern> dedupeDisjuncts() override { return shared_from_this(); }
   std::map<std::string, int> gatherVarCounts() override {
     return std::map<std::string, int>{};
   }
 
-  sptr<KOREPattern> desugarAssociative() override {
-    return shared_from_this();
-  }
+  sptr<KOREPattern> desugarAssociative() override { return shared_from_this(); }
 
-  sptr<KOREPattern> unflattenAndOr() override {
-    return shared_from_this();
-  }
+  sptr<KOREPattern> unflattenAndOr() override { return shared_from_this(); }
 
   sptr<KOREPattern> filterSubstitution(
       PrettyPrintData const &data, std::set<std::string> const &var) override {
@@ -665,14 +648,13 @@ private:
     return shared_from_this();
   }
 
-
   KOREStringPattern(std::string Contents)
       : contents(std::move(Contents)) { }
 };
 
 // KOREDeclaration
 class KOREDeclaration {
-protected:
+private:
   attribute_set attributes_;
   std::vector<sptr<KORESortVariable>> objectSortVariables;
 
@@ -683,7 +665,8 @@ public:
   void addObjectSortVariable(sptr<KORESortVariable> const &SortVariable);
   virtual void print(std::ostream &Out, unsigned indent = 0) const = 0;
 
-  [[nodiscard]] std::vector<sptr<KORESortVariable>> const &getObjectSortVariables() const {
+  [[nodiscard]] std::vector<sptr<KORESortVariable>> const &
+  getObjectSortVariables() const {
     return objectSortVariables;
   }
   virtual ~KOREDeclaration() = default;
@@ -716,9 +699,10 @@ private:
 };
 
 class KORESymbolAliasDeclaration : public KOREDeclaration {
-protected:
+private:
   ptr<KORESymbol> symbol;
 
+protected:
   KORESymbolAliasDeclaration(ptr<KORESymbol> Symbol)
       : symbol(std::move(Symbol)) { }
 
@@ -846,7 +830,8 @@ public:
   void print(std::ostream &Out, unsigned indent = 0) const;
 
   [[nodiscard]] std::string const &getName() const { return name; }
-  [[nodiscard]] std::vector<sptr<KOREDeclaration>> const &getDeclarations() const {
+  [[nodiscard]] std::vector<sptr<KOREDeclaration>> const &
+  getDeclarations() const {
     return declarations;
   }
 
@@ -966,22 +951,33 @@ public:
    */
   [[nodiscard]] SymbolMap getOverloads() const;
 
-  [[nodiscard]] std::vector<sptr<KOREModule>> const &getModules() const { return modules; }
-  [[nodiscard]] KORECompositeSortDeclarationMapType const &getSortDeclarations() const {
+  [[nodiscard]] std::vector<sptr<KOREModule>> const &getModules() const {
+    return modules;
+  }
+  [[nodiscard]] KORECompositeSortDeclarationMapType const &
+  getSortDeclarations() const {
     return sortDeclarations;
   }
-  [[nodiscard]] KORESymbolDeclarationMapType const &getSymbolDeclarations() const {
+  [[nodiscard]] KORESymbolDeclarationMapType const &
+  getSymbolDeclarations() const {
     return symbolDeclarations;
   }
-  [[nodiscard]] KOREAliasDeclarationMapType const &getAliasDeclarations() const {
+  [[nodiscard]] KOREAliasDeclarationMapType const &
+  getAliasDeclarations() const {
     return aliasDeclarations;
   }
-  [[nodiscard]] KORESymbolMapType const &getSymbols() const { return objectSymbols; }
+  [[nodiscard]] KORESymbolMapType const &getSymbols() const {
+    return objectSymbols;
+  }
   [[nodiscard]] KORESymbolStringMapType const &getAllSymbols() const {
     return allObjectSymbols;
   }
-  [[nodiscard]] KORECompositeSortMapType getHookedSorts() const { return hookedSorts; }
-  [[nodiscard]] std::list<KOREAxiomDeclaration *> const &getAxioms() const { return axioms; }
+  [[nodiscard]] KORECompositeSortMapType getHookedSorts() const {
+    return hookedSorts;
+  }
+  [[nodiscard]] std::list<KOREAxiomDeclaration *> const &getAxioms() const {
+    return axioms;
+  }
   [[nodiscard]] KOREAxiomDeclaration *getAxiomByOrdinal(size_t ordinal) const {
     return ordinals.at(ordinal);
   }

--- a/include/kllvm/ast/attribute_set.h
+++ b/include/kllvm/ast/attribute_set.h
@@ -89,7 +89,7 @@ public:
    * Returns true if there is any attribute with the given key; the arguments of
    * that attribute are not considered.
    */
-  bool contains(key k) const;
+  [[nodiscard]] bool contains(key k) const;
 
   /**
    * Look up the attribute pattern with the specified key.
@@ -97,7 +97,7 @@ public:
    * This lookup is unchecked; use `.contains(k)` first if the attribute may not
    * be present.
    */
-  std::shared_ptr<KORECompositePattern> const &get(key k) const;
+  [[nodiscard]] std::shared_ptr<KORECompositePattern> const &get(key k) const;
 
   /**
    * Look up an attribute with the specified key that has the form:
@@ -106,14 +106,14 @@ public:
    *
    * and extract the string data in the pattern's argument.
    */
-  std::string get_string(key k) const;
+  [[nodiscard]] std::string get_string(key k) const;
 
   /**
    * Get the underlying attribute table; this table will allow access to
    * attributes that are not statically whitelisted by the backend, and so
    * should only be used at library boundaries (e.g. in bindings code).
    */
-  storage_t const &underlying() const;
+  [[nodiscard]] storage_t const &underlying() const;
 
   /**
    * Support for iterating over the stored attributes.
@@ -121,8 +121,8 @@ public:
    * Code that uses this feature should not dispatch on specific attribute names
    * when iterating; the type-safe interface should be used to do so instead.
    */
-  storage_t::const_iterator begin() const;
-  storage_t::const_iterator end() const;
+  [[nodiscard]] storage_t::const_iterator begin() const;
+  [[nodiscard]] storage_t::const_iterator end() const;
 
 private:
   storage_t attribute_map_ = {};

--- a/include/kllvm/ast/pattern_matching.h
+++ b/include/kllvm/ast/pattern_matching.h
@@ -170,7 +170,8 @@ struct match_result {
  */
 class any_ {
 public:
-  [[nodiscard]] static match_result match(std::shared_ptr<KOREPattern> const &term) {
+  [[nodiscard]] static match_result
+  match(std::shared_ptr<KOREPattern> const &term) {
     return {true, nullptr};
   }
 };
@@ -194,13 +195,14 @@ public:
         "Cannot construct a subject expression with nested subject terms");
   }
 
-  [[nodiscard]] match_result match(std::shared_ptr<KOREPattern> const &term) const {
+  [[nodiscard]] match_result
+  match(std::shared_ptr<KOREPattern> const &term) const {
     auto inner_result = inner_.match(term);
 
     if (inner_result.matches) {
       return {true, term};
-    }       return {false, nullptr};
-   
+    }
+    return {false, nullptr};
   }
 
 private:
@@ -235,7 +237,8 @@ public:
    * assume that the first child lens to match with a returned subject pattern
    * is the only such lens.
    */
-  [[nodiscard]] match_result match(std::shared_ptr<KOREPattern> const &term) const {
+  [[nodiscard]] match_result
+  match(std::shared_ptr<KOREPattern> const &term) const {
     if (auto composite = std::dynamic_pointer_cast<KORECompositePattern>(term);
         composite && composite->getArguments().size() == arity()
         && composite->getConstructor()->getName() == constructor_) {

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <string>
+#include <utility>
 
 namespace kllvm {
 
@@ -13,7 +14,7 @@ namespace detail {
 
 constexpr uint64_t word(uint8_t byte) {
   auto ret = uint64_t{0};
-  for (auto i = 0u; i < sizeof(ret); ++i) {
+  for (auto i = 0U; i < sizeof(ret); ++i) {
     ret <<= 8;
     ret |= byte;
   }
@@ -36,7 +37,7 @@ constexpr uint64_t side_condition_end_sentinel = detail::word(0x33);
 
 class LLVMStepEvent : public std::enable_shared_from_this<LLVMStepEvent> {
 public:
-  virtual void print(std::ostream &Out, unsigned indent = 0u) const = 0;
+  virtual void print(std::ostream &Out, unsigned indent = 0U) const = 0;
   virtual ~LLVMStepEvent() = default;
 };
 
@@ -47,25 +48,25 @@ public:
 
 protected:
   uint64_t ruleOrdinal;
-  substitution_t substitution;
+  substitution_t substitution{};
 
-  void printSubstitution(std::ostream &Out, unsigned indent = 0u) const;
+  void printSubstitution(std::ostream &Out, unsigned indent = 0U) const;
 
 public:
   LLVMRewriteEvent(uint64_t _ruleOrdinal)
       : ruleOrdinal(_ruleOrdinal)
-      , substitution() { }
+       { }
 
-  uint64_t getRuleOrdinal() const { return ruleOrdinal; }
-  substitution_t const &getSubstitution() const { return substitution; }
+  [[nodiscard]] uint64_t getRuleOrdinal() const { return ruleOrdinal; }
+  [[nodiscard]] substitution_t const &getSubstitution() const { return substitution; }
 
   void addSubstitution(
-      std::string const &name, sptr<KOREPattern> term, uint64_t pattern_len) {
+      std::string const &name, const sptr<KOREPattern>& term, uint64_t pattern_len) {
     substitution.insert(
         std::make_pair(name, std::make_pair(term, pattern_len)));
   }
 
-  virtual ~LLVMRewriteEvent() = default;
+  ~LLVMRewriteEvent() override = default;
 };
 
 class LLVMRuleEvent : public LLVMRewriteEvent {
@@ -78,7 +79,7 @@ public:
     return sptr<LLVMRuleEvent>(new LLVMRuleEvent(_ruleOrdinal));
   }
 
-  virtual void print(std::ostream &Out, unsigned indent = 0u) const override;
+  void print(std::ostream &Out, unsigned indent = 0U) const override;
 };
 
 class LLVMSideConditionEvent : public LLVMRewriteEvent {
@@ -92,19 +93,19 @@ public:
         new LLVMSideConditionEvent(_ruleOrdinal));
   }
 
-  virtual void print(std::ostream &Out, unsigned indent = 0u) const override;
+  void print(std::ostream &Out, unsigned indent = 0U) const override;
 };
 
 class LLVMSideConditionEndEvent : public LLVMStepEvent {
 private:
   uint64_t ruleOrdinal;
-  sptr<KOREPattern> korePattern;
-  uint64_t patternLength;
+  sptr<KOREPattern> korePattern{};
+  uint64_t patternLength{0U};
 
   LLVMSideConditionEndEvent(uint64_t _ruleOrdinal)
       : ruleOrdinal(_ruleOrdinal)
       , korePattern(nullptr)
-      , patternLength(0u) { }
+       { }
 
 public:
   static sptr<LLVMSideConditionEndEvent> Create(uint64_t _ruleOrdinal) {
@@ -112,15 +113,15 @@ public:
         new LLVMSideConditionEndEvent(_ruleOrdinal));
   }
 
-  uint64_t getRuleOrdinal() const { return ruleOrdinal; }
-  sptr<KOREPattern> getKOREPattern() const { return korePattern; }
-  uint64_t getPatternLength() const { return patternLength; }
+  [[nodiscard]] uint64_t getRuleOrdinal() const { return ruleOrdinal; }
+  [[nodiscard]] sptr<KOREPattern> getKOREPattern() const { return korePattern; }
+  [[nodiscard]] uint64_t getPatternLength() const { return patternLength; }
   void setKOREPattern(sptr<KOREPattern> _korePattern, uint64_t _patternLength) {
-    korePattern = _korePattern;
+    korePattern = std::move(_korePattern);
     patternLength = _patternLength;
   }
 
-  virtual void print(std::ostream &Out, unsigned indent = 0u) const override;
+  void print(std::ostream &Out, unsigned indent = 0U) const override;
 };
 
 class LLVMEvent;
@@ -140,13 +141,13 @@ public:
         new LLVMFunctionEvent(_name, _relativePosition));
   }
 
-  std::string const &getName() const { return name; }
-  std::string const &getRelativePosition() const { return relativePosition; }
-  std::vector<LLVMEvent> const &getArguments() const;
+  [[nodiscard]] std::string const &getName() const { return name; }
+  [[nodiscard]] std::string const &getRelativePosition() const { return relativePosition; }
+  [[nodiscard]] std::vector<LLVMEvent> const &getArguments() const;
 
   void addArgument(LLVMEvent const &argument);
 
-  virtual void print(std::ostream &Out, unsigned indent = 0u) const override;
+  void print(std::ostream &Out, unsigned indent = 0U) const override;
 };
 
 class LLVMHookEvent : public LLVMStepEvent {
@@ -155,7 +156,7 @@ private:
   std::string relativePosition;
   std::vector<LLVMEvent> arguments;
   sptr<KOREPattern> korePattern;
-  uint64_t patternLength;
+  uint64_t patternLength{0U};
 
   LLVMHookEvent(std::string _name, std::string _relativePosition);
 
@@ -165,72 +166,72 @@ public:
     return sptr<LLVMHookEvent>(new LLVMHookEvent(_name, _relativePosition));
   }
 
-  std::string const &getName() const { return name; }
-  std::string const &getRelativePosition() const { return relativePosition; }
-  std::vector<LLVMEvent> const &getArguments() const { return arguments; }
-  sptr<KOREPattern> getKOREPattern() const { return korePattern; }
-  uint64_t getPatternLength() const { return patternLength; }
+  [[nodiscard]] std::string const &getName() const { return name; }
+  [[nodiscard]] std::string const &getRelativePosition() const { return relativePosition; }
+  [[nodiscard]] std::vector<LLVMEvent> const &getArguments() const { return arguments; }
+  [[nodiscard]] sptr<KOREPattern> getKOREPattern() const { return korePattern; }
+  [[nodiscard]] uint64_t getPatternLength() const { return patternLength; }
   void setKOREPattern(sptr<KOREPattern> _korePattern, uint64_t _patternLength) {
-    korePattern = _korePattern;
+    korePattern = std::move(_korePattern);
     patternLength = _patternLength;
   }
 
   void addArgument(LLVMEvent const &argument);
 
-  virtual void print(std::ostream &Out, unsigned indent = 0u) const override;
+  void print(std::ostream &Out, unsigned indent = 0U) const override;
 };
 
 class LLVMEvent {
 private:
-  bool isStepEvent;
-  sptr<LLVMStepEvent> stepEvent;
-  sptr<KOREPattern> korePattern;
-  uint64_t patternLength;
+  bool isStepEvent{};
+  sptr<LLVMStepEvent> stepEvent{};
+  sptr<KOREPattern> korePattern{};
+  uint64_t patternLength{};
 
 public:
-  bool isStep() const { return isStepEvent; }
-  bool isPattern() const { return !isStep(); }
-  sptr<LLVMStepEvent> getStepEvent() const { return stepEvent; }
-  sptr<KOREPattern> getKOREPattern() const { return korePattern; }
-  uint64_t getPatternLength() const { return patternLength; }
+  [[nodiscard]] bool isStep() const { return isStepEvent; }
+  [[nodiscard]] bool isPattern() const { return !isStep(); }
+  [[nodiscard]] sptr<LLVMStepEvent> getStepEvent() const { return stepEvent; }
+  [[nodiscard]] sptr<KOREPattern> getKOREPattern() const { return korePattern; }
+  [[nodiscard]] uint64_t getPatternLength() const { return patternLength; }
   void setStepEvent(sptr<LLVMStepEvent> _stepEvent) {
     isStepEvent = true;
-    stepEvent = _stepEvent;
+    stepEvent = std::move(_stepEvent);
   }
   void setKOREPattern(sptr<KOREPattern> _korePattern, uint64_t _patternLength) {
     isStepEvent = false;
-    korePattern = _korePattern;
+    korePattern = std::move(_korePattern);
     patternLength = _patternLength;
   }
-  void print(std::ostream &Out, bool isArg, unsigned indent = 0u) const;
+  void print(std::ostream &Out, bool isArg, unsigned indent = 0U) const;
 };
 
 class LLVMRewriteTrace {
 private:
-  uint32_t version;
-  std::vector<LLVMEvent> preTrace;
+  uint32_t version{};
+  std::vector<LLVMEvent> preTrace{};
   LLVMEvent initialConfig;
-  std::vector<LLVMEvent> trace;
+  std::vector<LLVMEvent> trace{};
 
 public:
-  uint32_t getVersion() const { return version; }
-  std::vector<LLVMEvent> const &getPreTrace() const { return preTrace; }
-  LLVMEvent getInitialConfig() const { return initialConfig; }
-  std::vector<LLVMEvent> const &getTrace() const { return trace; }
+  [[nodiscard]] uint32_t getVersion() const { return version; }
+  [[nodiscard]] std::vector<LLVMEvent> const &getPreTrace() const { return preTrace; }
+  [[nodiscard]] LLVMEvent getInitialConfig() const { return initialConfig; }
+  [[nodiscard]] std::vector<LLVMEvent> const &getTrace() const { return trace; }
   void setVersion(uint32_t _version) { version = _version; }
   void setInitialConfig(LLVMEvent _initialConfig) {
-    initialConfig = _initialConfig;
+    initialConfig = std::move(_initialConfig);
   }
 
   void addPreTraceEvent(LLVMEvent const &event) { preTrace.push_back(event); }
   void addTraceEvent(LLVMEvent const &event) { trace.push_back(event); }
 
-  void print(std::ostream &Out, unsigned indent = 0u) const;
+  void print(std::ostream &Out, unsigned indent = 0U) const;
 };
 
 class ProofTraceParser {
 public:
-  static constexpr uint32_t expectedVersion = 5u;
+  static constexpr uint32_t expectedVersion = 5U;
 
 private:
   bool verbose;
@@ -296,7 +297,7 @@ private:
 
   template <typename It>
   sptr<KOREPattern> parse_kore_term(It &ptr, It end, uint64_t &pattern_len) {
-    if (std::distance(ptr, end) < 11u) {
+    if (std::distance(ptr, end) < 11U) {
       return nullptr;
     }
     if (detail::read<char>(ptr, end) != '\x7F'
@@ -314,7 +315,7 @@ private:
 
     if (std::distance(ptr, end) < pattern_len) {
       return nullptr;
-    } else if (pattern_len > 0 && std::distance(ptr, end) > pattern_len) {
+    } if (pattern_len > 0 && std::distance(ptr, end) > pattern_len) {
       end = std::next(ptr, pattern_len);
     }
 
@@ -333,7 +334,7 @@ private:
 
   template <typename It>
   bool parse_header(It &ptr, It end, uint32_t &version) {
-    if (std::distance(ptr, end) < 4u) {
+    if (std::distance(ptr, end) < 4U) {
       return false;
     }
     if (detail::read<char>(ptr, end) != 'H'
@@ -361,7 +362,7 @@ private:
       return false;
     }
 
-    uint64_t pattern_len;
+    uint64_t pattern_len = 0;
     auto kore_term = parse_kore_term(ptr, end, pattern_len);
     if (!kore_term) {
       return false;
@@ -390,7 +391,7 @@ private:
 
     auto event = LLVMHookEvent::Create(name, location);
 
-    while (std::distance(ptr, end) < 8u
+    while (std::distance(ptr, end) < 8U
            || peek_word(ptr) != hook_result_sentinel) {
       LLVMEvent argument;
       if (!parse_argument(ptr, end, argument)) {
@@ -403,7 +404,7 @@ private:
       return nullptr;
     }
 
-    uint64_t pattern_len;
+    uint64_t pattern_len = 0;
     auto kore_term = parse_kore_term(ptr, end, pattern_len);
     if (!kore_term) {
       return nullptr;
@@ -431,7 +432,7 @@ private:
 
     auto event = LLVMFunctionEvent::Create(name, location);
 
-    while (std::distance(ptr, end) < 8u
+    while (std::distance(ptr, end) < 8U
            || peek_word(ptr) != function_end_sentinel) {
       LLVMEvent argument;
       if (!parse_argument(ptr, end, argument)) {
@@ -471,12 +472,12 @@ private:
       return nullptr;
     }
 
-    uint64_t ordinal;
+    uint64_t ordinal = 0;
     if (!parse_ordinal(ptr, end, ordinal)) {
       return nullptr;
     }
 
-    uint64_t arity;
+    uint64_t arity = 0;
     if (!parse_arity(ptr, end, arity)) {
       return nullptr;
     }
@@ -498,12 +499,12 @@ private:
       return nullptr;
     }
 
-    uint64_t ordinal;
+    uint64_t ordinal = 0;
     if (!parse_ordinal(ptr, end, ordinal)) {
       return nullptr;
     }
 
-    uint64_t arity;
+    uint64_t arity = 0;
     if (!parse_arity(ptr, end, arity)) {
       return nullptr;
     }
@@ -525,14 +526,14 @@ private:
       return nullptr;
     }
 
-    uint64_t ordinal;
+    uint64_t ordinal = 0;
     if (!parse_ordinal(ptr, end, ordinal)) {
       return nullptr;
     }
 
     auto event = LLVMSideConditionEndEvent::Create(ordinal);
 
-    uint64_t pattern_len;
+    uint64_t pattern_len = 0;
     auto kore_term = parse_kore_term(ptr, end, pattern_len);
     if (!kore_term) {
       return nullptr;
@@ -548,8 +549,8 @@ private:
 
   template <typename It>
   bool parse_argument(It &ptr, It end, LLVMEvent &event) {
-    if (std::distance(ptr, end) >= 1u && detail::peek(ptr) == '\x7F') {
-      uint64_t pattern_len;
+    if (std::distance(ptr, end) >= 1U && detail::peek(ptr) == '\x7F') {
+      uint64_t pattern_len = 0;
       auto kore_term = parse_kore_term(ptr, end, pattern_len);
       if (!kore_term) {
         return false;
@@ -559,7 +560,7 @@ private:
       return true;
     }
 
-    if (std::distance(ptr, end) < 8u) {
+    if (std::distance(ptr, end) < 8U) {
       return false;
     }
 
@@ -598,7 +599,7 @@ private:
 
   template <typename It>
   sptr<LLVMStepEvent> parse_step_event(It &ptr, It end) {
-    if (std::distance(ptr, end) < 8u) {
+    if (std::distance(ptr, end) < 8U) {
       return nullptr;
     }
 
@@ -620,12 +621,12 @@ private:
 
   template <typename It>
   bool parse_event(It &ptr, It end, LLVMEvent &event) {
-    if (std::distance(ptr, end) < 8u) {
+    if (std::distance(ptr, end) < 8U) {
       return false;
     }
 
     if (peek_word(ptr) == config_sentinel) {
-      uint64_t pattern_len;
+      uint64_t pattern_len = 0;
       auto config = parse_config(ptr, end, pattern_len);
       if (!config) {
         return false;
@@ -644,13 +645,13 @@ private:
 
   template <typename It>
   bool parse_trace(It &ptr, It end, LLVMRewriteTrace &trace) {
-    uint32_t version;
+    uint32_t version = 0;
     if (!parse_header(ptr, end, version)) {
       return false;
     }
     trace.setVersion(version);
 
-    while (std::distance(ptr, end) >= 8u && peek_word(ptr) != config_sentinel) {
+    while (std::distance(ptr, end) >= 8U && peek_word(ptr) != config_sentinel) {
       LLVMEvent event;
       if (!parse_event(ptr, end, event)) {
         return false;
@@ -658,7 +659,7 @@ private:
       trace.addPreTraceEvent(event);
     }
 
-    uint64_t pattern_len;
+    uint64_t pattern_len = 0;
     auto config = parse_config(ptr, end, pattern_len);
     if (!config) {
       return false;

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -46,10 +46,11 @@ public:
   using substitution_t
       = std::map<std::string, std::pair<sptr<KOREPattern>, uint64_t>>;
 
-protected:
+private:
   uint64_t ruleOrdinal;
   substitution_t substitution{};
 
+protected:
   void printSubstitution(std::ostream &Out, unsigned indent = 0U) const;
 
 public:

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -54,14 +54,16 @@ protected:
 
 public:
   LLVMRewriteEvent(uint64_t _ruleOrdinal)
-      : ruleOrdinal(_ruleOrdinal)
-       { }
+      : ruleOrdinal(_ruleOrdinal) { }
 
   [[nodiscard]] uint64_t getRuleOrdinal() const { return ruleOrdinal; }
-  [[nodiscard]] substitution_t const &getSubstitution() const { return substitution; }
+  [[nodiscard]] substitution_t const &getSubstitution() const {
+    return substitution;
+  }
 
   void addSubstitution(
-      std::string const &name, const sptr<KOREPattern>& term, uint64_t pattern_len) {
+      std::string const &name, sptr<KOREPattern> const &term,
+      uint64_t pattern_len) {
     substitution.insert(
         std::make_pair(name, std::make_pair(term, pattern_len)));
   }
@@ -104,8 +106,7 @@ private:
 
   LLVMSideConditionEndEvent(uint64_t _ruleOrdinal)
       : ruleOrdinal(_ruleOrdinal)
-      , korePattern(nullptr)
-       { }
+      , korePattern(nullptr) { }
 
 public:
   static sptr<LLVMSideConditionEndEvent> Create(uint64_t _ruleOrdinal) {
@@ -142,7 +143,9 @@ public:
   }
 
   [[nodiscard]] std::string const &getName() const { return name; }
-  [[nodiscard]] std::string const &getRelativePosition() const { return relativePosition; }
+  [[nodiscard]] std::string const &getRelativePosition() const {
+    return relativePosition;
+  }
   [[nodiscard]] std::vector<LLVMEvent> const &getArguments() const;
 
   void addArgument(LLVMEvent const &argument);
@@ -167,8 +170,12 @@ public:
   }
 
   [[nodiscard]] std::string const &getName() const { return name; }
-  [[nodiscard]] std::string const &getRelativePosition() const { return relativePosition; }
-  [[nodiscard]] std::vector<LLVMEvent> const &getArguments() const { return arguments; }
+  [[nodiscard]] std::string const &getRelativePosition() const {
+    return relativePosition;
+  }
+  [[nodiscard]] std::vector<LLVMEvent> const &getArguments() const {
+    return arguments;
+  }
   [[nodiscard]] sptr<KOREPattern> getKOREPattern() const { return korePattern; }
   [[nodiscard]] uint64_t getPatternLength() const { return patternLength; }
   void setKOREPattern(sptr<KOREPattern> _korePattern, uint64_t _patternLength) {
@@ -215,7 +222,9 @@ private:
 
 public:
   [[nodiscard]] uint32_t getVersion() const { return version; }
-  [[nodiscard]] std::vector<LLVMEvent> const &getPreTrace() const { return preTrace; }
+  [[nodiscard]] std::vector<LLVMEvent> const &getPreTrace() const {
+    return preTrace;
+  }
   [[nodiscard]] LLVMEvent getInitialConfig() const { return initialConfig; }
   [[nodiscard]] std::vector<LLVMEvent> const &getTrace() const { return trace; }
   void setVersion(uint32_t _version) { version = _version; }
@@ -315,7 +324,8 @@ private:
 
     if (std::distance(ptr, end) < pattern_len) {
       return nullptr;
-    } if (pattern_len > 0 && std::distance(ptr, end) > pattern_len) {
+    }
+    if (pattern_len > 0 && std::distance(ptr, end) > pattern_len) {
       end = std::next(ptr, pattern_len);
     }
 
@@ -356,7 +366,7 @@ private:
   }
 
   template <typename It>
-  bool parse_variable(It &ptr, It end, sptr<LLVMRewriteEvent> event) {
+  bool parse_variable(It &ptr, It end, sptr<LLVMRewriteEvent> const &event) {
     std::string name;
     if (!parse_name(ptr, end, name)) {
       return false;

--- a/include/kllvm/binary/deserializer.h
+++ b/include/kllvm/binary/deserializer.h
@@ -77,27 +77,27 @@ uint64_t read_length(It &ptr, It end, binary_version version, int v1_bytes) {
     }
 
     return ret;
-  }     uint64_t ret = 0;
-    auto should_continue = true;
-    auto steps = 0;
+  }
+  uint64_t ret = 0;
+  auto should_continue = true;
+  auto steps = 0;
 
-    while (should_continue) {
-      assert(ptr != end && "Invalid variable-length field");
-      assert(steps < 9 && "No terminating byte in variable-length field");
+  while (should_continue) {
+    assert(ptr != end && "Invalid variable-length field");
+    assert(steps < 9 && "No terminating byte in variable-length field");
 
-      auto chunk = peek(ptr);
-      auto cont_bit = uint8_t{0x80};
-      should_continue = static_cast<bool>(chunk & cont_bit);
+    auto chunk = peek(ptr);
+    auto cont_bit = uint8_t{0x80};
+    should_continue = static_cast<bool>(chunk & cont_bit);
 
-      chunk = chunk & ~cont_bit;
-      ret = ret | (uint64_t(chunk) << (7 * steps));
+    chunk = chunk & ~cont_bit;
+    ret = ret | (uint64_t(chunk) << (7 * steps));
 
-      ++steps;
-      ++ptr;
-    }
+    ++steps;
+    ++ptr;
+  }
 
-    return ret;
- 
+  return ret;
 }
 
 template <typename It>

--- a/include/kllvm/binary/deserializer.h
+++ b/include/kllvm/binary/deserializer.h
@@ -63,7 +63,7 @@ uint64_t read_pattern_size(It &ptr, It end, binary_version version) {
     return read_pattern_size_unchecked(ptr, end);
   }
 
-  return 0u;
+  return 0U;
 }
 
 template <typename It>
@@ -77,8 +77,7 @@ uint64_t read_length(It &ptr, It end, binary_version version, int v1_bytes) {
     }
 
     return ret;
-  } else {
-    uint64_t ret = 0;
+  }     uint64_t ret = 0;
     auto should_continue = true;
     auto steps = 0;
 
@@ -98,7 +97,7 @@ uint64_t read_length(It &ptr, It end, binary_version version, int v1_bytes) {
     }
 
     return ret;
-  }
+ 
 }
 
 template <typename It>
@@ -120,7 +119,7 @@ std::string read_string(It &ptr, It end, binary_version version) {
     auto begin = ptr - backref;
     auto len = read_length(begin, end, version, 4);
 
-    return std::string((char *)&*begin, (char *)(&*begin + len));
+    return {(char *)&*begin, (char *)(&*begin + len)};
   }
 
   default: throw std::runtime_error("Internal parsing exception");

--- a/include/kllvm/binary/serializer.h
+++ b/include/kllvm/binary/serializer.h
@@ -52,7 +52,7 @@ public:
   template <
       typename T,
       typename = std::enable_if_t<std::is_fundamental_v<std::decay_t<T>>>>
-  void emit(T t);
+  void emit(T val);
 
   /**
    * Emit a string to the output buffer, using the interning table to either
@@ -81,7 +81,7 @@ public:
    * Return a copy of the bytes currently stored by this serializer as a string,
    * for compatibility with interfaces that don't deal with vectors of bytes.
    */
-  std::string byte_string() const;
+  [[nodiscard]] std::string byte_string() const;
 
   /**
    * Reset the state of the serializer back to its newly-constructed state, with
@@ -94,7 +94,7 @@ public:
    * the topmost arity is dropped.
    */
   void reset_arity_flag();
-  bool use_arity() const { return use_arity_; }
+  [[nodiscard]] bool use_arity() const { return use_arity_; }
 
 private:
   bool use_header_;

--- a/include/kllvm/binary/version.h
+++ b/include/kllvm/binary/version.h
@@ -20,7 +20,7 @@ struct binary_version {
    * Two versions are compatible if they have identical v_major and v_minor
    * components; they may differ in the v_patch component.
    */
-  constexpr bool compatible(binary_version other) const {
+  [[nodiscard]] constexpr bool compatible(binary_version other) const {
     return std::tie(v_major, v_minor) == std::tie(other.v_major, other.v_minor);
   }
 

--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -21,7 +21,7 @@ private:
   std::set<KOREPattern *> staticTerms;
 
   llvm::Value *
-  alloc_arg(KORECompositePattern *pattern, int idx, std::string locationStack);
+  alloc_arg(KORECompositePattern *pattern, int idx, const std::string& locationStack);
   llvm::Value *createHook(
       KORECompositePattern *hookAtt, KORECompositePattern *pattern,
       std::string const &locationStack = "0");
@@ -30,7 +30,7 @@ private:
       bool tailcc, std::string const &locationStack = "0");
   llvm::Value *notInjectionCase(
       KORECompositePattern *constructor, llvm::Value *val,
-      std::string locationStack = "0");
+      const std::string& locationStack = "0");
   bool populateStaticSet(KOREPattern *pattern);
   std::pair<llvm::Value *, bool> createAllocation(
       KOREPattern *pattern, std::string const &locationStack = "0");
@@ -45,7 +45,7 @@ public:
       , Module(Module)
       , Ctx(Module->getContext())
       , isAnywhereOwise(isAnywhereOwise)
-      , staticTerms(std::set<KOREPattern *>()) { }
+       { }
 
   /* adds code to the specified basic block in the specified module which
      constructs an llvm value corresponding to the specified KORE RHS pattern
@@ -73,7 +73,7 @@ public:
       std::vector<llvm::Value *> const &args, bool sret, bool tailcc,
       std::string const &locationStack = "0");
 
-  llvm::BasicBlock *getCurrentBlock() const { return CurrentBlock; }
+  [[nodiscard]] llvm::BasicBlock *getCurrentBlock() const { return CurrentBlock; }
 };
 
 std::string escape(std::string const &str);

--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -20,8 +20,8 @@ private:
   bool isAnywhereOwise;
   std::set<KOREPattern *> staticTerms;
 
-  llvm::Value *
-  alloc_arg(KORECompositePattern *pattern, int idx, const std::string& locationStack);
+  llvm::Value *alloc_arg(
+      KORECompositePattern *pattern, int idx, std::string const &locationStack);
   llvm::Value *createHook(
       KORECompositePattern *hookAtt, KORECompositePattern *pattern,
       std::string const &locationStack = "0");
@@ -30,7 +30,7 @@ private:
       bool tailcc, std::string const &locationStack = "0");
   llvm::Value *notInjectionCase(
       KORECompositePattern *constructor, llvm::Value *val,
-      const std::string& locationStack = "0");
+      std::string const &locationStack = "0");
   bool populateStaticSet(KOREPattern *pattern);
   std::pair<llvm::Value *, bool> createAllocation(
       KOREPattern *pattern, std::string const &locationStack = "0");
@@ -44,8 +44,7 @@ public:
       , CurrentBlock(EntryBlock)
       , Module(Module)
       , Ctx(Module->getContext())
-      , isAnywhereOwise(isAnywhereOwise)
-       { }
+      , isAnywhereOwise(isAnywhereOwise) { }
 
   /* adds code to the specified basic block in the specified module which
      constructs an llvm value corresponding to the specified KORE RHS pattern
@@ -73,7 +72,9 @@ public:
       std::vector<llvm::Value *> const &args, bool sret, bool tailcc,
       std::string const &locationStack = "0");
 
-  [[nodiscard]] llvm::BasicBlock *getCurrentBlock() const { return CurrentBlock; }
+  [[nodiscard]] llvm::BasicBlock *getCurrentBlock() const {
+    return CurrentBlock;
+  }
 };
 
 std::string escape(std::string const &str);

--- a/include/kllvm/codegen/Debug.h
+++ b/include/kllvm/codegen/Debug.h
@@ -18,7 +18,7 @@
 namespace kllvm {
 
 void initDebugInfo(llvm::Module *module, std::string const &filename);
-void finalizeDebugInfo(void);
+void finalizeDebugInfo();
 
 void initDebugFunction(
     std::string const &name, std::string const &linkageName,
@@ -33,23 +33,23 @@ void initDebugGlobal(
     std::string const &name, llvm::DIType *type, llvm::GlobalVariable *var);
 
 llvm::DIType *getDebugType(ValueType type, std::string const &typeName);
-llvm::DIType *getIntDebugType(void);
-llvm::DIType *getLongDebugType(void);
-llvm::DIType *getVoidDebugType(void);
-llvm::DIType *getBoolDebugType(void);
-llvm::DIType *getShortDebugType(void);
+llvm::DIType *getIntDebugType();
+llvm::DIType *getLongDebugType();
+llvm::DIType *getVoidDebugType();
+llvm::DIType *getBoolDebugType();
+llvm::DIType *getShortDebugType();
 llvm::DIType *getPointerDebugType(llvm::DIType *, std::string const &typeName);
 llvm::DIType *
 getArrayDebugType(llvm::DIType *ty, size_t len, llvm::Align align);
-llvm::DIType *getCharPtrDebugType(void);
-llvm::DIType *getCharDebugType(void);
+llvm::DIType *getCharPtrDebugType();
+llvm::DIType *getCharDebugType();
 llvm::DIType *getForwardDecl(std::string const &name);
 
 llvm::DISubroutineType *
 getDebugFunctionType(llvm::Metadata *, std::vector<llvm::Metadata *>);
 
 void setDebugLoc(llvm::Instruction *instr);
-void resetDebugLoc(void);
+void resetDebugLoc();
 
 } // namespace kllvm
 #endif

--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -43,11 +43,13 @@ using var_set_type
     = std::unordered_map<var_type, std::unordered_set<IterNextNode *>, HashVar>;
 
 class DecisionNode {
-public:
-  virtual ~DecisionNode() = default;
+private:
   llvm::BasicBlock *cachedCode = nullptr;
   /* completed tracks whether codegen for this DecisionNode has concluded */
   bool completed = false;
+
+public:
+  virtual ~DecisionNode() = default;
 
   virtual void codegen(Decision *d) = 0;
   virtual void preprocess(std::unordered_set<LeafNode *> &) = 0;

--- a/include/kllvm/codegen/DecisionParser.h
+++ b/include/kllvm/codegen/DecisionParser.h
@@ -15,11 +15,11 @@ class DecisionNode;
 
 struct Residual {
   std::string occurrence;
-  KOREPattern *pattern;
+  KOREPattern *pattern{};
 };
 
 struct PartialStep {
-  DecisionNode *dt;
+  DecisionNode *dt{};
   std::vector<Residual> residuals;
 };
 

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -129,7 +129,6 @@ public:
       KOREAxiomDeclaration *axiom, llvm::Value *check_result,
       llvm::BasicBlock *current_block);
 
-
   ProofEvent(KOREDefinition *Definition, llvm::Module *Module)
       : Definition(Definition)
       , Module(Module)

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -129,7 +129,7 @@ public:
       KOREAxiomDeclaration *axiom, llvm::Value *check_result,
       llvm::BasicBlock *current_block);
 
-public:
+
   ProofEvent(KOREDefinition *Definition, llvm::Module *Module)
       : Definition(Definition)
       , Module(Module)

--- a/include/kllvm/parser/KOREParser.h
+++ b/include/kllvm/parser/KOREParser.h
@@ -14,7 +14,7 @@ namespace kllvm::parser {
 
 class KOREParser {
 public:
-  KOREParser(const std::string& filename)
+  KOREParser(std::string const &filename)
       : scanner(KOREScanner(filename))
       , loc(location(filename)) { }
 
@@ -73,6 +73,6 @@ private:
   } buffer = {"", token::EMPTY};
 };
 
-} // end namespace kllvm
+} // namespace kllvm::parser
 
 #endif // KOREPARSER_

--- a/include/kllvm/parser/KOREParser.h
+++ b/include/kllvm/parser/KOREParser.h
@@ -10,12 +10,11 @@
 #include <utility>
 #include <vector>
 
-namespace kllvm {
-namespace parser {
+namespace kllvm::parser {
 
 class KOREParser {
 public:
-  KOREParser(std::string filename)
+  KOREParser(const std::string& filename)
       : scanner(KOREScanner(filename))
       , loc(location(filename)) { }
 
@@ -74,7 +73,6 @@ private:
   } buffer = {"", token::EMPTY};
 };
 
-} // end namespace parser
 } // end namespace kllvm
 
 #endif // KOREPARSER_

--- a/include/kllvm/parser/KOREScanner.h
+++ b/include/kllvm/parser/KOREScanner.h
@@ -3,8 +3,7 @@
 
 #include "kllvm/parser/location.h"
 
-namespace kllvm {
-namespace parser {
+namespace kllvm::parser {
 
 enum class token {
   EMPTY,
@@ -41,7 +40,7 @@ public:
 
   friend class KOREParser;
 
-  typedef void *yyscan_t;
+  using yyscan_t = void *;
 
 private:
   yyscan_t scanner;
@@ -56,7 +55,6 @@ private:
   std::string stringBuffer;
 };
 
-} // end namespace parser
 } // end namespace kllvm
 
 #endif // KORESCANNER_H

--- a/include/kllvm/parser/KOREScanner.h
+++ b/include/kllvm/parser/KOREScanner.h
@@ -42,6 +42,12 @@ public:
 
   using yyscan_t = void *;
 
+  KOREScanner(KOREScanner const &other) = delete;
+  KOREScanner &operator=(KOREScanner const &other) = delete;
+
+  KOREScanner(KOREScanner &&other) = delete;
+  KOREScanner &operator=(KOREScanner &&other) = delete;
+
 private:
   yyscan_t scanner;
   token yylex(std::string *lval, location *loc, yyscan_t yyscanner);
@@ -55,6 +61,6 @@ private:
   std::string stringBuffer;
 };
 
-} // end namespace kllvm
+} // namespace kllvm::parser
 
 #endif // KORESCANNER_H

--- a/include/kllvm/parser/location.h
+++ b/include/kllvm/parser/location.h
@@ -40,7 +40,7 @@ operator<<(std::basic_ostream<YYChar> &ostr, position const &pos) {
 
 class location {
 public:
-  location(const std::string& filename)
+  location(std::string const &filename)
       : begin({filename, 1, 1})
       , end({filename, 1, 1}) { }
 
@@ -65,10 +65,10 @@ operator<<(std::basic_ostream<YYChar> &ostr, location const &loc) {
     ostr << '-' << loc.end.line << '.' << end_col;
   } else if (loc.begin.column < end_col) {
     ostr << '-' << end_col;
-}
+  }
   return ostr;
 }
 
-} // namespace kllvm
+} // namespace kllvm::parser
 
 #endif

--- a/include/kllvm/parser/location.h
+++ b/include/kllvm/parser/location.h
@@ -3,8 +3,7 @@
 
 #include <string>
 
-namespace kllvm {
-namespace parser {
+namespace kllvm::parser {
 
 class position {
 public:
@@ -41,7 +40,7 @@ operator<<(std::basic_ostream<YYChar> &ostr, position const &pos) {
 
 class location {
 public:
-  location(std::string filename)
+  location(const std::string& filename)
       : begin({filename, 1, 1})
       , end({filename, 1, 1}) { }
 
@@ -60,16 +59,16 @@ std::basic_ostream<YYChar> &
 operator<<(std::basic_ostream<YYChar> &ostr, location const &loc) {
   unsigned end_col = 0 < loc.end.column ? loc.end.column - 1 : 0;
   ostr << loc.begin;
-  if (loc.begin.filename != loc.end.filename)
+  if (loc.begin.filename != loc.end.filename) {
     ostr << '-' << loc.end.filename << ':' << loc.end.line << '.' << end_col;
-  else if (loc.begin.line < loc.end.line)
+  } else if (loc.begin.line < loc.end.line) {
     ostr << '-' << loc.end.line << '.' << end_col;
-  else if (loc.begin.column < end_col)
+  } else if (loc.begin.column < end_col) {
     ostr << '-' << end_col;
+}
   return ostr;
 }
 
-} // namespace parser
 } // namespace kllvm
 
 #endif

--- a/include/kllvm/util/temporary_file.h
+++ b/include/kllvm/util/temporary_file.h
@@ -29,6 +29,12 @@ public:
     }
   }
 
+  temporary_file(temporary_file const &other) = delete;
+  temporary_file &operator=(temporary_file const &other) = delete;
+
+  temporary_file(temporary_file &&other) = delete;
+  temporary_file &operator=(temporary_file &&other) = delete;
+
   ~temporary_file() {
     close(temp_fd);
     remove(temp_filename.data());

--- a/include/kllvm/util/temporary_file.h
+++ b/include/kllvm/util/temporary_file.h
@@ -40,7 +40,7 @@ public:
 
   FILE *file_pointer(std::string const &mode = "r") {
     if (!temp_c_file) {
-      auto f = fdopen(temp_fd, mode.data());
+      auto *f = fdopen(temp_fd, mode.data());
       if (f) {
         temp_c_file = std::unique_ptr<FILE, deleter>(f);
       } else {

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -19,16 +19,16 @@ struct arena {
   char allocation_semispace_id;
 };
 
-typedef struct {
+using memory_block_header = struct {
   char *next_block;
   char *next_superblock;
   char semispace;
-} memory_block_header;
+};
 
 // Macro to define a new arena with the given ID. Supports IDs ranging from 0 to
 // 127.
 #define REGISTER_ARENA(name, id)                                               \
-  static struct arena name = {.allocation_semispace_id = id}
+  static struct arena name = {.allocation_semispace_id = (id)}
 
 #define mem_block_start(ptr)                                                   \
   ((char *)(((uintptr_t)(ptr)-1) & ~(BLOCK_SIZE - 1)))

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -30,7 +30,7 @@ using memory_block_header = struct {
 #define REGISTER_ARENA(name, id)                                               \
   static struct arena name = {.allocation_semispace_id = (id)}
 
-#define mem_block_start(ptr)                                                   \
+#define MEM_BLOCK_START(ptr)                                                   \
   ((char *)(((uintptr_t)(ptr)-1) & ~(BLOCK_SIZE - 1)))
 
 // Resets the given arena.

--- a/include/runtime/collect.h
+++ b/include/runtime/collect.h
@@ -41,26 +41,26 @@ void koreCollect(void **, uint8_t, layoutitem *);
 }
 
 #ifdef GC_DBG
-#define initialize_age()                                                       \
+#define INITIALIZE_AGE()                                                       \
   uint64_t age = (hdr & AGE_MASK) >> AGE_OFFSET;                               \
   uint64_t oldAge = age;
 #define increment_age()                                                        \
   if (age < ((1 << AGE_WIDTH) - 1))                                            \
     age++;
-#define migrate_header(block)                                                  \
+#define MIGRATE_HEADER(block)                                                  \
   block->h.hdr |= shouldPromote ? NOT_YOUNG_OBJECT_BIT : 0;                    \
   block->h.hdr &= ~AGE_MASK;                                                   \
   block->h.hdr |= age << AGE_OFFSET
 #else
-#define initialize_age() bool age = hdr & AGE_MASK;
+#define INITIALIZE_AGE() bool age = hdr & AGE_MASK;
 #define increment_age()
-#define migrate_header(block)                                                  \
+#define MIGRATE_HEADER(block)                                                  \
   block->h.hdr |= shouldPromote ? NOT_YOUNG_OBJECT_BIT : AGE_MASK
 #endif
 
-#define initialize_migrate()                                                   \
+#define INITIALIZE_MIGRATE()                                                   \
   bool isInYoungGen = is_in_young_gen_hdr(hdr);                                \
-  initialize_age() bool isInOldGen = is_in_old_gen_hdr(hdr);                   \
+  INITIALIZE_AGE() bool isInOldGen = is_in_old_gen_hdr(hdr);                   \
   if (!(isInYoungGen || (isInOldGen && collect_old))) {                        \
     return;                                                                    \
   }                                                                            \

--- a/include/runtime/collect.h
+++ b/include/runtime/collect.h
@@ -8,7 +8,7 @@
 
 struct block;
 using block_iterator = std::vector<block **>::iterator;
-typedef std::pair<block_iterator, block_iterator> (*BlockEnumerator)(void);
+using BlockEnumerator = std::pair<block_iterator, block_iterator> (*)();
 
 // This function is exported to the rest of the runtime to enable registering
 // more GC roots other than the top cell of the configuration.

--- a/include/runtime/collect.h
+++ b/include/runtime/collect.h
@@ -27,7 +27,6 @@ using set_impl = set::iterator::tree_t;
 
 extern "C" {
 extern size_t numBytesLiveAtCollection[1 << AGE_WIDTH];
-bool during_gc(void);
 extern bool collect_old;
 size_t get_size(uint64_t, uint16_t);
 void migrate_once(block **);

--- a/include/runtime/collections/RBTree.h
+++ b/include/runtime/collections/RBTree.h
@@ -457,10 +457,11 @@ private:
         return balance(
             Color::B, lft.left(), lft.root_key(), lft.root_val(),
             RBTree(Color::R, lft.right(), x, v, RBTree()));
-      } else {
-        return RBTree(c, lft, x, v, rgt);
       }
+
+      return RBTree(c, lft, x, v, rgt);
     }
+
     // Black parent
     if (c == Color::B) {
       if (lft.non_empty(Color::BB) && rgt.non_empty(Color::B)) {
@@ -468,22 +469,26 @@ private:
             Color::BB, RBTree(Color::R, lft.paint(Color::B), x, v, rgt.left()),
             rgt.root_key(), rgt.root_val(), rgt.right());
       }
+
       if (lft.empty(Color::BB) && rgt.non_empty(Color::B)) {
         return balance(
             Color::BB, RBTree(Color::R, RBTree(), x, v, rgt.left()),
             rgt.root_key(), rgt.root_val(), rgt.right());
       }
+
       if (lft.non_empty(Color::B) && rgt.non_empty(Color::BB)) {
         return balance(
             Color::BB, lft.left(), lft.root_key(), lft.root_val(),
             RBTree(Color::R, lft.right(), x, v, rgt.paint(Color::B)));
       }
+
       if (lft.non_empty(Color::B) && rgt.empty(Color::BB)) {
         return balance(
             Color::BB, lft.left(), lft.root_key(), lft.root_val(),
             RBTree(Color::R, lft.right(), x, v, RBTree()));
-      } else if (
-          lft.non_empty(Color::BB) && rgt.non_empty(Color::R)
+      }
+
+      if (lft.non_empty(Color::BB) && rgt.non_empty(Color::R)
           && rgt.left().non_empty(Color::B)) {
         return RBTree(
             Color::B,
@@ -493,8 +498,9 @@ private:
                 rgt.left().root_key(), rgt.left().root_val(),
                 rgt.left().right()),
             rgt.root_key(), rgt.root_val(), rgt.right());
-      } else if (
-          lft.empty(Color::BB) && rgt.non_empty(Color::R)
+      }
+
+      if (lft.empty(Color::BB) && rgt.non_empty(Color::R)
           && rgt.left().non_empty(Color::B)) {
         return RBTree(
             Color::B,
@@ -503,8 +509,9 @@ private:
                 rgt.left().root_key(), rgt.left().root_val(),
                 rgt.left().right()),
             rgt.root_key(), rgt.root_val(), rgt.right());
-      } else if (
-          lft.non_empty(Color::R) && lft.right().non_empty(Color::B)
+      }
+
+      if (lft.non_empty(Color::R) && lft.right().non_empty(Color::B)
           && rgt.non_empty(Color::BB)) {
         return RBTree(
             Color::B, lft.left(), lft.root_key(), lft.root_val(),
@@ -513,8 +520,9 @@ private:
                 lft.right().root_val(),
                 RBTree(
                     Color::R, lft.right().right(), x, v, rgt.paint(Color::B))));
-      } else if (
-          lft.non_empty(Color::R) && lft.right().non_empty(Color::B)
+      }
+
+      if (lft.non_empty(Color::R) && lft.right().non_empty(Color::B)
           && rgt.empty(Color::BB)) {
         return RBTree(
             Color::B, lft.left(), lft.root_key(), lft.root_val(),
@@ -522,9 +530,9 @@ private:
                 Color::B, lft.right().left(), lft.right().root_key(),
                 lft.right().root_val(),
                 RBTree(Color::R, lft.right().right(), x, v, RBTree())));
-      } else {
-        return RBTree(c, lft, x, v, rgt);
       }
+
+      return RBTree(c, lft, x, v, rgt);
     }
     // Otherwise
     return RBTree(c, lft, x, v, rgt);
@@ -538,6 +546,7 @@ private:
           minus_one_color(c), lft.left().paint(Color::B), lft.root_key(),
           lft.root_val(), RBTree(Color::B, lft.right(), x, v, rgt));
     }
+
     if (lft.doubled_right()) {
       return RBTree(
           minus_one_color(c),
@@ -547,6 +556,7 @@ private:
           lft.right().root_key(), lft.right().root_val(),
           RBTree(Color::B, lft.right().right(), x, v, rgt));
     }
+
     if (rgt.doubled_left()) {
       return RBTree(
           minus_one_color(c), RBTree(Color::B, lft, x, v, rgt.left().left()),
@@ -555,13 +565,14 @@ private:
               Color::B, rgt.left().right(), rgt.root_key(), rgt.root_val(),
               rgt.right()));
     }
+
     if (rgt.doubled_right()) {
       return RBTree(
           minus_one_color(c), RBTree(Color::B, lft, x, v, rgt.left()),
           rgt.root_key(), rgt.root_val(), rgt.right().paint(Color::B));
-    } else {
-      return RBTree(c, lft, x, v, rgt);
     }
+
+    return RBTree(c, lft, x, v, rgt);
   }
 
   [[nodiscard]] bool empty(Color c) const {

--- a/include/runtime/collections/RBTree.h
+++ b/include/runtime/collections/RBTree.h
@@ -434,6 +434,7 @@ private:
     return rotate(root_color(), new_left, root_key(), root_val(), right());
   }
 
+  // NOLINTNEXTLINE(*-cognitive-complexity)
   static RBTree rotate(
       Color c, RBTree const &lft, T const &x, V const &v, RBTree const &rgt) {
     // Red parent

--- a/include/runtime/collections/RBTree.h
+++ b/include/runtime/collections/RBTree.h
@@ -280,7 +280,7 @@ public:
   // exception if the black invariant does not hold for this tree.
   // Black invariant: Every path from root to empty node contains the same
   // number of black nodes.
-  int assert_black_invariant() const {
+  int assert_black_invariant() const { // NOLINT(*-use-nodiscard)
     if (empty()) {
       return 0;
     }

--- a/include/runtime/collections/rangemap.h
+++ b/include/runtime/collections/rangemap.h
@@ -10,6 +10,7 @@
 #include <optional>
 #include <stack>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace rng_map {
@@ -51,10 +52,10 @@ public:
   T &end_mutable() { return end_; }
 
   // Getter for the start of this range.
-  T const &start() const { return start_; }
+  [[nodiscard]] T const &start() const { return start_; }
 
   // Getter for the end of this range.
-  T const &end() const { return end_; }
+  [[nodiscard]] T const &end() const { return end_; }
 
   // The following methods define the ordering for objects of class Range.
   // Operator < is used to subsequently define >, ==, <=, >=, and !=.
@@ -78,16 +79,19 @@ public:
   }
 
   // Returns true if this range contains k.
-  bool contains(T const &k) const { return k >= start_ && k < end_; }
+  [[nodiscard]] bool contains(T const &k) const {
+    return k >= start_ && k < end_;
+  }
 
   // Returns true if this range is empty.
-  bool empty() const { return start_ >= end_; }
+  [[nodiscard]] bool empty() const { return start_ >= end_; }
 
   // Returns true if this range overlaps with range r.
-  bool overlaps(Range const &r) const {
+  [[nodiscard]] bool overlaps(Range const &r) const {
     if (r.end_ <= start_) {
       return false;
-    } else if (end_ <= r.start_) {
+    }
+    if (end_ <= r.start_) {
       return false;
     }
     return true;
@@ -95,10 +99,11 @@ public:
 
   // Returns true if this range and range r overlap or are adjacent, i.e.,
   // share a bound, either inclusive or exclusive.
-  bool is_relevant(Range const &r) const {
+  [[nodiscard]] bool is_relevant(Range const &r) const {
     if (r.end_ < start_) {
       return false;
-    } else if (end_ < r.start_) {
+    }
+    if (end_ < r.start_) {
       return false;
     }
     return true;
@@ -118,9 +123,9 @@ private:
   // Create a rangemap on top of a red-black tree that uses ranges as keys.
   // The red black tree should already be a well-formed rangemap.
   RangeMap(rb_tree::RBTree<Range<T>, V> t)
-      : treemap_(t) { }
+      : treemap_(std::move(t)) { }
 
-  std::optional<std::pair<Range<T>, V>>
+  [[nodiscard]] std::optional<std::pair<Range<T>, V>>
   get_key_value(rb_tree::RBTree<Range<T>, V> const &t, T const &k) const {
     if (t.empty()) {
       return std::nullopt;
@@ -139,7 +144,7 @@ private:
 
   // Return true if range r partially or completely overlaps with any range
   // stored in the ordered map t that is passed as an argument.
-  bool
+  [[nodiscard]] bool
   overlaps(rb_tree::RBTree<Range<T>, V> const &t, Range<T> const &r) const {
     if (t.empty()) {
       return false;
@@ -153,7 +158,8 @@ private:
       // overlapping. Continue looking for overlapping ranges to the right of
       // root.
       return overlaps(t.right(), r);
-    } else if (end <= rstart) {
+    }
+    if (end <= rstart) {
       // The root is to the right of range r, possibly adjacent but not
       // overlapping. Continue looking for overlapping ranges to the left of
       // root.
@@ -268,7 +274,8 @@ private:
   // Return the intersection ranges of this rangemap and rangemap m, i.e. all
   // ranges in this rangemap that overlap (fully or partially) with ranges in m
   // and are mapped to the same value in both rangemaps.
-  std::vector<Range<T>> get_intersection_ranges(RangeMap const &m) const {
+  [[nodiscard]] std::vector<Range<T>>
+  get_intersection_ranges(RangeMap const &m) const {
     std::vector<std::pair<Range<T>, V>> r1;
     for_each(treemap_, [&r1](Range<T> const &x, V const &v) {
       r1.emplace_back(std::make_pair(x, v));
@@ -319,20 +326,24 @@ public:
   }
 
   // Getter for the rb-tree underlying this rangemap.
-  rb_tree::RBTree<Range<T>, V> treemap() const { return treemap_; }
+  [[nodiscard]] rb_tree::RBTree<Range<T>, V> treemap() const {
+    return treemap_;
+  }
 
   // Return the number of key ranges in the map.
-  size_t size() const { return treemap_.size(); }
+  [[nodiscard]] size_t size() const { return treemap_.size(); }
 
   // Returns true if this rangemap is empty.
-  bool empty() const { return treemap_.size() == 0; }
+  [[nodiscard]] bool empty() const { return treemap_.empty(); }
 
   // Return true if a range in this map contains the key k.
-  bool contains(T const &k) const { return get_key_value(k).has_value(); }
+  [[nodiscard]] bool contains(T const &k) const {
+    return get_key_value(k).has_value();
+  }
 
   // If the key k is contained in any range in this map, return the value
   // associated with k.
-  std::optional<V> get_value(T const &k) const {
+  [[nodiscard]] std::optional<V> get_value(T const &k) const {
     auto opt = get_key_value(k);
     if (opt.has_value()) {
       return opt.value().second;
@@ -342,7 +353,8 @@ public:
 
   // If the key k is contained in any range in this map, return the key range-
   // value pair associated with k.
-  std::optional<std::pair<Range<T>, V>> get_key_value(T const &k) const {
+  [[nodiscard]] std::optional<std::pair<Range<T>, V>>
+  get_key_value(T const &k) const {
     return get_key_value(treemap_, k);
   }
 
@@ -355,7 +367,7 @@ public:
      * existing range mapping to the same value, then the ranges will be
      * coalesced into a single contiguous range in the resulting map.
      */
-  RangeMap inserted(Range<T> const &r, V const &v) const {
+  [[nodiscard]] RangeMap inserted(Range<T> const &r, V const &v) const {
     // Empty ranges do not make sense here.
     if (r.empty()) {
       KLLVM_HOOK_INVALID_ARGUMENT("Insert empty range in range map");
@@ -418,7 +430,7 @@ public:
      * map, then the boundaries of these ranges are adjusted in the resulting
      * map so that they do not overlap with the removed range.
      */
-  RangeMap deleted(Range<T> const &r) const {
+  [[nodiscard]] RangeMap deleted(Range<T> const &r) const {
     // Empty ranges do not make sense here.
     if (r.empty()) {
       KLLVM_HOOK_INVALID_ARGUMENT("Delete empty range from range map");
@@ -452,7 +464,9 @@ public:
 
   // Return true if range r partially or completely overlaps with any key range
   // stored in this rangemap.
-  bool overlaps(Range<T> const &r) const { return overlaps(treemap_, r); }
+  [[nodiscard]] bool overlaps(Range<T> const &r) const {
+    return overlaps(treemap_, r);
+  }
 
   // Print this rangemap to output stream os.
   void print(std::ostream &os) const {
@@ -466,7 +480,7 @@ public:
   // Return a rangemap that is the concatenation of this rangemap and rangemap
   // m. Throw an exception if any of the key ranges in this rangemap overlaps
   // with any of the key ranges in rangemap m.
-  RangeMap concat(RangeMap const &m) const {
+  [[nodiscard]] RangeMap concat(RangeMap const &m) const {
     RangeMap res = *this;
     for_each(m.treemap_, [&res, this](Range<T> const &x, V const &v) {
       if (!overlaps(x)) {
@@ -484,7 +498,7 @@ public:
   // key range-value pairs whose keys are contained in ranges in both A and B
   // and are mapped to the same value. Then, we perform A - A^B, and return the
   // map resulting from deleting these ranges from A.
-  RangeMap difference(RangeMap const &m) const {
+  [[nodiscard]] RangeMap difference(RangeMap const &m) const {
     // Compute the intersection of this rangemap and m.
     std::vector<Range<T>> intersect = get_intersection_ranges(m);
     // Delete all collected intersection ranges from this rangemap.
@@ -498,7 +512,7 @@ public:
   // Return true if this rangemap is included in rangemap m, i.e. all key
   // range-value pairs contained in this rangemap whose keys are also contained
   // in key ranges in m and are mapped to the same value.
-  bool inclusion(RangeMap const &m) const {
+  [[nodiscard]] bool inclusion(RangeMap const &m) const {
     // Compute the intersection of this rangemap and m.
     std::vector<Range<T>> intersect = get_intersection_ranges(m);
     // Compare the intersection ranges with this rangemap's ranges.
@@ -529,7 +543,7 @@ template <class T, class V>
 class AbstractRangeMapIterator {
 
 protected:
-  std::stack<rb_tree::RBTree<Range<T>, V>> stack_;
+  std::stack<rb_tree::RBTree<Range<T>, V>> stack_{};
 
   void update_stack_state(rb_tree::RBTree<Range<T>, V> const &t) {
     rb_tree::RBTree<Range<T>, V> tmp = t;
@@ -553,7 +567,7 @@ public:
   }
 
   // Return true if there are more elements in the underlying rangemap.
-  bool has_next() const { return !stack_.empty(); }
+  [[nodiscard]] bool has_next() const { return !stack_.empty(); }
 };
 
 template <class T, class V>

--- a/include/runtime/collections/rangemap.h
+++ b/include/runtime/collections/rangemap.h
@@ -149,26 +149,29 @@ private:
     if (t.empty()) {
       return false;
     }
+
     T const &start = r.start();
     T const &end = r.end();
     T const &rstart = t.root_key().start();
     T const &rend = t.root_key().end();
+
     if (rend <= start) {
       // The root is to the left of range r, possibly adjacent but not
       // overlapping. Continue looking for overlapping ranges to the right of
       // root.
       return overlaps(t.right(), r);
     }
+
     if (end <= rstart) {
       // The root is to the right of range r, possibly adjacent but not
       // overlapping. Continue looking for overlapping ranges to the left of
       // root.
       return overlaps(t.left(), r);
-    } else {
-      // In any other case, range r somehow overlaps with root, either partially
-      // or completely.
-      return true;
     }
+
+    // In any other case, range r somehow overlaps with root, either partially
+    // or completely.
+    return true;
   }
 
   // Gather all <Range<T>, V> pairs in t that are overlapping or directly

--- a/include/runtime/collections/rangemap.h
+++ b/include/runtime/collections/rangemap.h
@@ -545,8 +545,11 @@ public:
 template <class T, class V>
 class AbstractRangeMapIterator {
 
-protected:
+private:
   std::stack<rb_tree::RBTree<Range<T>, V>> stack_{};
+
+protected:
+  auto const &stack() const { return stack_; }
 
   void update_stack_state(rb_tree::RBTree<Range<T>, V> const &t) {
     rb_tree::RBTree<Range<T>, V> tmp = t;
@@ -577,21 +580,19 @@ template <class T, class V>
 class ConstRangeMapIterator : public AbstractRangeMapIterator<T, V> {
 
 public:
-  using AbstractRangeMapIterator<T, V>::stack_;
-
   // Create an iterator over rangemap m.
   ConstRangeMapIterator(RangeMap<T, V> m)
       : AbstractRangeMapIterator<T, V>(m) { }
 
   // Dereference operator.
   std::pair<Range<T>, V> const &operator*() const {
-    rb_tree::RBTree<Range<T>, V> const &t = stack_.top();
+    rb_tree::RBTree<Range<T>, V> const &t = this->stack().top();
     return t.root_data();
   }
 
   // Member access (arrow) operator.
   std::pair<Range<T>, V> const *operator->() const {
-    rb_tree::RBTree<Range<T>, V> const &t = stack_.top();
+    rb_tree::RBTree<Range<T>, V> const &t = this->stack().top();
     return &t.root_data();
   }
 };

--- a/include/runtime/collections/rangemap.h
+++ b/include/runtime/collections/rangemap.h
@@ -549,7 +549,7 @@ private:
   std::stack<rb_tree::RBTree<Range<T>, V>> stack_{};
 
 protected:
-  auto const &stack() const { return stack_; }
+  [[nodiscard]] auto const &stack() const { return stack_; }
 
   void update_stack_state(rb_tree::RBTree<Range<T>, V> const &t) {
     rb_tree::RBTree<Range<T>, V> tmp = t;

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -40,7 +40,7 @@ struct MatchLog {
 
 // the actual length is equal to the block header with the gc bits masked out.
 
-#define struct_base(struct_type, member_name, member_addr)                     \
+#define STRUCT_BASE(struct_type, member_name, member_addr)                     \
   ((struct_type *)((char *)(member_addr)-offsetof(struct_type, member_name)))
 
 extern "C" {
@@ -191,9 +191,11 @@ __attribute__((always_inline)) constexpr bool is_heap_block(T const *s) {
 
 class KElem {
 public:
-  KElem() : elem(nullptr) { }
+  KElem()
+      : elem(nullptr) { }
 
-  KElem(block *elem) : elem(elem) { }
+  KElem(block *elem)
+      : elem(elem) { }
 
   bool operator==(KElem const &other) const {
     return hook_KEQUAL_eq(this->elem, other.elem);
@@ -222,10 +224,10 @@ struct kore_alloc_heap {
   static void *allocate(size_t size, Tags...) {
     if (during_gc()) {
       return ::operator new(size);
-    }       auto *result = (string *)koreAllocToken(size + sizeof(blockheader));
-      init_with_len(result, size);
-      return result->data;
-   
+    }
+    auto *result = (string *)koreAllocToken(size + sizeof(blockheader));
+    init_with_len(result, size);
+    return result->data;
   }
 
   static void deallocate(size_t size, void *data) {
@@ -249,10 +251,9 @@ using list = immer::flex_vector<
     KElem, immer::memory_policy<
                immer::heap_policy<kore_alloc_heap>, immer::no_refcount_policy,
                immer::no_lock_policy>>;
-using map = immer::map<
-    KElem, KElem, HashBlock, std::equal_to<>, list::memory_policy>;
-using set
-    = immer::set<KElem, HashBlock, std::equal_to<>, list::memory_policy>;
+using map
+    = immer::map<KElem, KElem, HashBlock, std::equal_to<>, list::memory_policy>;
+using set = immer::set<KElem, HashBlock, std::equal_to<>, list::memory_policy>;
 using rangemap = rng_map::RangeMap<KElem, KElem>;
 
 using mapiter = struct mapiter {

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -28,14 +28,14 @@
 struct MatchLog {
   enum { SUCCESS = 0, FUNCTION, FAIL } kind;
 
-  char const *function;
-  char const *debugName;
-  void *result;
-  std::vector<void *> args;
+  char const *function{};
+  char const *debugName{};
+  void *result{};
+  std::vector<void *> args{};
 
-  char const *pattern;
-  void *subject;
-  char const *sort;
+  char const *pattern{};
+  void *subject{};
+  char const *sort{};
 };
 
 // the actual length is equal to the block header with the gc bits masked out.
@@ -45,9 +45,9 @@ struct MatchLog {
 
 extern "C" {
 // llvm: blockheader = type { i64 }
-typedef struct blockheader {
+using blockheader = struct blockheader {
   uint64_t hdr;
-} blockheader;
+};
 
 // A value b of type block* is either a constant or a block.
 // if (((uintptr_t)b) & 3) == 3, then it is a bound variable and
@@ -56,53 +56,53 @@ typedef struct blockheader {
 // of the symbol. Otherwise, if ((uintptr_t)b) & 1 == 0 then it is a pointer to
 // a block.
 // llvm: block = type { %blockheader, [0 x i64 *] }
-typedef struct block {
+using block = struct block {
   blockheader h;
   uint64_t *children[];
-} block;
+};
 
 // llvm: string = type { %blockheader, [0 x i8] }
-typedef struct string {
+using string = struct string {
   blockheader h;
   char data[];
-} string;
+};
 
 // llvm: stringbuffer = type { i64, i64, %string* }
-typedef struct stringbuffer {
+using stringbuffer = struct stringbuffer {
   blockheader h;
   uint64_t strlen;
   string *contents;
-} stringbuffer;
+};
 
-typedef struct mpz_hdr {
+using mpz_hdr = struct mpz_hdr {
   blockheader h;
   mpz_t i;
-} mpz_hdr;
+};
 
-typedef struct floating {
+using floating = struct floating {
   uint64_t exp; // number of bits in exponent range
   mpfr_t f;
-} floating;
+};
 
-typedef struct floating_hdr {
+using floating_hdr = struct floating_hdr {
   blockheader h;
   floating f;
-} floating_hdr;
+};
 
-typedef struct layoutitem {
+using layoutitem = struct layoutitem {
   uint64_t offset;
   uint16_t cat;
-} layoutitem;
+};
 
-typedef struct layout {
+using layout = struct layout {
   uint8_t nargs;
   layoutitem *args;
-} layout;
+};
 
-typedef struct {
+using writer = struct {
   FILE *file;
   stringbuffer *buffer;
-} writer;
+};
 
 bool hook_KEQUAL_lt(block *, block *);
 bool hook_KEQUAL_eq(block *, block *);
@@ -191,9 +191,9 @@ __attribute__((always_inline)) constexpr bool is_heap_block(T const *s) {
 
 class KElem {
 public:
-  KElem() { this->elem = NULL; }
+  KElem() : elem(nullptr) { }
 
-  KElem(block *elem) { this->elem = elem; }
+  KElem(block *elem) : elem(elem) { }
 
   bool operator==(KElem const &other) const {
     return hook_KEQUAL_eq(this->elem, other.elem);
@@ -222,11 +222,10 @@ struct kore_alloc_heap {
   static void *allocate(size_t size, Tags...) {
     if (during_gc()) {
       return ::operator new(size);
-    } else {
-      string *result = (string *)koreAllocToken(size + sizeof(blockheader));
+    }       auto *result = (string *)koreAllocToken(size + sizeof(blockheader));
       init_with_len(result, size);
       return result->data;
-    }
+   
   }
 
   static void deallocate(size_t size, void *data) {
@@ -251,40 +250,40 @@ using list = immer::flex_vector<
                immer::heap_policy<kore_alloc_heap>, immer::no_refcount_policy,
                immer::no_lock_policy>>;
 using map = immer::map<
-    KElem, KElem, HashBlock, std::equal_to<KElem>, list::memory_policy>;
+    KElem, KElem, HashBlock, std::equal_to<>, list::memory_policy>;
 using set
-    = immer::set<KElem, HashBlock, std::equal_to<KElem>, list::memory_policy>;
+    = immer::set<KElem, HashBlock, std::equal_to<>, list::memory_policy>;
 using rangemap = rng_map::RangeMap<KElem, KElem>;
 
-typedef struct mapiter {
-  map::iterator curr;
-  map *map_item;
-} mapiter;
+using mapiter = struct mapiter {
+  map::iterator curr{};
+  map *map_item{};
+};
 
-typedef struct setiter {
-  set::iterator curr;
-  set *set_item;
-} setiter;
+using setiter = struct setiter {
+  set::iterator curr{};
+  set *set_item{};
+};
 
-typedef floating *SortFloat;
-typedef mpz_ptr SortInt;
-typedef string *SortString;
-typedef string *SortBytes;
-typedef stringbuffer *SortStringBuffer;
-typedef block *SortK;
-typedef block *SortKItem;
-typedef block *SortIOInt;
-typedef block *SortIOFile;
-typedef block *SortIOString;
-typedef block *SortJSON;
-typedef block *SortEndianness;
-typedef block *SortSignedness;
-typedef block *SortFFIType;
-typedef list *SortList;
-typedef map *SortMap;
-typedef set *SortSet;
-typedef block *SortRange;
-typedef rangemap *SortRangeMap;
+using SortFloat = floating *;
+using SortInt = mpz_ptr;
+using SortString = string *;
+using SortBytes = string *;
+using SortStringBuffer = stringbuffer *;
+using SortK = block *;
+using SortKItem = block *;
+using SortIOInt = block *;
+using SortIOFile = block *;
+using SortIOString = block *;
+using SortJSON = block *;
+using SortEndianness = block *;
+using SortSignedness = block *;
+using SortFFIType = block *;
+using SortList = list *;
+using SortMap = map *;
+using SortSet = set *;
+using SortRange = block *;
+using SortRangeMap = rangemap *;
 
 void *constructCompositePattern(uint32_t tag, std::vector<void *> &arguments);
 
@@ -359,7 +358,7 @@ char const *topSort(void);
 
 bool symbolIsInstantiation(uint32_t tag);
 
-typedef struct {
+using visitor = struct {
   void (*visitConfig)(writer *, block *, char const *, bool, void *);
   void (*visitMap)(
       writer *, map *, char const *, char const *, char const *, void *);
@@ -375,7 +374,7 @@ typedef struct {
   void (*visitSeparator)(writer *, void *);
   void (*visitRangeMap)(
       writer *, rangemap *, char const *, char const *, char const *, void *);
-} visitor;
+};
 
 void printMap(
     writer *, map *, char const *, char const *, char const *, void *);

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1467,11 +1467,11 @@ void KORECompositeSortDeclaration::print(
 void KORESymbolDeclaration::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent << (_isHooked ? "hooked-symbol " : "symbol ")
-      << symbol->getName();
+      << getSymbol()->getName();
   printSortVariables(Out);
   Out << "(";
   bool isFirst = true;
-  for (auto const &Argument : symbol->getArguments()) {
+  for (auto const &Argument : getSymbol()->getArguments()) {
     if (!isFirst) {
       Out << ",";
     }
@@ -1479,18 +1479,18 @@ void KORESymbolDeclaration::print(std::ostream &Out, unsigned indent) const {
     isFirst = false;
   }
   Out << ") : ";
-  symbol->getSort()->print(Out);
+  getSymbol()->getSort()->print(Out);
   Out << " ";
   printAttributeList(Out, attributes());
 }
 
 void KOREAliasDeclaration::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
-  Out << Indent << "alias " << symbol->getName();
+  Out << Indent << "alias " << getSymbol()->getName();
   printSortVariables(Out);
   Out << "(";
   bool isFirst = true;
-  for (auto const &Argument : symbol->getArguments()) {
+  for (auto const &Argument : getSymbol()->getArguments()) {
     if (!isFirst) {
       Out << ",";
     }
@@ -1498,7 +1498,7 @@ void KOREAliasDeclaration::print(std::ostream &Out, unsigned indent) const {
     isFirst = false;
   }
   Out << ") : ";
-  symbol->getSort()->print(Out);
+  getSymbol()->getSort()->print(Out);
   Out << " where ";
   boundVariables->print(Out);
   Out << " := ";

--- a/lib/binary/ProofTraceParser.cpp
+++ b/lib/binary/ProofTraceParser.cpp
@@ -23,7 +23,7 @@ LLVMHookEvent::LLVMHookEvent(std::string _name, std::string _relativePosition)
     : name(std::move(_name))
     , relativePosition(std::move(_relativePosition))
     , korePattern(nullptr)
-    , patternLength(0U) { }
+     { }
 
 void LLVMHookEvent::addArgument(LLVMEvent const &argument) {
   arguments.push_back(argument);

--- a/lib/binary/ProofTraceParser.cpp
+++ b/lib/binary/ProofTraceParser.cpp
@@ -22,8 +22,7 @@ void LLVMFunctionEvent::addArgument(LLVMEvent const &argument) {
 LLVMHookEvent::LLVMHookEvent(std::string _name, std::string _relativePosition)
     : name(std::move(_name))
     , relativePosition(std::move(_relativePosition))
-    , korePattern(nullptr)
-     { }
+    , korePattern(nullptr) { }
 
 void LLVMHookEvent::addArgument(LLVMEvent const &argument) {
   arguments.push_back(argument);
@@ -40,15 +39,15 @@ void LLVMRewriteEvent::printSubstitution(
 void LLVMRuleEvent::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent * indent_size, ' ');
   Out << fmt::format(
-      "{}rule: {} {}\n", Indent, ruleOrdinal, substitution.size());
+      "{}rule: {} {}\n", Indent, getRuleOrdinal(), getSubstitution().size());
   printSubstitution(Out, indent + 1U);
 }
 
 void LLVMSideConditionEvent::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent * indent_size, ' ');
   Out << fmt::format(
-      "{}side condition entry: {} {}\n", Indent, ruleOrdinal,
-      substitution.size());
+      "{}side condition entry: {} {}\n", Indent, getRuleOrdinal(),
+      getSubstitution().size());
   printSubstitution(Out, indent + 1U);
 }
 

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -292,7 +292,7 @@ sptr<KORESort> termSort(KOREPattern *pattern) {
 }
 
 llvm::Value *CreateTerm::alloc_arg(
-    KORECompositePattern *pattern, int idx, std::string locationStack) {
+    KORECompositePattern *pattern, int idx, std::string const &locationStack) {
   KOREPattern *p = pattern->getArguments()[idx].get();
   std::string newLocation = fmt::format("{}:{}", locationStack, idx);
   if (isInjectionSymbol(p, Definition->getInjSymbol())) {
@@ -752,7 +752,7 @@ llvm::Value *CreateTerm::createFunctionCall(
  * triangle injection pair */
 llvm::Value *CreateTerm::notInjectionCase(
     KORECompositePattern *constructor, llvm::Value *val,
-    std::string locationStack) {
+    std::string const &locationStack) {
   KORESymbol const *symbol = constructor->getConstructor();
   KORESymbolDeclaration *symbolDecl
       = Definition->getSymbolDeclarations().at(symbol->getName());

--- a/lib/codegen/DecisionParser.cpp
+++ b/lib/codegen/DecisionParser.cpp
@@ -24,7 +24,7 @@ namespace kllvm {
 
 class DTPreprocessor {
 private:
-  std::map<yaml_node_t *, DecisionNode *> uniqueNodes;
+  std::map<yaml_node_t *, DecisionNode *> uniqueNodes{};
   std::map<std::string, KORESymbol *> const &syms;
   std::map<ValueType, sptr<KORECompositeSort>> const &sorts;
   KORESymbol *dv;
@@ -111,10 +111,9 @@ public:
       llvm::Module *mod, yaml_document_t *doc)
       : syms(syms)
       , sorts(sorts)
+      , dv(KORESymbol::Create("\\dv").release())
       , doc(doc)
-      , mod(mod) {
-    dv = KORESymbol::Create("\\dv").release();
-  }
+      , mod(mod) { }
 
   static std::string to_string(std::vector<std::string> const &occurrence) {
     std::string result;

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -188,10 +188,10 @@ char *movePtr(char *ptr, size_t size, char const *arena_end_ptr) {
   if (next_ptr == arena_end_ptr) {
     return nullptr;
   }
-  if (next_ptr != mem_block_start(ptr) + BLOCK_SIZE) {
+  if (next_ptr != MEM_BLOCK_START(ptr) + BLOCK_SIZE) {
     return next_ptr;
   }
-  char *next_block = *(char **)mem_block_start(ptr);
+  char *next_block = *(char **)MEM_BLOCK_START(ptr);
   if (!next_block) {
     return nullptr;
   }
@@ -199,7 +199,7 @@ char *movePtr(char *ptr, size_t size, char const *arena_end_ptr) {
 }
 
 ssize_t ptrDiff(char *ptr1, char *ptr2) {
-  if (mem_block_start(ptr1) == mem_block_start(ptr2)) {
+  if (MEM_BLOCK_START(ptr1) == MEM_BLOCK_START(ptr2)) {
     return ptr1 - ptr2;
   }
   memory_block_header *hdr = mem_block_header(ptr2);

--- a/runtime/collect/migrate_collection.cpp
+++ b/runtime/collect/migrate_collection.cpp
@@ -5,7 +5,7 @@
 #include <cstring>
 
 void migrate_collection_node(void **nodePtr) {
-  string *currBlock = struct_base(string, data, *nodePtr);
+  string *currBlock = STRUCT_BASE(string, data, *nodePtr);
   if (youngspace_collection_id()
           != getArenaSemispaceIDOfObject((void *)currBlock)
       && oldspace_collection_id()
@@ -13,7 +13,7 @@ void migrate_collection_node(void **nodePtr) {
     return;
   }
   uint64_t const hdr = currBlock->h.hdr;
-  initialize_migrate();
+  INITIALIZE_MIGRATE();
   size_t lenInBytes = get_size(hdr, 0);
   if (!hasForwardingAddress) {
     string *newBlock = nullptr;
@@ -26,7 +26,7 @@ void migrate_collection_node(void **nodePtr) {
     numBytesLiveAtCollection[oldAge] += lenInBytes;
 #endif
     memcpy(newBlock, currBlock, lenInBytes);
-    migrate_header(newBlock);
+    MIGRATE_HEADER(newBlock);
     *(void **)(currBlock + 1) = newBlock + 1;
     currBlock->h.hdr |= FWD_PTR_BIT;
   }

--- a/runtime/collect/migrate_roots.cpp
+++ b/runtime/collect/migrate_roots.cpp
@@ -22,7 +22,7 @@ void migrateRoots() {
   migrate_collection_node((void **)&m);
   if (kllvm_randStateInitialized) {
     auto &rand = kllvm_randState->_mp_seed->_mp_d;
-    string *limbs = struct_base(string, data, rand);
+    string *limbs = STRUCT_BASE(string, data, rand);
     migrate((block **)&limbs);
     rand = (mp_limb_t *)limbs->data;
   }

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -25,7 +25,7 @@ mapfile -t inputs < <(find "${source_dirs[@]}" -name '*.cpp' -or -name '*.h')
 
 "${driver}"                           \
   "${inputs[@]}"                      \
-  -header-filter 'include/(kllvm|runtime)'              \
+  -header-filter 'include/(kllvm|runtime)/'              \
   -clang-tidy-binary "${clang_tidy}"  \
   -j "$(nproc)"                       \
   -p "${BUILD_DIR}" "$@"              \

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -25,6 +25,7 @@ mapfile -t inputs < <(find "${source_dirs[@]}" -name '*.cpp' -or -name '*.h')
 
 "${driver}"                           \
   "${inputs[@]}"                      \
+  -header-filter 'include/(kllvm|runtime)'              \
   -clang-tidy-binary "${clang_tidy}"  \
   -j "$(nproc)"                       \
   -p "${BUILD_DIR}" "$@"              \

--- a/unittests/runtime-collections/rangemaps.cpp
+++ b/unittests/runtime-collections/rangemaps.cpp
@@ -50,13 +50,13 @@ BOOST_AUTO_TEST_CASE(rangemap_test_concat_failure) {
   auto m1
       = (rng_map::RangeMap<int, int>()).inserted(rng_map::Range<int>(0, 3), 2);
   auto map2 = m1.inserted(rng_map::Range<int>(8, 9), 4);
-  BOOST_CHECK_THROW(map1.concat(map2), std::invalid_argument);
+  BOOST_CHECK_THROW((void)map1.concat(map2), std::invalid_argument);
   auto map3
       = (rng_map::RangeMap<int, int>()).inserted(rng_map::Range<int>(3, 6), 2);
-  BOOST_CHECK_THROW(map1.concat(map3), std::invalid_argument);
+  BOOST_CHECK_THROW((void)map1.concat(map3), std::invalid_argument);
   auto map4
       = (rng_map::RangeMap<int, int>()).inserted(rng_map::Range<int>(5, 8), 2);
-  BOOST_CHECK_THROW(map1.concat(map4), std::invalid_argument);
+  BOOST_CHECK_THROW((void)map1.concat(map4), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(rangemap_test_contains_key) {

--- a/unittests/runtime-collections/treemaps.cpp
+++ b/unittests/runtime-collections/treemaps.cpp
@@ -107,14 +107,14 @@ BOOST_AUTO_TEST_CASE(treemap_test_concat_success) {
 BOOST_AUTO_TEST_CASE(treemap_test_concat_failure) {
   auto m1 = (rb_tree::RBTree<int, int>()).inserted(0, 1);
   auto m2 = (rb_tree::RBTree<int, int>()).inserted(0, 2);
-  BOOST_CHECK_THROW(m1.concat(m2), std::invalid_argument);
+  BOOST_CHECK_THROW((void)m1.concat(m2), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(treemap_test_at) {
   auto map = (rb_tree::RBTree<int, int>()).inserted(0, 1);
   auto result = map.at(0);
   BOOST_CHECK_EQUAL(result, 1);
-  BOOST_CHECK_THROW(map.at(2), std::invalid_argument);
+  BOOST_CHECK_THROW((void)map.at(2), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(treemap_test_contains) {


### PR DESCRIPTION
This is a largely mechanical PR that extends our `clang-tidy` setup to run on header files as well as implementations (an oversight in our earlier introduction of the checker).

No new checks are added, so there shouldn't be anything controversial in the changes here.

Fixes #995