### PR TITLE
Add source artifacts for Scala compiler bridge

### DIFF
--- a/matching/pom.xml
+++ b/matching/pom.xml
@@ -75,6 +75,11 @@
       <version>1.4</version>
       <classifier>linux64</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.scala-sbt</groupId>
+      <artifactId>compiler-bridge_2.12</artifactId>
+      <version>1.8.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/nix/llvm-backend-matching.nix
+++ b/nix/llvm-backend-matching.nix
@@ -12,10 +12,16 @@ let self = maven.buildMavenPackage rec {
       "org.apache.maven.plugins:maven-compiler-plugin:3.7.0"
     ];
 
+    manualMvnSourceArtifacts = [
+      "org.scala-sbt:compiler-bridge_2.12"
+    ];
+
     passthru = {
       jar =
         "${self}/share/java/llvm-backend-matching-1.0-SNAPSHOT-jar-with-dependencies.jar";
     };
+
+    mvnParameters = "-DsecondaryCacheDir=secondary-cache";
 
     installPhase = ''
       mkdir -p $out/share/java

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -21,7 +21,7 @@ let
 
   llvm-backend-matching = import ./llvm-backend-matching.nix {
     src = prev.llvm-backend-matching-src;
-    mvnHash = "sha256-5wHyZF/a4seBo3gOHXkhNJimMyUaXxlSSbMeBH7ET7k=";
+    mvnHash = "sha256-2X8G3T05Pk1apA0f04Mdu/8DAB89oB9XwTBQ3KVoc/A=";
     inherit (final) maven;
   };
 


### PR DESCRIPTION
https://github.com/runtimeverification/llvm-backend/pull/1006 is failing because the Scala Maven plugin is trying to download the sources for the compiler bridge, but can't do so outside of a Nix FOD. This PR adds the bridge to the manually-downloaded Maven artifacts (as we did in https://github.com/runtimeverification/k/pull/4055)