### PR TITLE
Don't emit non-exhaustiveness warning if `no-evaluators` is present

### DIFF
--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
@@ -1087,15 +1087,16 @@ class Matrix private (
       val location   = Parser.location(attributes)
       val source     = Parser.source(attributes)
 
-      kem(
-        new MatchingException(
-          MatchingException.Type.NON_EXHAUSTIVE_MATCH,
-          "Non exhaustive match detected",
-          source,
-          location,
-          func
+      if (!Parser.hasAtt(attributes, "no-evaluators"))
+        kem(
+          new MatchingException(
+            MatchingException.Type.NON_EXHAUSTIVE_MATCH,
+            "Non exhaustive match detected",
+            source,
+            location,
+            func
+          )
         )
-      )
     }
   }
 


### PR DESCRIPTION
Closes runtimeverification/k#4148

Updates `matching` to not emit a warning if the `no-evaluators` attribute is present.