### PR TITLE
Modify `side_condition` results to be only `false` or `true` in Proof Hints

### DIFF
--- a/bindings/python/ast.cpp
+++ b/bindings/python/ast.cpp
@@ -405,7 +405,7 @@ void bind_proof_trace(py::module_ &m) {
       .def_property_readonly(
           "rule_ordinal", &llvm_side_condition_end_event::get_rule_ordinal)
       .def_property_readonly(
-          "check_result", &llvm_side_condition_end_event::getkore_pattern);
+          "check_result", &llvm_side_condition_end_event::get_result);
 
   py::class_<llvm_function_event, std::shared_ptr<llvm_function_event>>(
       proof_trace, "llvm_function_event", step_event)

--- a/docs/proof-trace.md
+++ b/docs/proof-trace.md
@@ -49,7 +49,7 @@ variable          ::= name kore_term WORD(0xCC)
 rule              ::= WORD(0x22) ordinal arity variable*
 
 side_cond_entry   ::= WORD(0xEE) ordinal arity variable*
-side_cond_exit    ::= WORD(0x33) ordinal kore_term WORD(0xCC)
+side_cond_exit    ::= WORD(0x33) ordinal boolean_result
 
 config            ::= WORD(0xFF) kore_term WORD(0xCC)
 

--- a/docs/proof-trace.md
+++ b/docs/proof-trace.md
@@ -45,6 +45,7 @@ hook              ::= WORD(0xAA) name location arg* WORD(0xBB) kore_term
 
 ordinal           ::= uint64
 arity             ::= uint64
+boolean_result    ::= uint8
 variable          ::= name kore_term WORD(0xCC)
 rule              ::= WORD(0x22) ordinal arity variable*
 

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -595,10 +595,6 @@ private:
 
     event->set_result(side_condition_result);
 
-    if (!check_word(ptr, end, kore_end_sentinel)) {
-      return nullptr;
-    }
-
     return event;
   }
 

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -107,31 +107,20 @@ public:
 class llvm_side_condition_end_event : public llvm_step_event {
 private:
   uint64_t rule_ordinal_;
-  sptr<kore_pattern> kore_pattern_{};
-  bool result_{false};
-  uint64_t pattern_length_{0U};
+  bool result_;
 
-  llvm_side_condition_end_event(uint64_t rule_ordinal)
+  llvm_side_condition_end_event(uint64_t rule_ordinal, bool result)
       : rule_ordinal_(rule_ordinal)
-      , kore_pattern_(nullptr) { }
+      , result_(result) { }
 
 public:
-  static sptr<llvm_side_condition_end_event> create(uint64_t rule_ordinal) {
+  static sptr<llvm_side_condition_end_event>
+  create(uint64_t rule_ordinal, bool result) {
     return sptr<llvm_side_condition_end_event>(
-        new llvm_side_condition_end_event(rule_ordinal));
+        new llvm_side_condition_end_event(rule_ordinal, result));
   }
 
   [[nodiscard]] uint64_t get_rule_ordinal() const { return rule_ordinal_; }
-  [[nodiscard]] sptr<kore_pattern> getkore_pattern() const {
-    return kore_pattern_;
-  }
-  [[nodiscard]] uint64_t get_pattern_length() const { return pattern_length_; }
-  void
-  setkore_pattern(sptr<kore_pattern> kore_pattern, uint64_t pattern_length) {
-    kore_pattern_ = std::move(kore_pattern);
-    pattern_length_ = pattern_length;
-  }
-
   [[nodiscard]] bool get_result() const { return result_; }
   void set_result(bool result) { result_ = result; }
 
@@ -585,15 +574,14 @@ private:
       return nullptr;
     }
 
-    auto event = llvm_side_condition_end_event::create(ordinal);
-
     bool side_condition_result = false;
     auto result = parse_bool(ptr, end, side_condition_result);
     if (!result) {
       return nullptr;
     }
 
-    event->set_result(side_condition_result);
+    auto event
+        = llvm_side_condition_end_event::create(ordinal, side_condition_result);
 
     return event;
   }

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -122,7 +122,6 @@ public:
 
   [[nodiscard]] uint64_t get_rule_ordinal() const { return rule_ordinal_; }
   [[nodiscard]] bool get_result() const { return result_; }
-  void set_result(bool result) { result_ = result; }
 
   void print(std::ostream &out, bool expand_terms, unsigned indent = 0U)
       const override;

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -587,7 +587,7 @@ private:
 
     auto event = llvm_side_condition_end_event::create(ordinal);
 
-    bool side_condition_result;
+    bool side_condition_result = false;
     auto result = parse_bool(ptr, end, side_condition_result);
     if (!result) {
       return nullptr;

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -272,7 +272,7 @@ public:
 
 class proof_trace_parser {
 public:
-  static constexpr uint32_t expected_version = 6U;
+  static constexpr uint32_t expected_version = 7U;
 
 private:
   bool verbose_;

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -69,7 +69,7 @@ private:
       llvm::BasicBlock *insert_at_end);
 
   /*
-  * Emit a call that will serialize a boolean value to the specified `outputFile`.
+  * Emit a call that will serialize a boolean value to the specified `output_file`.
   */
   llvm::CallInst *emit_bool_term(
       llvm::Value *output_file, llvm::Value *term,

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -69,13 +69,20 @@ private:
       llvm::BasicBlock *insert_at_end);
 
   /*
+  * Emit a call that will serialize a boolean value to the specified `outputFile`.
+  */
+  llvm::CallInst *emit_bool_term(
+      llvm::Value *output_file, llvm::Value *term,
+      llvm::BasicBlock *insert_at_end);
+
+  /*
    * Emit a call that will serialize `str` to the specified `outputFile`.
    */
   llvm::CallInst *emit_write_string(
       llvm::Value *output_file, std::string const &str,
       llvm::BasicBlock *insert_at_end);
 
-  /* 
+  /*
    * Emit an instruction that has no effect and will be removed by optimization
    * passes.
    *

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -334,7 +334,7 @@ void serialize_configuration(
 void serialize_configuration_to_file(
     FILE *file, block *subject, bool emit_size, bool use_intern);
 void write_uint64_to_file(FILE *file, uint64_t i);
-void write_bool_to_file(FILE *file, void *subject);
+void write_bool_to_file(FILE *file, bool b);
 void serialize_term_to_file(
     FILE *file, block *subject, char const *sort, bool use_intern);
 void serialize_raw_term_to_file(

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -334,6 +334,7 @@ void serialize_configuration(
 void serialize_configuration_to_file(
     FILE *file, block *subject, bool emit_size, bool use_intern);
 void write_uint64_to_file(FILE *file, uint64_t i);
+void write_bool_to_file(FILE *file, void* b);
 void serialize_term_to_file(
     FILE *file, block *subject, char const *sort, bool use_intern);
 void serialize_raw_term_to_file(

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -334,7 +334,7 @@ void serialize_configuration(
 void serialize_configuration_to_file(
     FILE *file, block *subject, bool emit_size, bool use_intern);
 void write_uint64_to_file(FILE *file, uint64_t i);
-void write_bool_to_file(FILE *file, void* subject);
+void write_bool_to_file(FILE *file, void *subject);
 void serialize_term_to_file(
     FILE *file, block *subject, char const *sort, bool use_intern);
 void serialize_raw_term_to_file(

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -334,7 +334,7 @@ void serialize_configuration(
 void serialize_configuration_to_file(
     FILE *file, block *subject, bool emit_size, bool use_intern);
 void write_uint64_to_file(FILE *file, uint64_t i);
-void write_bool_to_file(FILE *file, void* b);
+void write_bool_to_file(FILE *file, void* subject);
 void serialize_term_to_file(
     FILE *file, block *subject, char const *sort, bool use_intern);
 void serialize_raw_term_to_file(

--- a/lib/binary/ProofTraceParser.cpp
+++ b/lib/binary/ProofTraceParser.cpp
@@ -63,16 +63,9 @@ void llvm_side_condition_event::print(
 void llvm_side_condition_end_event::print(
     std::ostream &out, bool expand_terms, unsigned ind) const {
   std::string indent(ind * indent_size, ' ');
-  if (expand_terms) {
-    out << fmt::format(
-        "{}side condition exit: {} kore[", indent, rule_ordinal_);
-    kore_pattern_->print(out);
-    out << fmt::format("]\n");
-  } else {
-    out << fmt::format(
-        "{}side condition exit: {} kore[{}]\n", indent, rule_ordinal_,
-        pattern_length_);
-  }
+  out << fmt::format("{}side condition exit: {} ", indent, rule_ordinal_);
+  out << (result_ ? "true" : "false");
+  out << fmt::format("\n");
 }
 
 void llvm_function_event::print(

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -403,7 +403,6 @@ llvm::BasicBlock *proof_event::side_condition_event_post(
   emit_write_uint64(outputFile, detail::word(0x33), true_block);
   emit_write_uint64(outputFile, ordinal, true_block);
   emit_bool_term(outputFile, check_result, true_block);
-  emit_write_uint64(outputFile, detail::word(0xCC), true_block);
 
   llvm::BranchInst::Create(merge_block, true_block);
 

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -118,8 +118,8 @@ llvm::CallInst *proof_event::emit_bool_term(
     term = b.CreatePointerCast(term, i8_ptr_ty);
   }
 
-  auto *func_ty = llvm::FunctionType::get(
-      void_ty, {i8_ptr_ty, i8_ptr_ty}, false);
+  auto *func_ty
+      = llvm::FunctionType::get(void_ty, {i8_ptr_ty, i8_ptr_ty}, false);
 
   auto *serialize
       = get_or_insert_function(module_, "write_bool_to_file", func_ty);

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -112,11 +112,7 @@ llvm::CallInst *proof_event::emit_bool_term(
   auto *void_ty = llvm::Type::getVoidTy(ctx_);
   auto *i8_ptr_ty = llvm::Type::getInt8PtrTy(ctx_);
 
-  if (term->getType()->isIntegerTy()) {
-    term = b.CreateIntToPtr(term, i8_ptr_ty);
-  } else {
-    term = b.CreatePointerCast(term, i8_ptr_ty);
-  }
+  term = b.CreateIntToPtr(term, i8_ptr_ty);
 
   auto *func_ty
       = llvm::FunctionType::get(void_ty, {i8_ptr_ty, i8_ptr_ty}, false);

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -444,9 +444,8 @@ void write_uint64_to_file(FILE *file, uint64_t i) {
   fwrite(&i, 8, 1, file);
 }
 
-void write_bool_to_file(FILE *file, void *subject) {
-  bool value = (bool)subject;
-  fwrite(&value, 1, 1, file);
+void write_bool_to_file(FILE *file, bool b) {
+  fwrite(&b, 1, 1, file);
 }
 
 void serialize_term_to_file(

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -444,6 +444,11 @@ void write_uint64_to_file(FILE *file, uint64_t i) {
   fwrite(&i, 8, 1, file);
 }
 
+void write_bool_to_file(FILE *file, void *subject) {
+  bool value = (bool)subject;
+  fwrite(&value, 1, 1, file);
+}
+
 void serialize_term_to_file(
     FILE *file, block *subject, char const *sort, bool use_intern) {
   char *data = nullptr;

--- a/runtime/util/util.cpp
+++ b/runtime/util/util.cpp
@@ -35,7 +35,7 @@ block *construct_raw_term(void *subject, char const *sort, bool raw_value) {
 }
 
 void print_proof_hint_header(FILE *file) {
-  uint32_t version = 6;
+  uint32_t version = 7;
   fmt::print(file, "HINT");
   fwrite(&version, sizeof(version), 1, file);
 }

--- a/test/output/imp-proof/imp-proof.expanded.out.diff
+++ b/test/output/imp-proof/imp-proof.expanded.out.diff
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 hook: MAP.element (0)
   function: Lbl'UndsPipe'-'-GT-Unds'{} (0)
   arg: kore[inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))]

--- a/test/output/imp-proof/imp-proof.expanded.out.diff
+++ b/test/output/imp-proof/imp-proof.expanded.out.diff
@@ -103,7 +103,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -134,7 +134,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -173,7 +173,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -194,7 +194,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -213,7 +213,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -238,7 +238,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -259,7 +259,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
@@ -280,7 +280,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -302,7 +302,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -322,7 +322,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -341,7 +341,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -363,7 +363,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -409,7 +409,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -429,7 +429,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -454,7 +454,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -475,7 +475,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
@@ -496,7 +496,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -521,7 +521,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -542,7 +542,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
@@ -563,7 +563,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -585,7 +585,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -606,7 +606,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -637,7 +637,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -657,7 +657,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -682,7 +682,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -703,7 +703,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
@@ -724,7 +724,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -752,7 +752,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -773,7 +773,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
@@ -794,7 +794,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -816,7 +816,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -837,7 +837,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -876,7 +876,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -897,7 +897,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -916,7 +916,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -941,7 +941,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -962,7 +962,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
@@ -983,7 +983,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1005,7 +1005,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1025,7 +1025,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1044,7 +1044,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1066,7 +1066,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1112,7 +1112,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1132,7 +1132,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1157,7 +1157,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1178,7 +1178,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
@@ -1199,7 +1199,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1224,7 +1224,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1245,7 +1245,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
@@ -1266,7 +1266,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1288,7 +1288,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1309,7 +1309,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -1340,7 +1340,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1360,7 +1360,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1385,7 +1385,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1406,7 +1406,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
@@ -1427,7 +1427,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1455,7 +1455,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1476,7 +1476,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
@@ -1497,7 +1497,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1519,7 +1519,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1540,7 +1540,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -1579,7 +1579,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1600,7 +1600,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1619,7 +1619,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1644,7 +1644,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1665,7 +1665,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
@@ -1686,7 +1686,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1708,7 +1708,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1728,7 +1728,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1747,7 +1747,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1769,7 +1769,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1815,7 +1815,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1835,7 +1835,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1860,7 +1860,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1881,7 +1881,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
@@ -1902,7 +1902,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1927,7 +1927,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1948,7 +1948,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
@@ -1969,7 +1969,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1991,7 +1991,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2012,7 +2012,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -2043,7 +2043,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2063,7 +2063,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2088,7 +2088,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2109,7 +2109,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
@@ -2130,7 +2130,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2158,7 +2158,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2179,7 +2179,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
@@ -2200,7 +2200,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2222,7 +2222,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2243,7 +2243,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -2282,7 +2282,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2303,7 +2303,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2322,7 +2322,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2347,7 +2347,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2368,7 +2368,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
@@ -2389,7 +2389,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2411,7 +2411,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2431,7 +2431,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2450,7 +2450,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2472,7 +2472,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2518,7 +2518,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2538,7 +2538,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2563,7 +2563,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2584,7 +2584,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
@@ -2605,7 +2605,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2630,7 +2630,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2651,7 +2651,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
@@ -2672,7 +2672,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2694,7 +2694,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2715,7 +2715,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -2746,7 +2746,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2766,7 +2766,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2791,7 +2791,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2812,7 +2812,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
@@ -2833,7 +2833,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2861,7 +2861,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2882,7 +2882,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
@@ -2903,7 +2903,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2925,7 +2925,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2946,7 +2946,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -2985,7 +2985,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3006,7 +3006,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3025,7 +3025,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3050,7 +3050,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3071,7 +3071,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
@@ -3092,7 +3092,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3114,7 +3114,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3134,7 +3134,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3153,7 +3153,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3175,7 +3175,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3221,7 +3221,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3241,7 +3241,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3266,7 +3266,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3287,7 +3287,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
@@ -3308,7 +3308,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3333,7 +3333,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3354,7 +3354,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
@@ -3375,7 +3375,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3397,7 +3397,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3418,7 +3418,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -3449,7 +3449,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3469,7 +3469,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3494,7 +3494,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3515,7 +3515,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
@@ -3536,7 +3536,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3564,7 +3564,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3585,7 +3585,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
@@ -3606,7 +3606,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3628,7 +3628,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3649,7 +3649,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -3688,7 +3688,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3709,7 +3709,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3728,7 +3728,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3753,7 +3753,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3774,7 +3774,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
@@ -3795,7 +3795,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3817,7 +3817,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3837,7 +3837,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3856,7 +3856,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3878,7 +3878,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3924,7 +3924,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3944,7 +3944,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3969,7 +3969,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3990,7 +3990,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
@@ -4011,7 +4011,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4036,7 +4036,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4057,7 +4057,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
@@ -4078,7 +4078,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4100,7 +4100,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4121,7 +4121,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -4152,7 +4152,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4172,7 +4172,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4197,7 +4197,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4218,7 +4218,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
@@ -4239,7 +4239,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4267,7 +4267,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4288,7 +4288,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
@@ -4309,7 +4309,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4331,7 +4331,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4352,7 +4352,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -4391,7 +4391,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4412,7 +4412,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4431,7 +4431,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4456,7 +4456,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4477,7 +4477,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
@@ -4498,7 +4498,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4520,7 +4520,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4540,7 +4540,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4559,7 +4559,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4581,7 +4581,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4627,7 +4627,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4647,7 +4647,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4672,7 +4672,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4693,7 +4693,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
@@ -4714,7 +4714,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4739,7 +4739,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4760,7 +4760,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
@@ -4781,7 +4781,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4803,7 +4803,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4824,7 +4824,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -4855,7 +4855,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4875,7 +4875,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4900,7 +4900,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4921,7 +4921,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
@@ -4942,7 +4942,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4970,7 +4970,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4991,7 +4991,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
@@ -5012,7 +5012,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5034,7 +5034,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5055,7 +5055,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -5094,7 +5094,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5115,7 +5115,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5134,7 +5134,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5159,7 +5159,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5180,7 +5180,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
@@ -5201,7 +5201,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5223,7 +5223,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5243,7 +5243,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5262,7 +5262,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5284,7 +5284,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5330,7 +5330,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5350,7 +5350,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5375,7 +5375,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5396,7 +5396,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
@@ -5417,7 +5417,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5442,7 +5442,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5463,7 +5463,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
@@ -5484,7 +5484,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5506,7 +5506,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5527,7 +5527,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -5558,7 +5558,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5578,7 +5578,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5603,7 +5603,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5624,7 +5624,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
@@ -5645,7 +5645,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5673,7 +5673,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5694,7 +5694,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
@@ -5715,7 +5715,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5737,7 +5737,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5758,7 +5758,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -5797,7 +5797,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -5818,7 +5818,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -5837,7 +5837,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -5862,7 +5862,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -5883,7 +5883,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
@@ -5904,7 +5904,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -5926,7 +5926,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -5946,7 +5946,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -5965,7 +5965,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -5987,7 +5987,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6033,7 +6033,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6053,7 +6053,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6078,7 +6078,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6099,7 +6099,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
@@ -6120,7 +6120,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6145,7 +6145,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6166,7 +6166,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
@@ -6187,7 +6187,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6209,7 +6209,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6230,7 +6230,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -6261,7 +6261,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6281,7 +6281,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6306,7 +6306,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6327,7 +6327,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
@@ -6348,7 +6348,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6376,7 +6376,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6397,7 +6397,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
@@ -6418,7 +6418,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6440,7 +6440,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6461,7 +6461,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -6500,7 +6500,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6521,7 +6521,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6540,7 +6540,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6565,7 +6565,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6586,7 +6586,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
@@ -6607,7 +6607,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6629,7 +6629,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6649,7 +6649,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6668,7 +6668,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6690,7 +6690,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6736,7 +6736,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6756,7 +6756,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6781,7 +6781,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6802,7 +6802,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
@@ -6823,7 +6823,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6848,7 +6848,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6869,7 +6869,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
@@ -6890,7 +6890,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6912,7 +6912,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("55"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6933,7 +6933,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -6964,7 +6964,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -6984,7 +6984,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7009,7 +7009,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7030,7 +7030,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
@@ -7051,7 +7051,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7079,7 +7079,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7100,7 +7100,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
@@ -7121,7 +7121,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7143,7 +7143,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7164,7 +7164,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -7203,7 +7203,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7224,7 +7224,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7243,7 +7243,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7268,7 +7268,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7289,7 +7289,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
@@ -7310,7 +7310,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7332,7 +7332,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7352,7 +7352,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7371,7 +7371,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7393,7 +7393,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2916 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]

--- a/test/output/imp-proof/imp-proof.out.diff
+++ b/test/output/imp-proof/imp-proof.out.diff
@@ -103,7 +103,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1237]
@@ -134,7 +134,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -173,7 +173,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -194,7 +194,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -213,7 +213,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -238,7 +238,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -259,7 +259,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -280,7 +280,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -302,7 +302,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -322,7 +322,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -341,7 +341,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -363,7 +363,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -409,7 +409,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -429,7 +429,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -454,7 +454,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -475,7 +475,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[56]
@@ -496,7 +496,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -521,7 +521,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -542,7 +542,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -563,7 +563,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -585,7 +585,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -606,7 +606,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -637,7 +637,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -657,7 +657,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -682,7 +682,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -703,7 +703,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[57]
@@ -724,7 +724,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -752,7 +752,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -773,7 +773,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[57]
@@ -794,7 +794,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -816,7 +816,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -837,7 +837,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -876,7 +876,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -897,7 +897,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -916,7 +916,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -941,7 +941,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -962,7 +962,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -983,7 +983,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1005,7 +1005,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1025,7 +1025,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1044,7 +1044,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1066,7 +1066,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1112,7 +1112,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1132,7 +1132,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1157,7 +1157,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1178,7 +1178,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -1199,7 +1199,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1224,7 +1224,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1245,7 +1245,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -1266,7 +1266,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1288,7 +1288,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1309,7 +1309,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -1340,7 +1340,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1360,7 +1360,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1385,7 +1385,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1406,7 +1406,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -1427,7 +1427,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1455,7 +1455,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1476,7 +1476,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -1497,7 +1497,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1519,7 +1519,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1540,7 +1540,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -1579,7 +1579,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1600,7 +1600,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1619,7 +1619,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1644,7 +1644,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1665,7 +1665,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -1686,7 +1686,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1708,7 +1708,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1728,7 +1728,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1747,7 +1747,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1769,7 +1769,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1815,7 +1815,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1835,7 +1835,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1860,7 +1860,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1881,7 +1881,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -1902,7 +1902,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1927,7 +1927,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1948,7 +1948,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -1969,7 +1969,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1991,7 +1991,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2012,7 +2012,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -2043,7 +2043,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2063,7 +2063,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2088,7 +2088,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2109,7 +2109,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -2130,7 +2130,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2158,7 +2158,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2179,7 +2179,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -2200,7 +2200,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2222,7 +2222,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2243,7 +2243,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -2282,7 +2282,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2303,7 +2303,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2322,7 +2322,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2347,7 +2347,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2368,7 +2368,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -2389,7 +2389,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2411,7 +2411,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2431,7 +2431,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2450,7 +2450,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2472,7 +2472,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2518,7 +2518,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2538,7 +2538,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2563,7 +2563,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2584,7 +2584,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -2605,7 +2605,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2630,7 +2630,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2651,7 +2651,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -2672,7 +2672,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2694,7 +2694,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2715,7 +2715,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -2746,7 +2746,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2766,7 +2766,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2791,7 +2791,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2812,7 +2812,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -2833,7 +2833,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2861,7 +2861,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2882,7 +2882,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -2903,7 +2903,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2925,7 +2925,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2946,7 +2946,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -2985,7 +2985,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3006,7 +3006,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3025,7 +3025,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3050,7 +3050,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3071,7 +3071,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -3092,7 +3092,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3114,7 +3114,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3134,7 +3134,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3153,7 +3153,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3175,7 +3175,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3221,7 +3221,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3241,7 +3241,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3266,7 +3266,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3287,7 +3287,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -3308,7 +3308,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3333,7 +3333,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3354,7 +3354,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -3375,7 +3375,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3397,7 +3397,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3418,7 +3418,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -3449,7 +3449,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3469,7 +3469,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3494,7 +3494,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3515,7 +3515,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -3536,7 +3536,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3564,7 +3564,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3585,7 +3585,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -3606,7 +3606,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3628,7 +3628,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3649,7 +3649,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -3688,7 +3688,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3709,7 +3709,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3728,7 +3728,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3753,7 +3753,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3774,7 +3774,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -3795,7 +3795,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3817,7 +3817,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3837,7 +3837,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3856,7 +3856,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3878,7 +3878,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3924,7 +3924,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3944,7 +3944,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3969,7 +3969,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3990,7 +3990,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -4011,7 +4011,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4036,7 +4036,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4057,7 +4057,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -4078,7 +4078,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4100,7 +4100,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4121,7 +4121,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -4152,7 +4152,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4172,7 +4172,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4197,7 +4197,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4218,7 +4218,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -4239,7 +4239,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4267,7 +4267,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4288,7 +4288,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -4309,7 +4309,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4331,7 +4331,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4352,7 +4352,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -4391,7 +4391,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4412,7 +4412,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4431,7 +4431,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4456,7 +4456,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4477,7 +4477,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -4498,7 +4498,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4520,7 +4520,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4540,7 +4540,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4559,7 +4559,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4581,7 +4581,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4627,7 +4627,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4647,7 +4647,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4672,7 +4672,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4693,7 +4693,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -4714,7 +4714,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4739,7 +4739,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4760,7 +4760,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -4781,7 +4781,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4803,7 +4803,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4824,7 +4824,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -4855,7 +4855,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4875,7 +4875,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4900,7 +4900,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4921,7 +4921,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -4942,7 +4942,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4970,7 +4970,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4991,7 +4991,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -5012,7 +5012,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5034,7 +5034,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5055,7 +5055,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -5094,7 +5094,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5115,7 +5115,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5134,7 +5134,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5159,7 +5159,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5180,7 +5180,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -5201,7 +5201,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5223,7 +5223,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5243,7 +5243,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5262,7 +5262,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5284,7 +5284,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5330,7 +5330,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5350,7 +5350,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5375,7 +5375,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5396,7 +5396,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -5417,7 +5417,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5442,7 +5442,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5463,7 +5463,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -5484,7 +5484,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5506,7 +5506,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5527,7 +5527,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -5558,7 +5558,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5578,7 +5578,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5603,7 +5603,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5624,7 +5624,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -5645,7 +5645,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5673,7 +5673,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5694,7 +5694,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -5715,7 +5715,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5737,7 +5737,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5758,7 +5758,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -5797,7 +5797,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5818,7 +5818,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5837,7 +5837,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5862,7 +5862,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5883,7 +5883,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -5904,7 +5904,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5926,7 +5926,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5946,7 +5946,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5965,7 +5965,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5987,7 +5987,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6033,7 +6033,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6053,7 +6053,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6078,7 +6078,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6099,7 +6099,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -6120,7 +6120,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6145,7 +6145,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6166,7 +6166,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -6187,7 +6187,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6209,7 +6209,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6230,7 +6230,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -6261,7 +6261,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6281,7 +6281,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6306,7 +6306,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6327,7 +6327,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -6348,7 +6348,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6376,7 +6376,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6397,7 +6397,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -6418,7 +6418,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6440,7 +6440,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6461,7 +6461,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -6500,7 +6500,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6521,7 +6521,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6540,7 +6540,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6565,7 +6565,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6586,7 +6586,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -6607,7 +6607,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6629,7 +6629,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6649,7 +6649,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6668,7 +6668,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6690,7 +6690,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6736,7 +6736,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6756,7 +6756,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6781,7 +6781,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6802,7 +6802,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -6823,7 +6823,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6848,7 +6848,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6869,7 +6869,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -6890,7 +6890,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6912,7 +6912,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6933,7 +6933,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -6964,7 +6964,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6984,7 +6984,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7009,7 +7009,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7030,7 +7030,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -7051,7 +7051,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7079,7 +7079,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7100,7 +7100,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -7121,7 +7121,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7143,7 +7143,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7164,7 +7164,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -7203,7 +7203,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7224,7 +7224,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7243,7 +7243,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7268,7 +7268,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7289,7 +7289,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -7310,7 +7310,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7332,7 +7332,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7352,7 +7352,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7371,7 +7371,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7393,7 +7393,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2916 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]

--- a/test/output/imp-proof/imp-proof.out.diff
+++ b/test/output/imp-proof/imp-proof.out.diff
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 hook: MAP.element (0)
   function: Lbl'UndsPipe'-'-GT-Unds'{} (0)
   arg: kore[74]

--- a/test/output/imp-slow-proof/imp-slow-proof.expanded.out.diff
+++ b/test/output/imp-slow-proof/imp-slow-proof.expanded.out.diff
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 hook: MAP.element (0)
   function: Lbl'UndsPipe'-'-GT-Unds'{} (0)
     arg: kore[inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))]
@@ -122,7 +122,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -158,7 +158,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -202,7 +202,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -224,7 +224,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -244,7 +244,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -270,7 +270,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -292,7 +292,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
@@ -315,7 +315,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -340,7 +340,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -361,7 +361,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -381,7 +381,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -404,7 +404,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -451,7 +451,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -472,7 +472,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -498,7 +498,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -520,7 +520,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
@@ -543,7 +543,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -569,7 +569,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -591,7 +591,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
@@ -614,7 +614,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -639,7 +639,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -661,7 +661,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -697,7 +697,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -718,7 +718,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -744,7 +744,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -766,7 +766,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
@@ -789,7 +789,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -820,7 +820,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -842,7 +842,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
@@ -865,7 +865,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -890,7 +890,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
@@ -912,7 +912,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -956,7 +956,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -978,7 +978,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -998,7 +998,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1024,7 +1024,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1046,7 +1046,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
@@ -1069,7 +1069,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1094,7 +1094,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1115,7 +1115,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1135,7 +1135,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1158,7 +1158,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1205,7 +1205,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1226,7 +1226,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1252,7 +1252,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1274,7 +1274,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
@@ -1297,7 +1297,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1323,7 +1323,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1345,7 +1345,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
@@ -1368,7 +1368,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1393,7 +1393,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1415,7 +1415,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -1451,7 +1451,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1472,7 +1472,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1498,7 +1498,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1520,7 +1520,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
@@ -1543,7 +1543,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1574,7 +1574,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1596,7 +1596,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
@@ -1619,7 +1619,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1644,7 +1644,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
@@ -1666,7 +1666,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -1710,7 +1710,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1732,7 +1732,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1752,7 +1752,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1778,7 +1778,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1800,7 +1800,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
@@ -1823,7 +1823,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1848,7 +1848,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1869,7 +1869,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1889,7 +1889,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1912,7 +1912,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1959,7 +1959,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -1980,7 +1980,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2006,7 +2006,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2028,7 +2028,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
@@ -2051,7 +2051,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2077,7 +2077,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2099,7 +2099,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
@@ -2122,7 +2122,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2147,7 +2147,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2169,7 +2169,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -2205,7 +2205,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2226,7 +2226,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2252,7 +2252,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2274,7 +2274,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
@@ -2297,7 +2297,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2328,7 +2328,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2350,7 +2350,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
@@ -2373,7 +2373,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2398,7 +2398,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
@@ -2420,7 +2420,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -2464,7 +2464,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2486,7 +2486,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2506,7 +2506,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2532,7 +2532,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2554,7 +2554,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
@@ -2577,7 +2577,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2602,7 +2602,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2623,7 +2623,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2643,7 +2643,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2666,7 +2666,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2713,7 +2713,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2734,7 +2734,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2760,7 +2760,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2782,7 +2782,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
@@ -2805,7 +2805,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2831,7 +2831,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2853,7 +2853,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
@@ -2876,7 +2876,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2901,7 +2901,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2923,7 +2923,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -2959,7 +2959,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -2980,7 +2980,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -3006,7 +3006,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -3028,7 +3028,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
@@ -3051,7 +3051,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -3082,7 +3082,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -3104,7 +3104,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
@@ -3127,7 +3127,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -3152,7 +3152,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
@@ -3174,7 +3174,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -3218,7 +3218,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3240,7 +3240,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3260,7 +3260,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3286,7 +3286,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3308,7 +3308,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
@@ -3331,7 +3331,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3356,7 +3356,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3377,7 +3377,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3397,7 +3397,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3420,7 +3420,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3467,7 +3467,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3488,7 +3488,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3514,7 +3514,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3536,7 +3536,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
@@ -3559,7 +3559,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3585,7 +3585,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3607,7 +3607,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
@@ -3630,7 +3630,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3655,7 +3655,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3677,7 +3677,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -3713,7 +3713,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3734,7 +3734,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3760,7 +3760,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3782,7 +3782,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
@@ -3805,7 +3805,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3836,7 +3836,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3858,7 +3858,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
@@ -3881,7 +3881,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3906,7 +3906,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
@@ -3928,7 +3928,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -3972,7 +3972,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -3994,7 +3994,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4014,7 +4014,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4040,7 +4040,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4062,7 +4062,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
@@ -4085,7 +4085,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4110,7 +4110,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4131,7 +4131,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4151,7 +4151,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4174,7 +4174,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4221,7 +4221,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4242,7 +4242,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4268,7 +4268,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4290,7 +4290,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
@@ -4313,7 +4313,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4339,7 +4339,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4361,7 +4361,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
@@ -4384,7 +4384,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4409,7 +4409,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4431,7 +4431,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -4467,7 +4467,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4488,7 +4488,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4514,7 +4514,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4536,7 +4536,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
@@ -4559,7 +4559,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4590,7 +4590,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4612,7 +4612,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
@@ -4635,7 +4635,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4660,7 +4660,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
@@ -4682,7 +4682,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -4726,7 +4726,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4748,7 +4748,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4768,7 +4768,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4794,7 +4794,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4816,7 +4816,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
@@ -4839,7 +4839,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4864,7 +4864,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4885,7 +4885,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4905,7 +4905,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4928,7 +4928,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4975,7 +4975,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -4996,7 +4996,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5022,7 +5022,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5044,7 +5044,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
@@ -5067,7 +5067,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5093,7 +5093,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5115,7 +5115,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
@@ -5138,7 +5138,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5163,7 +5163,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5185,7 +5185,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -5221,7 +5221,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5242,7 +5242,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5268,7 +5268,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5290,7 +5290,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
@@ -5313,7 +5313,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5344,7 +5344,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5366,7 +5366,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
@@ -5389,7 +5389,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5414,7 +5414,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
@@ -5436,7 +5436,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -5480,7 +5480,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5502,7 +5502,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5522,7 +5522,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5548,7 +5548,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5570,7 +5570,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
@@ -5593,7 +5593,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5618,7 +5618,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5639,7 +5639,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5659,7 +5659,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5682,7 +5682,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5729,7 +5729,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5750,7 +5750,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5776,7 +5776,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5798,7 +5798,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
@@ -5821,7 +5821,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5847,7 +5847,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5869,7 +5869,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
@@ -5892,7 +5892,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5917,7 +5917,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5939,7 +5939,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -5975,7 +5975,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -5996,7 +5996,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -6022,7 +6022,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -6044,7 +6044,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
@@ -6067,7 +6067,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -6098,7 +6098,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -6120,7 +6120,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
@@ -6143,7 +6143,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -6168,7 +6168,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
@@ -6190,7 +6190,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -6234,7 +6234,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6256,7 +6256,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6276,7 +6276,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6302,7 +6302,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6324,7 +6324,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
@@ -6347,7 +6347,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6372,7 +6372,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6393,7 +6393,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6413,7 +6413,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6436,7 +6436,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6483,7 +6483,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6504,7 +6504,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6530,7 +6530,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6552,7 +6552,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
@@ -6575,7 +6575,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6601,7 +6601,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6623,7 +6623,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
@@ -6646,7 +6646,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6671,7 +6671,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6693,7 +6693,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -6729,7 +6729,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6750,7 +6750,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6776,7 +6776,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6798,7 +6798,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
@@ -6821,7 +6821,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6852,7 +6852,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6874,7 +6874,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
@@ -6897,7 +6897,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6922,7 +6922,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
@@ -6944,7 +6944,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -6988,7 +6988,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7010,7 +7010,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7030,7 +7030,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7056,7 +7056,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7078,7 +7078,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
@@ -7101,7 +7101,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7126,7 +7126,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7147,7 +7147,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7167,7 +7167,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7190,7 +7190,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7237,7 +7237,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7258,7 +7258,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7284,7 +7284,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7306,7 +7306,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
@@ -7329,7 +7329,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7355,7 +7355,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7377,7 +7377,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
@@ -7400,7 +7400,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7425,7 +7425,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("55"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7447,7 +7447,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
@@ -7483,7 +7483,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7504,7 +7504,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7530,7 +7530,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2884 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7552,7 +7552,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
@@ -7575,7 +7575,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7606,7 +7606,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2885 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7628,7 +7628,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2903 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
@@ -7651,7 +7651,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2904 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7676,7 +7676,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2890 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
@@ -7698,7 +7698,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2912 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar2 = kore[kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())]
@@ -7742,7 +7742,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7764,7 +7764,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7784,7 +7784,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7810,7 +7810,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2888 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7832,7 +7832,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2909 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
@@ -7855,7 +7855,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2910 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7880,7 +7880,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2880 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7901,7 +7901,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2894 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7921,7 +7921,7 @@ hook: BOOL.and (0)
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
-side condition exit: 2891 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")))]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
@@ -7944,7 +7944,7 @@ hook: BOOL.and (0)
   hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
   arg: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
 hook result: kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
-side condition exit: 2915 kore[rawTerm{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")))]
+side condition exit: 2915 false
 rule: 2916 5
   Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]

--- a/test/output/imp-slow-proof/imp-slow-proof.out.diff
+++ b/test/output/imp-slow-proof/imp-slow-proof.out.diff
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 hook: MAP.element (0)
   function: Lbl'UndsPipe'-'-GT-Unds'{} (0)
     arg: kore[74]
@@ -122,7 +122,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1237]
@@ -158,7 +158,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -202,7 +202,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -224,7 +224,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -244,7 +244,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -270,7 +270,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -292,7 +292,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -315,7 +315,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -340,7 +340,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -361,7 +361,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -381,7 +381,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -404,7 +404,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -451,7 +451,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -472,7 +472,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -498,7 +498,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -520,7 +520,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[56]
@@ -543,7 +543,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -569,7 +569,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -591,7 +591,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -614,7 +614,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -639,7 +639,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -661,7 +661,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -697,7 +697,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -718,7 +718,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -744,7 +744,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -766,7 +766,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[57]
@@ -789,7 +789,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -820,7 +820,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -842,7 +842,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[57]
@@ -865,7 +865,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -890,7 +890,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[338]
@@ -912,7 +912,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -956,7 +956,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -978,7 +978,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -998,7 +998,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1024,7 +1024,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1046,7 +1046,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -1069,7 +1069,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1094,7 +1094,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1115,7 +1115,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1135,7 +1135,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1158,7 +1158,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1205,7 +1205,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1226,7 +1226,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1252,7 +1252,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1274,7 +1274,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -1297,7 +1297,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1323,7 +1323,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1345,7 +1345,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -1368,7 +1368,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1393,7 +1393,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1415,7 +1415,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -1451,7 +1451,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1472,7 +1472,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1498,7 +1498,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1520,7 +1520,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -1543,7 +1543,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1574,7 +1574,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1596,7 +1596,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -1619,7 +1619,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1644,7 +1644,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1666,7 +1666,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -1710,7 +1710,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1732,7 +1732,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1752,7 +1752,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1778,7 +1778,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1800,7 +1800,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -1823,7 +1823,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1848,7 +1848,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1869,7 +1869,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1889,7 +1889,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1912,7 +1912,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1959,7 +1959,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -1980,7 +1980,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2006,7 +2006,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2028,7 +2028,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -2051,7 +2051,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2077,7 +2077,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2099,7 +2099,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -2122,7 +2122,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2147,7 +2147,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2169,7 +2169,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -2205,7 +2205,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2226,7 +2226,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2252,7 +2252,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2274,7 +2274,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -2297,7 +2297,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2328,7 +2328,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2350,7 +2350,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -2373,7 +2373,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2398,7 +2398,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2420,7 +2420,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -2464,7 +2464,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2486,7 +2486,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2506,7 +2506,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2532,7 +2532,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2554,7 +2554,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -2577,7 +2577,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2602,7 +2602,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2623,7 +2623,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2643,7 +2643,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2666,7 +2666,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2713,7 +2713,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2734,7 +2734,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2760,7 +2760,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2782,7 +2782,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -2805,7 +2805,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2831,7 +2831,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2853,7 +2853,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -2876,7 +2876,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2901,7 +2901,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2923,7 +2923,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -2959,7 +2959,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -2980,7 +2980,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3006,7 +3006,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3028,7 +3028,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -3051,7 +3051,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3082,7 +3082,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3104,7 +3104,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -3127,7 +3127,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3152,7 +3152,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3174,7 +3174,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -3218,7 +3218,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3240,7 +3240,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3260,7 +3260,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3286,7 +3286,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3308,7 +3308,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -3331,7 +3331,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3356,7 +3356,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3377,7 +3377,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3397,7 +3397,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3420,7 +3420,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3467,7 +3467,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3488,7 +3488,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3514,7 +3514,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3536,7 +3536,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -3559,7 +3559,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3585,7 +3585,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3607,7 +3607,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -3630,7 +3630,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3655,7 +3655,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3677,7 +3677,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -3713,7 +3713,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3734,7 +3734,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3760,7 +3760,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3782,7 +3782,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -3805,7 +3805,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3836,7 +3836,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3858,7 +3858,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -3881,7 +3881,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3906,7 +3906,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3928,7 +3928,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -3972,7 +3972,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -3994,7 +3994,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4014,7 +4014,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4040,7 +4040,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4062,7 +4062,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -4085,7 +4085,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4110,7 +4110,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4131,7 +4131,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4151,7 +4151,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4174,7 +4174,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4221,7 +4221,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4242,7 +4242,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4268,7 +4268,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4290,7 +4290,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -4313,7 +4313,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4339,7 +4339,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4361,7 +4361,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -4384,7 +4384,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4409,7 +4409,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4431,7 +4431,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -4467,7 +4467,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4488,7 +4488,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4514,7 +4514,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4536,7 +4536,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -4559,7 +4559,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4590,7 +4590,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4612,7 +4612,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -4635,7 +4635,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4660,7 +4660,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4682,7 +4682,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -4726,7 +4726,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4748,7 +4748,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4768,7 +4768,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4794,7 +4794,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4816,7 +4816,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -4839,7 +4839,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4864,7 +4864,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4885,7 +4885,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4905,7 +4905,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4928,7 +4928,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4975,7 +4975,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -4996,7 +4996,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5022,7 +5022,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5044,7 +5044,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -5067,7 +5067,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5093,7 +5093,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5115,7 +5115,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -5138,7 +5138,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5163,7 +5163,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5185,7 +5185,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -5221,7 +5221,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5242,7 +5242,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5268,7 +5268,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5290,7 +5290,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -5313,7 +5313,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5344,7 +5344,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5366,7 +5366,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -5389,7 +5389,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5414,7 +5414,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5436,7 +5436,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -5480,7 +5480,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5502,7 +5502,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5522,7 +5522,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5548,7 +5548,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5570,7 +5570,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -5593,7 +5593,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5618,7 +5618,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5639,7 +5639,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5659,7 +5659,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5682,7 +5682,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5729,7 +5729,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5750,7 +5750,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5776,7 +5776,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5798,7 +5798,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -5821,7 +5821,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5847,7 +5847,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5869,7 +5869,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -5892,7 +5892,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5917,7 +5917,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5939,7 +5939,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -5975,7 +5975,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -5996,7 +5996,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6022,7 +6022,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6044,7 +6044,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -6067,7 +6067,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6098,7 +6098,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6120,7 +6120,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -6143,7 +6143,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6168,7 +6168,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6190,7 +6190,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -6234,7 +6234,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6256,7 +6256,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6276,7 +6276,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6302,7 +6302,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6324,7 +6324,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -6347,7 +6347,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6372,7 +6372,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6393,7 +6393,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6413,7 +6413,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6436,7 +6436,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6483,7 +6483,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6504,7 +6504,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6530,7 +6530,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6552,7 +6552,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -6575,7 +6575,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6601,7 +6601,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6623,7 +6623,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -6646,7 +6646,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6671,7 +6671,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6693,7 +6693,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -6729,7 +6729,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6750,7 +6750,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6776,7 +6776,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6798,7 +6798,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -6821,7 +6821,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6852,7 +6852,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6874,7 +6874,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -6897,7 +6897,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6922,7 +6922,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -6944,7 +6944,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -6988,7 +6988,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7010,7 +7010,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7030,7 +7030,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7056,7 +7056,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7078,7 +7078,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -7101,7 +7101,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7126,7 +7126,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7147,7 +7147,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7167,7 +7167,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7190,7 +7190,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2917 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7237,7 +7237,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7258,7 +7258,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7284,7 +7284,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7306,7 +7306,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
@@ -7329,7 +7329,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7355,7 +7355,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7377,7 +7377,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
@@ -7400,7 +7400,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7425,7 +7425,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7447,7 +7447,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1373]
@@ -7483,7 +7483,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2912 kore[75]
+side condition exit: 2912 true
 rule: 2912 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7504,7 +7504,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2903 kore[75]
+side condition exit: 2903 true
 rule: 2903 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7530,7 +7530,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2884 kore[75]
+side condition exit: 2884 true
 rule: 2884 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7552,7 +7552,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
@@ -7575,7 +7575,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2904 kore[75]
+side condition exit: 2904 true
 rule: 2904 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7606,7 +7606,7 @@ hook: BOOL.and (0)
     VarKResult = kore[60]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2885 kore[75]
+side condition exit: 2885 true
 rule: 2885 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7628,7 +7628,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2903 kore[76]
+side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
@@ -7651,7 +7651,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2904 kore[76]
+side condition exit: 2904 false
 rule: 2905 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7676,7 +7676,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2890 kore[75]
+side condition exit: 2890 true
 rule: 2890 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7698,7 +7698,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2912 kore[76]
+side condition exit: 2912 false
 rule: 2913 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar2 = kore[1043]
@@ -7742,7 +7742,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2915 kore[75]
+side condition exit: 2915 true
 rule: 2915 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7764,7 +7764,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2894 kore[75]
+side condition exit: 2894 true
 rule: 2894 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7784,7 +7784,7 @@ hook: BOOL.and (0)
   hook result: kore[75]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2909 kore[75]
+side condition exit: 2909 true
 rule: 2909 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7810,7 +7810,7 @@ hook: BOOL.and (0)
     VarKResult = kore[59]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2888 kore[75]
+side condition exit: 2888 true
 rule: 2888 6
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7832,7 +7832,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2909 kore[76]
+side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
@@ -7855,7 +7855,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2910 kore[76]
+side condition exit: 2910 false
 rule: 2911 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7880,7 +7880,7 @@ hook: BOOL.and (0)
     VarKResult = kore[64]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2880 kore[75]
+side condition exit: 2880 true
 rule: 2880 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7901,7 +7901,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2894 kore[76]
+side condition exit: 2894 false
 rule: 2895 4
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7921,7 +7921,7 @@ hook: BOOL.and (0)
     VarKResult = kore[65]
   arg: kore[75]
 hook result: kore[75]
-side condition exit: 2891 kore[75]
+side condition exit: 2891 true
 rule: 2891 7
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]
@@ -7944,7 +7944,7 @@ hook: BOOL.and (0)
   hook result: kore[76]
   arg: kore[76]
 hook result: kore[76]
-side condition exit: 2915 kore[76]
+side condition exit: 2915 false
 rule: 2916 5
   Var'Unds'DotVar0 = kore[61]
   Var'Unds'DotVar1 = kore[337]


### PR DESCRIPTION
This modification was proposed by the LLVM Backend and Math Proof Generation Teams from Pi2 to optimize the Hints generated by the `llvm-krun` as constructing and parsing the boolean values of the side conditions takes some time. Then, we choose to simplify the way we're generating these hints. 