### PR TITLE
Remove `zlib` dependency

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,8 +24,7 @@ sudo apt install      \
   pkg-config          \
   python3             \
   python3-pip         \
-  xxd                 \
-  zlib1g-dev
+  xxd
 python3 -m pip install pybind11 lit
 ```
 

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -4,7 +4,6 @@ find_package(Boost      REQUIRED COMPONENTS unit_test_framework)
 find_package(FLEX       REQUIRED)
 find_package(GMP        REQUIRED)
 find_package(PkgConfig  REQUIRED)
-find_package(ZLIB       REQUIRED)
 find_package(fmt        REQUIRED)
 
 pkg_check_modules(FFI REQUIRED libffi)


### PR DESCRIPTION
When setting CLion up to do some automatic refactoring, it complained about not being able to find this dependency. Some digging reveals it was added in the very first commit of the backend's build system and has not been touched since, so I think it's safe to remove.