### PR TITLE
Adding `get_requires()` to Python bindings

### DIFF
--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -179,7 +179,8 @@ void bind_ast(py::module_ &m) {
           py::arg("is_claim") = false)
       .def_property_readonly("is_claim", &kore_axiom_declaration::is_claim)
       .def("add_pattern", &kore_axiom_declaration::add_pattern)
-      .def_property_readonly("pattern", &kore_axiom_declaration::get_pattern);
+      .def_property_readonly("pattern", &kore_axiom_declaration::get_pattern)
+      .def("get_requires", &kore_axiom_declaration::get_requires);
 
   py::class_<
       kore_module_import_declaration,

--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -180,7 +180,7 @@ void bind_ast(py::module_ &m) {
       .def_property_readonly("is_claim", &kore_axiom_declaration::is_claim)
       .def("add_pattern", &kore_axiom_declaration::add_pattern)
       .def_property_readonly("pattern", &kore_axiom_declaration::get_pattern)
-      .def("get_requires", &kore_axiom_declaration::get_requires);
+      .def_property_readonly("requires", &kore_axiom_declaration::get_requires);
 
   py::class_<
       kore_module_import_declaration,


### PR DESCRIPTION
This is a requirement from the Math Proof Generation Team of $Piˆ2$ to get easy access to the Pattern of a requires clause.

This PR must be merged before this [PyK PR](https://github.com/runtimeverification/pyk/pull/1056) that will properly expose this binding to the Pi2 project.