### PR TITLE
Fix locations in proof hints

### DIFF
--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -71,8 +71,7 @@ public:
     */
   llvm::Value *create_function_call(
       std::string const &name, value_type return_cat,
-      std::vector<llvm::Value *> const &args, bool sret, bool tailcc,
-      std::string const &location_stack = "0");
+      std::vector<llvm::Value *> const &args, bool sret, bool tailcc);
 
   [[nodiscard]] llvm::BasicBlock *get_current_block() const {
     return current_block_;

--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -25,16 +25,16 @@ private:
       std::string const &location_stack);
   llvm::Value *create_hook(
       kore_composite_pattern *hook_att, kore_composite_pattern *pattern,
-      std::string const &location_stack = "0");
+      std::string const &location_stack = "");
   llvm::Value *create_function_call(
       std::string const &name, kore_composite_pattern *pattern, bool sret,
-      bool tailcc, bool is_hook, std::string const &location_stack = "0");
+      bool tailcc, bool is_hook, std::string const &location_stack = "");
   llvm::Value *not_injection_case(
       kore_composite_pattern *constructor, llvm::Value *val,
-      std::string const &location_stack = "0");
+      std::string const &location_stack = "");
   bool populate_static_set(kore_pattern *pattern);
   std::pair<llvm::Value *, bool> create_allocation(
-      kore_pattern *pattern, std::string const &location_stack = "0");
+      kore_pattern *pattern, std::string const &location_stack = "");
 
 public:
   create_term(

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -737,14 +737,12 @@ llvm::Value *create_term::create_function_call(
     }
   }
 
-  return create_function_call(
-      name, return_cat, args, sret, tailcc, location_stack);
+  return create_function_call(name, return_cat, args, sret, tailcc);
 }
 
 llvm::Value *create_term::create_function_call(
     std::string const &name, value_type return_cat,
-    std::vector<llvm::Value *> const &args, bool sret, bool tailcc,
-    std::string const &location_stack) {
+    std::vector<llvm::Value *> const &args, bool sret, bool tailcc) {
   llvm::Type *return_type = getvalue_type(return_cat, module_);
   std::vector<llvm::Type *> types;
   bool collection = false;

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -323,9 +323,9 @@ llvm::Value *create_term::alloc_arg(
     kore_composite_pattern *pattern, int idx, bool is_hook_arg,
     std::string const &location_stack) {
   kore_pattern *p = pattern->get_arguments()[idx].get();
-  std::string new_location = location_stack.size()
-                                 ? fmt::format("{}:{}", location_stack, idx)
-                                 : fmt::format("{}", idx);
+  std::string new_location = location_stack.empty()
+                                 ? fmt::format("{}", idx)
+                                 : fmt::format("{}:{}", location_stack, idx);
   llvm::Value *ret = create_allocation(p, new_location).first;
   auto *sort = dynamic_cast<kore_composite_sort *>(p->get_sort().get());
   proof_event e(definition_, module_);
@@ -819,9 +819,9 @@ llvm::Value *create_term::not_injection_case(
     if (idx == 0 && val != nullptr) {
       child_value = val;
     } else {
-      std::string new_location = location_stack.size()
-                                     ? fmt::format("{}:{}", location_stack, idx)
-                                     : fmt::format("{}", idx);
+      std::string new_location
+          = location_stack.empty() ? fmt::format("{}", idx)
+                                   : fmt::format("{}:{}", location_stack, idx);
       if (is_injection) {
         new_location = location_stack;
       }

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -805,7 +805,8 @@ llvm::Value *create_term::not_injection_case(
       = get_block_header(module_, definition_, symbol, block_type);
   int idx = 0;
   std::vector<llvm::Value *> children;
-  bool is_injection = symbol_decl->attributes().contains(attribute_set::key::SortInjection);
+  bool is_injection
+      = symbol_decl->attributes().contains(attribute_set::key::SortInjection);
   assert(!is_injection || constructor->get_arguments().size() == 1);
   for (auto const &child : constructor->get_arguments()) {
     auto *sort = dynamic_cast<kore_composite_sort *>(child->get_sort().get());
@@ -818,7 +819,9 @@ llvm::Value *create_term::not_injection_case(
     if (idx == 0 && val != nullptr) {
       child_value = val;
     } else {
-      std::string new_location = location_stack.size() ? fmt::format("{}:{}", location_stack, idx) : fmt::format("{}", idx);
+      std::string new_location = location_stack.size()
+                                     ? fmt::format("{}:{}", location_stack, idx)
+                                     : fmt::format("{}", idx);
       if (is_injection) {
         new_location = location_stack;
       }

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -323,7 +323,9 @@ llvm::Value *create_term::alloc_arg(
     kore_composite_pattern *pattern, int idx, bool is_hook_arg,
     std::string const &location_stack) {
   kore_pattern *p = pattern->get_arguments()[idx].get();
-  std::string new_location = fmt::format("{}:{}", location_stack, idx);
+  std::string new_location = location_stack.size()
+                                 ? fmt::format("{}:{}", location_stack, idx)
+                                 : fmt::format("{}", idx);
   llvm::Value *ret = create_allocation(p, new_location).first;
   auto *sort = dynamic_cast<kore_composite_sort *>(p->get_sort().get());
   proof_event e(definition_, module_);

--- a/test/output/imp-proof/imp-proof.expanded.out.diff
+++ b/test/output/imp-proof/imp-proof.expanded.out.diff
@@ -1,24 +1,24 @@
 version: 8
-hook: MAP.element (0)
-  function: Lbl'UndsPipe'-'-GT-Unds'{} (0)
+hook: MAP.element ()
+  function: Lbl'UndsPipe'-'-GT-Unds'{} ()
   arg: kore[inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))]
   arg: kore[inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))]
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
-hook: MAP.unit (0)
-  function: Lbl'Stop'Map{} (0)
+hook: MAP.unit ()
+  function: Lbl'Stop'Map{} ()
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Stop'Map{}())]
-hook: MAP.concat (0)
-  function: Lbl'Unds'Map'Unds'{} (0)
+hook: MAP.concat ()
+  function: Lbl'Unds'Map'Unds'{} ()
   arg: kore[inj{SortMap{}, SortKItem{}}(Lbl'Stop'Map{}())]
   arg: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
-function: LblinitGeneratedTopCell{} (0)
+function: LblinitGeneratedTopCell{} ()
 rule: 2969 1
   VarInit = kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
-function: LblinitTCell{} (0:0)
+function: LblinitTCell{} (0)
 rule: 2972 1
   VarInit = kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
-function: LblinitKCell{} (0:0)
+function: LblinitKCell{} (0)
 rule: 2970 1
   VarInit = kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
 function: Lblproject'Coln'Pgm{} (0:0)
@@ -29,12 +29,12 @@ function: Lblproject'Coln'Pgm{} (0:0)
   hook result: kore[inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))]
 rule: 3070 1
   VarK = kore[Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))]
-function: LblinitStateCell{} (0:1)
+function: LblinitStateCell{} (1)
 rule: 2971 0
-hook: MAP.unit (0:0)
-  function: Lbl'Stop'Map{} (0:0)
+hook: MAP.unit (0)
+  function: Lbl'Stop'Map{} (0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Stop'Map{}())]
-function: LblinitGeneratedCounterCell{} (0:1)
+function: LblinitGeneratedCounterCell{} (1)
 rule: 2968 0
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Stop'Map{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 rule: 2919 5
@@ -43,10 +43,10 @@ rule: 2919 5
   Var'Unds'Gen1 = kore[inj{SortMap{}, SortKItem{}}(Lbl'Stop'Map{}())]
   VarX = kore[\dv{SortId{}}("n")]
   VarXs = kore[Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:1)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:1)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:1)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:1)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))))]
@@ -59,10 +59,10 @@ rule: 2919 5
   Var'Unds'Gen1 = kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))))]
   VarX = kore[\dv{SortId{}}("sum")]
   VarXs = kore[Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}()]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:1)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:1)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:1)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:1)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))))]
@@ -88,10 +88,10 @@ rule: 2914 5
   VarS2 = kore[Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -106,10 +106,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))))]
@@ -118,10 +118,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -136,10 +136,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))))]
@@ -155,10 +155,10 @@ rule: 2892 6
   VarS = kore[Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -175,10 +175,10 @@ rule: 2915 6
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -193,10 +193,10 @@ rule: 2894 4
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -219,9 +219,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -236,10 +236,10 @@ rule: 2888 6
   VarK1 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -250,17 +250,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -274,16 +274,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -297,10 +297,10 @@ rule: 2880 5
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -313,14 +313,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -336,10 +336,10 @@ rule: 2891 7
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -377,10 +377,10 @@ rule: 2914 5
   VarS2 = kore[Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -396,10 +396,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -422,9 +422,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("sum")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -439,10 +439,10 @@ rule: 2884 6
   VarK1 = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -453,17 +453,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -486,9 +486,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -503,10 +503,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -517,17 +517,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -541,16 +541,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -565,10 +565,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -583,10 +583,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))))]
@@ -595,10 +595,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -614,10 +614,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -640,9 +640,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -657,10 +657,10 @@ rule: 2884 6
   VarK1 = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -671,17 +671,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -700,16 +700,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -724,10 +724,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -738,17 +738,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -762,16 +762,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -786,10 +786,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -804,10 +804,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))))]
@@ -823,10 +823,10 @@ rule: 2892 6
   VarS = kore[Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -843,10 +843,10 @@ rule: 2915 6
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -861,10 +861,10 @@ rule: 2894 4
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -887,9 +887,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -904,10 +904,10 @@ rule: 2888 6
   VarK1 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -918,17 +918,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -942,16 +942,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -965,10 +965,10 @@ rule: 2880 5
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -981,14 +981,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1004,10 +1004,10 @@ rule: 2891 7
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1045,10 +1045,10 @@ rule: 2914 5
   VarS2 = kore[Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1064,10 +1064,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1090,9 +1090,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("sum")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1107,10 +1107,10 @@ rule: 2884 6
   VarK1 = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1121,17 +1121,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1154,9 +1154,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1171,10 +1171,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1185,17 +1185,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1209,16 +1209,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1233,10 +1233,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1251,10 +1251,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))))]
@@ -1263,10 +1263,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1282,10 +1282,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1308,9 +1308,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1325,10 +1325,10 @@ rule: 2884 6
   VarK1 = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1339,17 +1339,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1368,16 +1368,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1392,10 +1392,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1406,17 +1406,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1430,16 +1430,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1454,10 +1454,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1472,10 +1472,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))))]
@@ -1491,10 +1491,10 @@ rule: 2892 6
   VarS = kore[Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1511,10 +1511,10 @@ rule: 2915 6
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1529,10 +1529,10 @@ rule: 2894 4
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1555,9 +1555,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1572,10 +1572,10 @@ rule: 2888 6
   VarK1 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1586,17 +1586,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1610,16 +1610,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1633,10 +1633,10 @@ rule: 2880 5
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1649,14 +1649,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1672,10 +1672,10 @@ rule: 2891 7
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1713,10 +1713,10 @@ rule: 2914 5
   VarS2 = kore[Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1732,10 +1732,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1758,9 +1758,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("sum")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1775,10 +1775,10 @@ rule: 2884 6
   VarK1 = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1789,17 +1789,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1822,9 +1822,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1839,10 +1839,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1853,17 +1853,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1877,16 +1877,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1901,10 +1901,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1919,10 +1919,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))))]
@@ -1931,10 +1931,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1950,10 +1950,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -1976,9 +1976,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -1993,10 +1993,10 @@ rule: 2884 6
   VarK1 = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2007,17 +2007,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2036,16 +2036,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2060,10 +2060,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2074,17 +2074,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2098,16 +2098,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2122,10 +2122,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2140,10 +2140,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))))]
@@ -2159,10 +2159,10 @@ rule: 2892 6
   VarS = kore[Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2179,10 +2179,10 @@ rule: 2915 6
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2197,10 +2197,10 @@ rule: 2894 4
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2223,9 +2223,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2240,10 +2240,10 @@ rule: 2888 6
   VarK1 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2254,17 +2254,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2278,16 +2278,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2301,10 +2301,10 @@ rule: 2880 5
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2317,14 +2317,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2340,10 +2340,10 @@ rule: 2891 7
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2381,10 +2381,10 @@ rule: 2914 5
   VarS2 = kore[Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2400,10 +2400,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2426,9 +2426,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("sum")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2443,10 +2443,10 @@ rule: 2884 6
   VarK1 = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2457,17 +2457,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2490,9 +2490,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2507,10 +2507,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2521,17 +2521,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2545,16 +2545,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2569,10 +2569,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2587,10 +2587,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))))]
@@ -2599,10 +2599,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2618,10 +2618,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2644,9 +2644,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2661,10 +2661,10 @@ rule: 2884 6
   VarK1 = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2675,17 +2675,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2704,16 +2704,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2728,10 +2728,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2742,17 +2742,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2766,16 +2766,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2790,10 +2790,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2808,10 +2808,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))))]
@@ -2827,10 +2827,10 @@ rule: 2892 6
   VarS = kore[Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2847,10 +2847,10 @@ rule: 2915 6
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2865,10 +2865,10 @@ rule: 2894 4
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -2891,9 +2891,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2908,10 +2908,10 @@ rule: 2888 6
   VarK1 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2922,17 +2922,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2946,16 +2946,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2969,10 +2969,10 @@ rule: 2880 5
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -2985,14 +2985,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3008,10 +3008,10 @@ rule: 2891 7
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3049,10 +3049,10 @@ rule: 2914 5
   VarS2 = kore[Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3068,10 +3068,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3094,9 +3094,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("sum")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3111,10 +3111,10 @@ rule: 2884 6
   VarK1 = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3125,17 +3125,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3158,9 +3158,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3175,10 +3175,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3189,17 +3189,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3213,16 +3213,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3237,10 +3237,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3255,10 +3255,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))))]
@@ -3267,10 +3267,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3286,10 +3286,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3312,9 +3312,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3329,10 +3329,10 @@ rule: 2884 6
   VarK1 = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3343,17 +3343,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3372,16 +3372,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3396,10 +3396,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3410,17 +3410,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3434,16 +3434,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3458,10 +3458,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3476,10 +3476,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))))]
@@ -3495,10 +3495,10 @@ rule: 2892 6
   VarS = kore[Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3515,10 +3515,10 @@ rule: 2915 6
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3533,10 +3533,10 @@ rule: 2894 4
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3559,9 +3559,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3576,10 +3576,10 @@ rule: 2888 6
   VarK1 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3590,17 +3590,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3614,16 +3614,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3637,10 +3637,10 @@ rule: 2880 5
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3653,14 +3653,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3676,10 +3676,10 @@ rule: 2891 7
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3717,10 +3717,10 @@ rule: 2914 5
   VarS2 = kore[Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3736,10 +3736,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3762,9 +3762,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("sum")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3779,10 +3779,10 @@ rule: 2884 6
   VarK1 = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3793,17 +3793,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3826,9 +3826,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3843,10 +3843,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3857,17 +3857,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3881,16 +3881,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3905,10 +3905,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3923,10 +3923,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))))]
@@ -3935,10 +3935,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3954,10 +3954,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -3980,9 +3980,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -3997,10 +3997,10 @@ rule: 2884 6
   VarK1 = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4011,17 +4011,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4040,16 +4040,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4064,10 +4064,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4078,17 +4078,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4102,16 +4102,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4126,10 +4126,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4144,10 +4144,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))))]
@@ -4163,10 +4163,10 @@ rule: 2892 6
   VarS = kore[Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4183,10 +4183,10 @@ rule: 2915 6
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4201,10 +4201,10 @@ rule: 2894 4
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4227,9 +4227,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4244,10 +4244,10 @@ rule: 2888 6
   VarK1 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4258,17 +4258,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4282,16 +4282,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4305,10 +4305,10 @@ rule: 2880 5
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4321,14 +4321,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4344,10 +4344,10 @@ rule: 2891 7
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4385,10 +4385,10 @@ rule: 2914 5
   VarS2 = kore[Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4404,10 +4404,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4430,9 +4430,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("sum")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4447,10 +4447,10 @@ rule: 2884 6
   VarK1 = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4461,17 +4461,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4494,9 +4494,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4511,10 +4511,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4525,17 +4525,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4549,16 +4549,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4573,10 +4573,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4591,10 +4591,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))))]
@@ -4603,10 +4603,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4622,10 +4622,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4648,9 +4648,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4665,10 +4665,10 @@ rule: 2884 6
   VarK1 = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4679,17 +4679,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4708,16 +4708,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4732,10 +4732,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4746,17 +4746,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4770,16 +4770,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4794,10 +4794,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4812,10 +4812,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))))]
@@ -4831,10 +4831,10 @@ rule: 2892 6
   VarS = kore[Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4851,10 +4851,10 @@ rule: 2915 6
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4869,10 +4869,10 @@ rule: 2894 4
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -4895,9 +4895,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4912,10 +4912,10 @@ rule: 2888 6
   VarK1 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4926,17 +4926,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4950,16 +4950,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4973,10 +4973,10 @@ rule: 2880 5
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -4989,14 +4989,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5012,10 +5012,10 @@ rule: 2891 7
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5053,10 +5053,10 @@ rule: 2914 5
   VarS2 = kore[Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5072,10 +5072,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5098,9 +5098,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("sum")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5115,10 +5115,10 @@ rule: 2884 6
   VarK1 = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5129,17 +5129,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5162,9 +5162,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5179,10 +5179,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5193,17 +5193,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5217,16 +5217,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5241,10 +5241,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5259,10 +5259,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))))]
@@ -5271,10 +5271,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5290,10 +5290,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5316,9 +5316,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5333,10 +5333,10 @@ rule: 2884 6
   VarK1 = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5347,17 +5347,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5376,16 +5376,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5400,10 +5400,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5414,17 +5414,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5438,16 +5438,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5462,10 +5462,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5480,10 +5480,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))))]
@@ -5499,10 +5499,10 @@ rule: 2892 6
   VarS = kore[Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5519,10 +5519,10 @@ rule: 2915 6
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5537,10 +5537,10 @@ rule: 2894 4
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5563,9 +5563,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5580,10 +5580,10 @@ rule: 2888 6
   VarK1 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5594,17 +5594,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5618,16 +5618,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5641,10 +5641,10 @@ rule: 2880 5
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5657,14 +5657,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5680,10 +5680,10 @@ rule: 2891 7
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5721,10 +5721,10 @@ rule: 2914 5
   VarS2 = kore[Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5740,10 +5740,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5766,9 +5766,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("sum")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5783,10 +5783,10 @@ rule: 2884 6
   VarK1 = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5797,17 +5797,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5830,9 +5830,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5847,10 +5847,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5861,17 +5861,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5885,16 +5885,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5909,10 +5909,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -5927,10 +5927,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))))]
@@ -5939,10 +5939,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5958,10 +5958,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -5984,9 +5984,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6001,10 +6001,10 @@ rule: 2884 6
   VarK1 = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6015,17 +6015,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6044,16 +6044,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6068,10 +6068,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6082,17 +6082,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6106,16 +6106,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6130,10 +6130,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6148,10 +6148,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))))]
@@ -6167,10 +6167,10 @@ rule: 2892 6
   VarS = kore[Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6187,10 +6187,10 @@ rule: 2915 6
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6205,10 +6205,10 @@ rule: 2894 4
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6231,9 +6231,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6248,10 +6248,10 @@ rule: 2888 6
   VarK1 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6262,17 +6262,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6286,16 +6286,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6309,10 +6309,10 @@ rule: 2880 5
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6325,14 +6325,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6348,10 +6348,10 @@ rule: 2891 7
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6389,10 +6389,10 @@ rule: 2914 5
   VarS2 = kore[Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6408,10 +6408,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6434,9 +6434,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("sum")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6451,10 +6451,10 @@ rule: 2884 6
   VarK1 = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6465,17 +6465,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6498,9 +6498,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6515,10 +6515,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6529,17 +6529,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6553,16 +6553,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("55"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6577,10 +6577,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("sum")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("55"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("55"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6595,10 +6595,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))))]
@@ -6607,10 +6607,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6626,10 +6626,10 @@ rule: 2912 5
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6652,9 +6652,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6669,10 +6669,10 @@ rule: 2884 6
   VarK1 = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6683,17 +6683,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6712,16 +6712,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6736,10 +6736,10 @@ rule: 2885 6
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6750,17 +6750,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6774,16 +6774,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6798,10 +6798,10 @@ rule: 2890 6
   VarK0 = kore[\dv{SortId{}}("n")]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6816,10 +6816,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
       arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))))]
@@ -6835,10 +6835,10 @@ rule: 2892 6
   VarS = kore[Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6855,10 +6855,10 @@ rule: 2915 6
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6873,10 +6873,10 @@ rule: 2894 4
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
@@ -6899,9 +6899,9 @@ rule: 2893 6
   VarX = kore[\dv{SortId{}}("n")]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6916,10 +6916,10 @@ rule: 2888 6
   VarK1 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6930,17 +6930,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6954,16 +6954,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6977,10 +6977,10 @@ rule: 2880 5
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -6993,14 +6993,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
@@ -7016,10 +7016,10 @@ rule: 2891 7
   VarK2 = kore[Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]

--- a/test/output/imp-proof/imp-proof.out.diff
+++ b/test/output/imp-proof/imp-proof.out.diff
@@ -1,24 +1,24 @@
 version: 8
-hook: MAP.element (0)
-  function: Lbl'UndsPipe'-'-GT-Unds'{} (0)
+hook: MAP.element ()
+  function: Lbl'UndsPipe'-'-GT-Unds'{} ()
   arg: kore[74]
   arg: kore[1787]
 hook result: kore[1924]
-hook: MAP.unit (0)
-  function: Lbl'Stop'Map{} (0)
+hook: MAP.unit ()
+  function: Lbl'Stop'Map{} ()
 hook result: kore[51]
-hook: MAP.concat (0)
-  function: Lbl'Unds'Map'Unds'{} (0)
+hook: MAP.concat ()
+  function: Lbl'Unds'Map'Unds'{} ()
   arg: kore[51]
   arg: kore[1924]
 hook result: kore[1924]
-function: LblinitGeneratedTopCell{} (0)
+function: LblinitGeneratedTopCell{} ()
 rule: 2969 1
   VarInit = kore[1924]
-function: LblinitTCell{} (0:0)
+function: LblinitTCell{} (0)
 rule: 2972 1
   VarInit = kore[1924]
-function: LblinitKCell{} (0:0)
+function: LblinitKCell{} (0)
 rule: 2970 1
   VarInit = kore[1924]
 function: Lblproject'Coln'Pgm{} (0:0)
@@ -29,12 +29,12 @@ function: Lblproject'Coln'Pgm{} (0:0)
   hook result: kore[1787]
 rule: 3070 1
   VarK = kore[1754]
-function: LblinitStateCell{} (0:1)
+function: LblinitStateCell{} (1)
 rule: 2971 0
-hook: MAP.unit (0:0)
-  function: Lbl'Stop'Map{} (0:0)
+hook: MAP.unit (0)
+  function: Lbl'Stop'Map{} (0)
 hook result: kore[51]
-function: LblinitGeneratedCounterCell{} (0:1)
+function: LblinitGeneratedCounterCell{} (1)
 rule: 2968 0
 config: kore[1372]
 rule: 2919 5
@@ -43,10 +43,10 @@ rule: 2919 5
   Var'Unds'Gen1 = kore[51]
   VarX = kore[23]
   VarXs = kore[186]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:1)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:1)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:1)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:1)
       arg: kore[55]
       arg: kore[57]
     hook result: kore[175]
@@ -59,10 +59,10 @@ rule: 2919 5
   Var'Unds'Gen1 = kore[175]
   VarX = kore[25]
   VarXs = kore[98]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:1)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:1)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:1)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:1)
       arg: kore[57]
       arg: kore[57]
     hook result: kore[177]
@@ -88,10 +88,10 @@ rule: 2914 5
   VarS2 = kore[150]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -106,10 +106,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[58]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[55]
       arg: kore[58]
     hook result: kore[176]
@@ -118,10 +118,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[344]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -136,10 +136,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[57]
       arg: kore[57]
     hook result: kore[177]
@@ -155,10 +155,10 @@ rule: 2892 6
   VarS = kore[678]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[288]
     arg: kore[63]
@@ -175,10 +175,10 @@ rule: 2915 6
   VarK2 = kore[44]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[235]
     arg: kore[63]
@@ -193,10 +193,10 @@ rule: 2894 4
   VarHOLE = kore[181]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -219,9 +219,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -236,10 +236,10 @@ rule: 2888 6
   VarK1 = kore[56]
 side condition entry: 2909 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -250,17 +250,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -274,16 +274,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[58]
   arg: kore[57]
 hook result: kore[63]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[65]
   arg: kore[62]
@@ -297,10 +297,10 @@ rule: 2880 5
   VarHOLE = kore[62]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[65]
     arg: kore[62]
@@ -313,14 +313,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[64]
   arg: kore[62]
@@ -336,10 +336,10 @@ rule: 2891 7
   VarK2 = kore[44]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[64]
     arg: kore[62]
@@ -377,10 +377,10 @@ rule: 2914 5
   VarS2 = kore[286]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[231]
     arg: kore[63]
@@ -396,10 +396,10 @@ rule: 2912 5
   VarK0 = kore[25]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[77]
     arg: kore[63]
@@ -422,9 +422,9 @@ rule: 2893 6
   VarX = kore[25]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -439,10 +439,10 @@ rule: 2884 6
   VarK1 = kore[54]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -453,17 +453,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -486,9 +486,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -503,10 +503,10 @@ rule: 2885 6
   VarK0 = kore[56]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -517,17 +517,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -541,16 +541,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[58]
 hook result: kore[58]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -565,10 +565,10 @@ rule: 2890 6
   VarK0 = kore[25]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -583,10 +583,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[57]
       arg: kore[58]
     hook result: kore[178]
@@ -595,10 +595,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[345]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[248]
     arg: kore[63]
@@ -614,10 +614,10 @@ rule: 2912 5
   VarK0 = kore[23]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -640,9 +640,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -657,10 +657,10 @@ rule: 2884 6
   VarK1 = kore[73]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -671,17 +671,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[127]
     arg: kore[63]
@@ -700,16 +700,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[338]
   Var'Unds'DotVar2 = kore[1392]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -724,10 +724,10 @@ rule: 2885 6
   VarK0 = kore[57]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -738,17 +738,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -762,16 +762,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[58]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[58]
   arg: kore[58]
 hook result: kore[57]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -786,10 +786,10 @@ rule: 2890 6
   VarK0 = kore[23]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -804,10 +804,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[55]
       arg: kore[57]
     hook result: kore[175]
@@ -823,10 +823,10 @@ rule: 2892 6
   VarS = kore[678]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[288]
     arg: kore[63]
@@ -843,10 +843,10 @@ rule: 2915 6
   VarK2 = kore[44]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[235]
     arg: kore[63]
@@ -861,10 +861,10 @@ rule: 2894 4
   VarHOLE = kore[181]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -887,9 +887,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -904,10 +904,10 @@ rule: 2888 6
   VarK1 = kore[56]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -918,17 +918,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -942,16 +942,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[63]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[65]
   arg: kore[62]
@@ -965,10 +965,10 @@ rule: 2880 5
   VarHOLE = kore[62]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[65]
     arg: kore[62]
@@ -981,14 +981,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[64]
   arg: kore[62]
@@ -1004,10 +1004,10 @@ rule: 2891 7
   VarK2 = kore[44]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[64]
     arg: kore[62]
@@ -1045,10 +1045,10 @@ rule: 2914 5
   VarS2 = kore[286]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[231]
     arg: kore[63]
@@ -1064,10 +1064,10 @@ rule: 2912 5
   VarK0 = kore[25]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[77]
     arg: kore[63]
@@ -1090,9 +1090,9 @@ rule: 2893 6
   VarX = kore[25]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -1107,10 +1107,10 @@ rule: 2884 6
   VarK1 = kore[54]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -1121,17 +1121,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -1154,9 +1154,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -1171,10 +1171,10 @@ rule: 2885 6
   VarK0 = kore[57]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -1185,17 +1185,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -1209,16 +1209,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[58]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -1233,10 +1233,10 @@ rule: 2890 6
   VarK0 = kore[25]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -1251,10 +1251,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[57]
       arg: kore[58]
     hook result: kore[178]
@@ -1263,10 +1263,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[344]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[248]
     arg: kore[63]
@@ -1282,10 +1282,10 @@ rule: 2912 5
   VarK0 = kore[23]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -1308,9 +1308,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -1325,10 +1325,10 @@ rule: 2884 6
   VarK1 = kore[73]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -1339,17 +1339,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[127]
     arg: kore[63]
@@ -1368,16 +1368,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -1392,10 +1392,10 @@ rule: 2885 6
   VarK0 = kore[56]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -1406,17 +1406,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -1430,16 +1430,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[58]
 hook result: kore[57]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -1454,10 +1454,10 @@ rule: 2890 6
   VarK0 = kore[23]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -1472,10 +1472,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[55]
       arg: kore[57]
     hook result: kore[175]
@@ -1491,10 +1491,10 @@ rule: 2892 6
   VarS = kore[678]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[288]
     arg: kore[63]
@@ -1511,10 +1511,10 @@ rule: 2915 6
   VarK2 = kore[44]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[235]
     arg: kore[63]
@@ -1529,10 +1529,10 @@ rule: 2894 4
   VarHOLE = kore[181]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -1555,9 +1555,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -1572,10 +1572,10 @@ rule: 2888 6
   VarK1 = kore[56]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -1586,17 +1586,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -1610,16 +1610,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[63]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[65]
   arg: kore[62]
@@ -1633,10 +1633,10 @@ rule: 2880 5
   VarHOLE = kore[62]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[65]
     arg: kore[62]
@@ -1649,14 +1649,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[64]
   arg: kore[62]
@@ -1672,10 +1672,10 @@ rule: 2891 7
   VarK2 = kore[44]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[64]
     arg: kore[62]
@@ -1713,10 +1713,10 @@ rule: 2914 5
   VarS2 = kore[286]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[231]
     arg: kore[63]
@@ -1732,10 +1732,10 @@ rule: 2912 5
   VarK0 = kore[25]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[77]
     arg: kore[63]
@@ -1758,9 +1758,9 @@ rule: 2893 6
   VarX = kore[25]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -1775,10 +1775,10 @@ rule: 2884 6
   VarK1 = kore[54]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -1789,17 +1789,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -1822,9 +1822,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -1839,10 +1839,10 @@ rule: 2885 6
   VarK0 = kore[57]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -1853,17 +1853,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -1877,16 +1877,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[58]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -1901,10 +1901,10 @@ rule: 2890 6
   VarK0 = kore[25]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -1919,10 +1919,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[57]
       arg: kore[58]
     hook result: kore[178]
@@ -1931,10 +1931,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[344]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[248]
     arg: kore[63]
@@ -1950,10 +1950,10 @@ rule: 2912 5
   VarK0 = kore[23]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -1976,9 +1976,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -1993,10 +1993,10 @@ rule: 2884 6
   VarK1 = kore[73]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -2007,17 +2007,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[127]
     arg: kore[63]
@@ -2036,16 +2036,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -2060,10 +2060,10 @@ rule: 2885 6
   VarK0 = kore[56]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -2074,17 +2074,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -2098,16 +2098,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[58]
 hook result: kore[57]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -2122,10 +2122,10 @@ rule: 2890 6
   VarK0 = kore[23]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -2140,10 +2140,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[55]
       arg: kore[57]
     hook result: kore[175]
@@ -2159,10 +2159,10 @@ rule: 2892 6
   VarS = kore[678]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[288]
     arg: kore[63]
@@ -2179,10 +2179,10 @@ rule: 2915 6
   VarK2 = kore[44]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[235]
     arg: kore[63]
@@ -2197,10 +2197,10 @@ rule: 2894 4
   VarHOLE = kore[181]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -2223,9 +2223,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -2240,10 +2240,10 @@ rule: 2888 6
   VarK1 = kore[56]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -2254,17 +2254,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -2278,16 +2278,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[63]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[65]
   arg: kore[62]
@@ -2301,10 +2301,10 @@ rule: 2880 5
   VarHOLE = kore[62]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[65]
     arg: kore[62]
@@ -2317,14 +2317,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[64]
   arg: kore[62]
@@ -2340,10 +2340,10 @@ rule: 2891 7
   VarK2 = kore[44]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[64]
     arg: kore[62]
@@ -2381,10 +2381,10 @@ rule: 2914 5
   VarS2 = kore[286]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[231]
     arg: kore[63]
@@ -2400,10 +2400,10 @@ rule: 2912 5
   VarK0 = kore[25]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[77]
     arg: kore[63]
@@ -2426,9 +2426,9 @@ rule: 2893 6
   VarX = kore[25]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -2443,10 +2443,10 @@ rule: 2884 6
   VarK1 = kore[54]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -2457,17 +2457,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -2490,9 +2490,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -2507,10 +2507,10 @@ rule: 2885 6
   VarK0 = kore[57]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -2521,17 +2521,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -2545,16 +2545,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[58]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -2569,10 +2569,10 @@ rule: 2890 6
   VarK0 = kore[25]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -2587,10 +2587,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[57]
       arg: kore[58]
     hook result: kore[178]
@@ -2599,10 +2599,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[344]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[248]
     arg: kore[63]
@@ -2618,10 +2618,10 @@ rule: 2912 5
   VarK0 = kore[23]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -2644,9 +2644,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -2661,10 +2661,10 @@ rule: 2884 6
   VarK1 = kore[73]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -2675,17 +2675,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[127]
     arg: kore[63]
@@ -2704,16 +2704,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -2728,10 +2728,10 @@ rule: 2885 6
   VarK0 = kore[56]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -2742,17 +2742,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -2766,16 +2766,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[58]
 hook result: kore[57]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -2790,10 +2790,10 @@ rule: 2890 6
   VarK0 = kore[23]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -2808,10 +2808,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[55]
       arg: kore[57]
     hook result: kore[175]
@@ -2827,10 +2827,10 @@ rule: 2892 6
   VarS = kore[678]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[288]
     arg: kore[63]
@@ -2847,10 +2847,10 @@ rule: 2915 6
   VarK2 = kore[44]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[235]
     arg: kore[63]
@@ -2865,10 +2865,10 @@ rule: 2894 4
   VarHOLE = kore[181]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -2891,9 +2891,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -2908,10 +2908,10 @@ rule: 2888 6
   VarK1 = kore[56]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -2922,17 +2922,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -2946,16 +2946,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[63]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[65]
   arg: kore[62]
@@ -2969,10 +2969,10 @@ rule: 2880 5
   VarHOLE = kore[62]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[65]
     arg: kore[62]
@@ -2985,14 +2985,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[64]
   arg: kore[62]
@@ -3008,10 +3008,10 @@ rule: 2891 7
   VarK2 = kore[44]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[64]
     arg: kore[62]
@@ -3049,10 +3049,10 @@ rule: 2914 5
   VarS2 = kore[286]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[231]
     arg: kore[63]
@@ -3068,10 +3068,10 @@ rule: 2912 5
   VarK0 = kore[25]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[77]
     arg: kore[63]
@@ -3094,9 +3094,9 @@ rule: 2893 6
   VarX = kore[25]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -3111,10 +3111,10 @@ rule: 2884 6
   VarK1 = kore[54]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -3125,17 +3125,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -3158,9 +3158,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -3175,10 +3175,10 @@ rule: 2885 6
   VarK0 = kore[57]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -3189,17 +3189,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -3213,16 +3213,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[58]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -3237,10 +3237,10 @@ rule: 2890 6
   VarK0 = kore[25]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -3255,10 +3255,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[57]
       arg: kore[58]
     hook result: kore[178]
@@ -3267,10 +3267,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[344]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[248]
     arg: kore[63]
@@ -3286,10 +3286,10 @@ rule: 2912 5
   VarK0 = kore[23]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -3312,9 +3312,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -3329,10 +3329,10 @@ rule: 2884 6
   VarK1 = kore[73]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -3343,17 +3343,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[127]
     arg: kore[63]
@@ -3372,16 +3372,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -3396,10 +3396,10 @@ rule: 2885 6
   VarK0 = kore[56]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -3410,17 +3410,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -3434,16 +3434,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[58]
 hook result: kore[57]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -3458,10 +3458,10 @@ rule: 2890 6
   VarK0 = kore[23]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -3476,10 +3476,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[55]
       arg: kore[57]
     hook result: kore[175]
@@ -3495,10 +3495,10 @@ rule: 2892 6
   VarS = kore[678]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[288]
     arg: kore[63]
@@ -3515,10 +3515,10 @@ rule: 2915 6
   VarK2 = kore[44]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[235]
     arg: kore[63]
@@ -3533,10 +3533,10 @@ rule: 2894 4
   VarHOLE = kore[181]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -3559,9 +3559,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -3576,10 +3576,10 @@ rule: 2888 6
   VarK1 = kore[56]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -3590,17 +3590,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -3614,16 +3614,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[63]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[65]
   arg: kore[62]
@@ -3637,10 +3637,10 @@ rule: 2880 5
   VarHOLE = kore[62]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[65]
     arg: kore[62]
@@ -3653,14 +3653,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[64]
   arg: kore[62]
@@ -3676,10 +3676,10 @@ rule: 2891 7
   VarK2 = kore[44]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[64]
     arg: kore[62]
@@ -3717,10 +3717,10 @@ rule: 2914 5
   VarS2 = kore[286]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[231]
     arg: kore[63]
@@ -3736,10 +3736,10 @@ rule: 2912 5
   VarK0 = kore[25]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[77]
     arg: kore[63]
@@ -3762,9 +3762,9 @@ rule: 2893 6
   VarX = kore[25]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -3779,10 +3779,10 @@ rule: 2884 6
   VarK1 = kore[54]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -3793,17 +3793,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -3826,9 +3826,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -3843,10 +3843,10 @@ rule: 2885 6
   VarK0 = kore[57]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -3857,17 +3857,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -3881,16 +3881,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[58]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -3905,10 +3905,10 @@ rule: 2890 6
   VarK0 = kore[25]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -3923,10 +3923,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[57]
       arg: kore[58]
     hook result: kore[178]
@@ -3935,10 +3935,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[344]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[248]
     arg: kore[63]
@@ -3954,10 +3954,10 @@ rule: 2912 5
   VarK0 = kore[23]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -3980,9 +3980,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -3997,10 +3997,10 @@ rule: 2884 6
   VarK1 = kore[73]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -4011,17 +4011,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[127]
     arg: kore[63]
@@ -4040,16 +4040,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -4064,10 +4064,10 @@ rule: 2885 6
   VarK0 = kore[56]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -4078,17 +4078,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -4102,16 +4102,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[58]
 hook result: kore[57]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -4126,10 +4126,10 @@ rule: 2890 6
   VarK0 = kore[23]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -4144,10 +4144,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[55]
       arg: kore[57]
     hook result: kore[175]
@@ -4163,10 +4163,10 @@ rule: 2892 6
   VarS = kore[678]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[288]
     arg: kore[63]
@@ -4183,10 +4183,10 @@ rule: 2915 6
   VarK2 = kore[44]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[235]
     arg: kore[63]
@@ -4201,10 +4201,10 @@ rule: 2894 4
   VarHOLE = kore[181]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -4227,9 +4227,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -4244,10 +4244,10 @@ rule: 2888 6
   VarK1 = kore[56]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -4258,17 +4258,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -4282,16 +4282,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[63]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[65]
   arg: kore[62]
@@ -4305,10 +4305,10 @@ rule: 2880 5
   VarHOLE = kore[62]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[65]
     arg: kore[62]
@@ -4321,14 +4321,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[64]
   arg: kore[62]
@@ -4344,10 +4344,10 @@ rule: 2891 7
   VarK2 = kore[44]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[64]
     arg: kore[62]
@@ -4385,10 +4385,10 @@ rule: 2914 5
   VarS2 = kore[286]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[231]
     arg: kore[63]
@@ -4404,10 +4404,10 @@ rule: 2912 5
   VarK0 = kore[25]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[77]
     arg: kore[63]
@@ -4430,9 +4430,9 @@ rule: 2893 6
   VarX = kore[25]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -4447,10 +4447,10 @@ rule: 2884 6
   VarK1 = kore[54]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -4461,17 +4461,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -4494,9 +4494,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -4511,10 +4511,10 @@ rule: 2885 6
   VarK0 = kore[57]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -4525,17 +4525,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -4549,16 +4549,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[58]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -4573,10 +4573,10 @@ rule: 2890 6
   VarK0 = kore[25]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -4591,10 +4591,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[57]
       arg: kore[58]
     hook result: kore[178]
@@ -4603,10 +4603,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[344]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[248]
     arg: kore[63]
@@ -4622,10 +4622,10 @@ rule: 2912 5
   VarK0 = kore[23]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -4648,9 +4648,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -4665,10 +4665,10 @@ rule: 2884 6
   VarK1 = kore[73]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -4679,17 +4679,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[127]
     arg: kore[63]
@@ -4708,16 +4708,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -4732,10 +4732,10 @@ rule: 2885 6
   VarK0 = kore[56]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -4746,17 +4746,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -4770,16 +4770,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[58]
 hook result: kore[57]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -4794,10 +4794,10 @@ rule: 2890 6
   VarK0 = kore[23]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -4812,10 +4812,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[55]
       arg: kore[57]
     hook result: kore[175]
@@ -4831,10 +4831,10 @@ rule: 2892 6
   VarS = kore[678]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[288]
     arg: kore[63]
@@ -4851,10 +4851,10 @@ rule: 2915 6
   VarK2 = kore[44]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[235]
     arg: kore[63]
@@ -4869,10 +4869,10 @@ rule: 2894 4
   VarHOLE = kore[181]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -4895,9 +4895,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -4912,10 +4912,10 @@ rule: 2888 6
   VarK1 = kore[56]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -4926,17 +4926,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -4950,16 +4950,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[63]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[65]
   arg: kore[62]
@@ -4973,10 +4973,10 @@ rule: 2880 5
   VarHOLE = kore[62]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[65]
     arg: kore[62]
@@ -4989,14 +4989,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[64]
   arg: kore[62]
@@ -5012,10 +5012,10 @@ rule: 2891 7
   VarK2 = kore[44]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[64]
     arg: kore[62]
@@ -5053,10 +5053,10 @@ rule: 2914 5
   VarS2 = kore[286]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[231]
     arg: kore[63]
@@ -5072,10 +5072,10 @@ rule: 2912 5
   VarK0 = kore[25]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[77]
     arg: kore[63]
@@ -5098,9 +5098,9 @@ rule: 2893 6
   VarX = kore[25]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -5115,10 +5115,10 @@ rule: 2884 6
   VarK1 = kore[54]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -5129,17 +5129,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -5162,9 +5162,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -5179,10 +5179,10 @@ rule: 2885 6
   VarK0 = kore[57]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -5193,17 +5193,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -5217,16 +5217,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[58]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -5241,10 +5241,10 @@ rule: 2890 6
   VarK0 = kore[25]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -5259,10 +5259,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[57]
       arg: kore[58]
     hook result: kore[178]
@@ -5271,10 +5271,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[344]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[248]
     arg: kore[63]
@@ -5290,10 +5290,10 @@ rule: 2912 5
   VarK0 = kore[23]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -5316,9 +5316,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -5333,10 +5333,10 @@ rule: 2884 6
   VarK1 = kore[73]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -5347,17 +5347,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[127]
     arg: kore[63]
@@ -5376,16 +5376,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -5400,10 +5400,10 @@ rule: 2885 6
   VarK0 = kore[56]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -5414,17 +5414,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -5438,16 +5438,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[58]
 hook result: kore[57]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -5462,10 +5462,10 @@ rule: 2890 6
   VarK0 = kore[23]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -5480,10 +5480,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[55]
       arg: kore[57]
     hook result: kore[175]
@@ -5499,10 +5499,10 @@ rule: 2892 6
   VarS = kore[678]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[288]
     arg: kore[63]
@@ -5519,10 +5519,10 @@ rule: 2915 6
   VarK2 = kore[44]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[235]
     arg: kore[63]
@@ -5537,10 +5537,10 @@ rule: 2894 4
   VarHOLE = kore[181]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -5563,9 +5563,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -5580,10 +5580,10 @@ rule: 2888 6
   VarK1 = kore[56]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -5594,17 +5594,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -5618,16 +5618,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[63]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[65]
   arg: kore[62]
@@ -5641,10 +5641,10 @@ rule: 2880 5
   VarHOLE = kore[62]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[65]
     arg: kore[62]
@@ -5657,14 +5657,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[64]
   arg: kore[62]
@@ -5680,10 +5680,10 @@ rule: 2891 7
   VarK2 = kore[44]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[64]
     arg: kore[62]
@@ -5721,10 +5721,10 @@ rule: 2914 5
   VarS2 = kore[286]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[231]
     arg: kore[63]
@@ -5740,10 +5740,10 @@ rule: 2912 5
   VarK0 = kore[25]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[77]
     arg: kore[63]
@@ -5766,9 +5766,9 @@ rule: 2893 6
   VarX = kore[25]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -5783,10 +5783,10 @@ rule: 2884 6
   VarK1 = kore[54]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -5797,17 +5797,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -5830,9 +5830,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -5847,10 +5847,10 @@ rule: 2885 6
   VarK0 = kore[57]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -5861,17 +5861,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -5885,16 +5885,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[58]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -5909,10 +5909,10 @@ rule: 2890 6
   VarK0 = kore[25]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -5927,10 +5927,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[57]
       arg: kore[58]
     hook result: kore[178]
@@ -5939,10 +5939,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[344]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[248]
     arg: kore[63]
@@ -5958,10 +5958,10 @@ rule: 2912 5
   VarK0 = kore[23]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -5984,9 +5984,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -6001,10 +6001,10 @@ rule: 2884 6
   VarK1 = kore[73]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -6015,17 +6015,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[127]
     arg: kore[63]
@@ -6044,16 +6044,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -6068,10 +6068,10 @@ rule: 2885 6
   VarK0 = kore[56]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -6082,17 +6082,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -6106,16 +6106,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[58]
 hook result: kore[57]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -6130,10 +6130,10 @@ rule: 2890 6
   VarK0 = kore[23]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -6148,10 +6148,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[55]
       arg: kore[57]
     hook result: kore[175]
@@ -6167,10 +6167,10 @@ rule: 2892 6
   VarS = kore[678]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[288]
     arg: kore[63]
@@ -6187,10 +6187,10 @@ rule: 2915 6
   VarK2 = kore[44]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[235]
     arg: kore[63]
@@ -6205,10 +6205,10 @@ rule: 2894 4
   VarHOLE = kore[181]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -6231,9 +6231,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -6248,10 +6248,10 @@ rule: 2888 6
   VarK1 = kore[56]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -6262,17 +6262,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -6286,16 +6286,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[63]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[65]
   arg: kore[62]
@@ -6309,10 +6309,10 @@ rule: 2880 5
   VarHOLE = kore[62]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[65]
     arg: kore[62]
@@ -6325,14 +6325,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[64]
   arg: kore[62]
@@ -6348,10 +6348,10 @@ rule: 2891 7
   VarK2 = kore[44]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[64]
     arg: kore[62]
@@ -6389,10 +6389,10 @@ rule: 2914 5
   VarS2 = kore[286]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[231]
     arg: kore[63]
@@ -6408,10 +6408,10 @@ rule: 2912 5
   VarK0 = kore[25]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[77]
     arg: kore[63]
@@ -6434,9 +6434,9 @@ rule: 2893 6
   VarX = kore[25]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -6451,10 +6451,10 @@ rule: 2884 6
   VarK1 = kore[54]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -6465,17 +6465,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -6498,9 +6498,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -6515,10 +6515,10 @@ rule: 2885 6
   VarK0 = kore[57]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -6529,17 +6529,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -6553,16 +6553,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[58]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -6577,10 +6577,10 @@ rule: 2890 6
   VarK0 = kore[25]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -6595,10 +6595,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[57]
       arg: kore[58]
     hook result: kore[178]
@@ -6607,10 +6607,10 @@ hook: MAP.concat (0:0:1:0)
 hook result: kore[344]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[248]
     arg: kore[63]
@@ -6626,10 +6626,10 @@ rule: 2912 5
   VarK0 = kore[23]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -6652,9 +6652,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -6669,10 +6669,10 @@ rule: 2884 6
   VarK1 = kore[73]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -6683,17 +6683,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[127]
     arg: kore[63]
@@ -6712,16 +6712,16 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[58]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[60]
   arg: kore[62]
@@ -6736,10 +6736,10 @@ rule: 2885 6
   VarK0 = kore[56]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -6750,17 +6750,17 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[60]
     arg: kore[62]
@@ -6774,16 +6774,16 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[58]
 hook result: kore[57]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -6798,10 +6798,10 @@ rule: 2890 6
   VarK0 = kore[23]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -6816,10 +6816,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
       arg: kore[55]
       arg: kore[57]
     hook result: kore[175]
@@ -6835,10 +6835,10 @@ rule: 2892 6
   VarS = kore[678]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[288]
     arg: kore[63]
@@ -6855,10 +6855,10 @@ rule: 2915 6
   VarK2 = kore[44]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[235]
     arg: kore[63]
@@ -6873,10 +6873,10 @@ rule: 2894 4
   VarHOLE = kore[181]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3014 1
       VarK = kore[75]
     arg: kore[63]
@@ -6899,9 +6899,9 @@ rule: 2893 6
   VarX = kore[23]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[59]
   arg: kore[62]
@@ -6916,10 +6916,10 @@ rule: 2888 6
   VarK1 = kore[56]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -6930,17 +6930,17 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[59]
     arg: kore[62]
@@ -6954,16 +6954,16 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
   arg: kore[57]
   arg: kore[57]
 hook result: kore[62]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[64]
   arg: kore[62]
@@ -6977,10 +6977,10 @@ rule: 2880 5
   VarHOLE = kore[61]
 side condition entry: 2894 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[64]
     arg: kore[62]
@@ -6993,14 +6993,14 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[62]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[62]
 hook result: kore[63]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
   rule: 3015 1
     VarKResult = kore[65]
   arg: kore[62]
@@ -7016,10 +7016,10 @@ rule: 2891 7
   VarK2 = kore[44]
 side condition entry: 2915 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
     rule: 3015 1
       VarKResult = kore[65]
     arg: kore[62]

--- a/test/output/imp-slow-proof/imp-slow-proof.expanded.out.diff
+++ b/test/output/imp-slow-proof/imp-slow-proof.expanded.out.diff
@@ -1,30 +1,30 @@
 version: 8
-hook: MAP.element (0)
-  function: Lbl'UndsPipe'-'-GT-Unds'{} (0)
+hook: MAP.element ()
+  function: Lbl'UndsPipe'-'-GT-Unds'{} ()
     arg: kore[inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))]
     arg: kore[inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))]
   arg: kore[inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))]
   arg: kore[inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))]
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
-hook: MAP.unit (0)
-  function: Lbl'Stop'Map{} (0)
+hook: MAP.unit ()
+  function: Lbl'Stop'Map{} ()
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Stop'Map{}())]
-hook: MAP.concat (0)
-  function: Lbl'Unds'Map'Unds'{} (0)
+hook: MAP.concat ()
+  function: Lbl'Unds'Map'Unds'{} ()
     arg: kore[inj{SortMap{}, SortKItem{}}(Lbl'Stop'Map{}())]
     arg: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
   arg: kore[inj{SortMap{}, SortKItem{}}(Lbl'Stop'Map{}())]
   arg: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
-function: LblinitGeneratedTopCell{} (0)
+function: LblinitGeneratedTopCell{} ()
   arg: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
 rule: 2969 1
   VarInit = kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
-function: LblinitTCell{} (0:0)
+function: LblinitTCell{} (0)
   arg: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
 rule: 2972 1
   VarInit = kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
-function: LblinitKCell{} (0:0)
+function: LblinitKCell{} (0)
   arg: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
 rule: 2970 1
   VarInit = kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))))))]
@@ -39,12 +39,12 @@ function: Lblproject'Coln'Pgm{} (0:0)
   arg: kore[kseq{}(inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}())]
 rule: 3070 1
   VarK = kore[Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))]
-function: LblinitStateCell{} (0:1)
+function: LblinitStateCell{} (1)
 rule: 2971 0
-hook: MAP.unit (0:0)
-  function: Lbl'Stop'Map{} (0:0)
+hook: MAP.unit (0)
+  function: Lbl'Stop'Map{} (0)
 hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Stop'Map{}())]
-function: LblinitGeneratedCounterCell{} (0:1)
+function: LblinitGeneratedCounterCell{} (1)
 rule: 2968 0
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("n"),Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())),Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Stop'Map{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 rule: 2919 5
@@ -53,11 +53,11 @@ rule: 2919 5
   Var'Unds'Gen1 = kore[inj{SortMap{}, SortKItem{}}(Lbl'Stop'Map{}())]
   VarX = kore[\dv{SortId{}}("n")]
   VarXs = kore[Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(\dv{SortId{}}("sum"),Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}())]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
     arg: kore[inj{SortMap{}, SortKItem{}}(Lbl'Stop'Map{}())]
-    hook: MAP.element (0:0:1:0:1)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:1)
+    hook: MAP.element (0:1:0:1)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:1)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
@@ -74,11 +74,11 @@ rule: 2919 5
   Var'Unds'Gen1 = kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))))]
   VarX = kore[\dv{SortId{}}("sum")]
   VarXs = kore[Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}()]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
     arg: kore[inj{SortMap{}, SortKItem{}}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))))]
-    hook: MAP.element (0:0:1:0:1)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:1)
+    hook: MAP.element (0:1:0:1)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:1)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
@@ -111,10 +111,10 @@ rule: 2914 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -130,10 +130,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
@@ -147,10 +147,10 @@ hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -166,10 +166,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
@@ -191,10 +191,10 @@ rule: 2892 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
@@ -213,10 +213,10 @@ rule: 2915 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
@@ -233,10 +233,10 @@ rule: 2894 4
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -262,9 +262,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -281,10 +281,10 @@ rule: 2888 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -296,9 +296,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -306,8 +306,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -322,8 +322,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
@@ -332,9 +332,9 @@ hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -350,10 +350,10 @@ rule: 2880 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -367,15 +367,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -393,10 +393,10 @@ rule: 2891 7
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -440,10 +440,10 @@ rule: 2914 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
@@ -461,10 +461,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
@@ -490,9 +490,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -509,10 +509,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -524,9 +524,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -534,8 +534,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -561,9 +561,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -580,10 +580,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -595,9 +595,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -605,8 +605,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -621,8 +621,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
@@ -631,9 +631,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -650,10 +650,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -669,10 +669,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
@@ -686,10 +686,10 @@ hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
@@ -707,10 +707,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -736,9 +736,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -755,10 +755,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -770,9 +770,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -780,8 +780,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
@@ -802,8 +802,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
@@ -812,9 +812,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -831,10 +831,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -846,9 +846,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -856,8 +856,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -872,8 +872,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
@@ -882,9 +882,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
@@ -901,10 +901,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
@@ -920,10 +920,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
@@ -945,10 +945,10 @@ rule: 2892 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
@@ -967,10 +967,10 @@ rule: 2915 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
@@ -987,10 +987,10 @@ rule: 2894 4
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -1016,9 +1016,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
@@ -1035,10 +1035,10 @@ rule: 2888 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
@@ -1050,9 +1050,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
@@ -1060,8 +1060,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -1076,8 +1076,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
@@ -1086,9 +1086,9 @@ hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -1104,10 +1104,10 @@ rule: 2880 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -1121,15 +1121,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -1147,10 +1147,10 @@ rule: 2891 7
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -1194,10 +1194,10 @@ rule: 2914 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
@@ -1215,10 +1215,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
@@ -1244,9 +1244,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -1263,10 +1263,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -1278,9 +1278,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -1288,8 +1288,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -1315,9 +1315,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
@@ -1334,10 +1334,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -1349,9 +1349,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("10"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("10"))]
@@ -1359,8 +1359,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
@@ -1375,8 +1375,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
@@ -1385,9 +1385,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
@@ -1404,10 +1404,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
@@ -1423,10 +1423,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("10"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
@@ -1440,10 +1440,10 @@ hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
@@ -1461,10 +1461,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -1490,9 +1490,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
@@ -1509,10 +1509,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
@@ -1524,9 +1524,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
@@ -1534,8 +1534,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
@@ -1556,8 +1556,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
@@ -1566,9 +1566,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -1585,10 +1585,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
@@ -1600,9 +1600,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("9"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("9"))]
@@ -1610,8 +1610,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -1626,8 +1626,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
@@ -1636,9 +1636,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
@@ -1655,10 +1655,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
@@ -1674,10 +1674,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("9"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
@@ -1699,10 +1699,10 @@ rule: 2892 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
@@ -1721,10 +1721,10 @@ rule: 2915 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
@@ -1741,10 +1741,10 @@ rule: 2894 4
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -1770,9 +1770,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
@@ -1789,10 +1789,10 @@ rule: 2888 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
@@ -1804,9 +1804,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
@@ -1814,8 +1814,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -1830,8 +1830,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
@@ -1840,9 +1840,9 @@ hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -1858,10 +1858,10 @@ rule: 2880 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -1875,15 +1875,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -1901,10 +1901,10 @@ rule: 2891 7
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -1948,10 +1948,10 @@ rule: 2914 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
@@ -1969,10 +1969,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
@@ -1998,9 +1998,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
@@ -2017,10 +2017,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
@@ -2032,9 +2032,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
@@ -2042,8 +2042,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -2069,9 +2069,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
@@ -2088,10 +2088,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
@@ -2103,9 +2103,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("19"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("19"))]
@@ -2113,8 +2113,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
@@ -2129,8 +2129,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
@@ -2139,9 +2139,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
@@ -2158,10 +2158,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
@@ -2177,10 +2177,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("19"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
@@ -2194,10 +2194,10 @@ hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
@@ -2215,10 +2215,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -2244,9 +2244,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
@@ -2263,10 +2263,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
@@ -2278,9 +2278,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
@@ -2288,8 +2288,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
@@ -2310,8 +2310,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
@@ -2320,9 +2320,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -2339,10 +2339,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
@@ -2354,9 +2354,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("8"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("8"))]
@@ -2364,8 +2364,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -2380,8 +2380,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
@@ -2390,9 +2390,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
@@ -2409,10 +2409,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
@@ -2428,10 +2428,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("8"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
@@ -2453,10 +2453,10 @@ rule: 2892 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
@@ -2475,10 +2475,10 @@ rule: 2915 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
@@ -2495,10 +2495,10 @@ rule: 2894 4
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -2524,9 +2524,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
@@ -2543,10 +2543,10 @@ rule: 2888 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
@@ -2558,9 +2558,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
@@ -2568,8 +2568,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -2584,8 +2584,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
@@ -2594,9 +2594,9 @@ hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -2612,10 +2612,10 @@ rule: 2880 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -2629,15 +2629,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -2655,10 +2655,10 @@ rule: 2891 7
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -2702,10 +2702,10 @@ rule: 2914 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
@@ -2723,10 +2723,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
@@ -2752,9 +2752,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
@@ -2771,10 +2771,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
@@ -2786,9 +2786,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
@@ -2796,8 +2796,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -2823,9 +2823,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
@@ -2842,10 +2842,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
@@ -2857,9 +2857,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("27"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("27"))]
@@ -2867,8 +2867,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
@@ -2883,8 +2883,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
@@ -2893,9 +2893,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
@@ -2912,10 +2912,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
@@ -2931,10 +2931,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("27"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
@@ -2948,10 +2948,10 @@ hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
@@ -2969,10 +2969,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -2998,9 +2998,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
@@ -3017,10 +3017,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
@@ -3032,9 +3032,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
@@ -3042,8 +3042,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
@@ -3064,8 +3064,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
@@ -3074,9 +3074,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -3093,10 +3093,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
@@ -3108,9 +3108,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("7"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("7"))]
@@ -3118,8 +3118,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -3134,8 +3134,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
@@ -3144,9 +3144,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
@@ -3163,10 +3163,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
@@ -3182,10 +3182,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("7"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
@@ -3207,10 +3207,10 @@ rule: 2892 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
@@ -3229,10 +3229,10 @@ rule: 2915 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
@@ -3249,10 +3249,10 @@ rule: 2894 4
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -3278,9 +3278,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
@@ -3297,10 +3297,10 @@ rule: 2888 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
@@ -3312,9 +3312,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
@@ -3322,8 +3322,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -3338,8 +3338,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
@@ -3348,9 +3348,9 @@ hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -3366,10 +3366,10 @@ rule: 2880 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -3383,15 +3383,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -3409,10 +3409,10 @@ rule: 2891 7
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -3456,10 +3456,10 @@ rule: 2914 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
@@ -3477,10 +3477,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
@@ -3506,9 +3506,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
@@ -3525,10 +3525,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
@@ -3540,9 +3540,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
@@ -3550,8 +3550,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -3577,9 +3577,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
@@ -3596,10 +3596,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
@@ -3611,9 +3611,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("34"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("34"))]
@@ -3621,8 +3621,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
@@ -3637,8 +3637,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
@@ -3647,9 +3647,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
@@ -3666,10 +3666,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
@@ -3685,10 +3685,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("34"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
@@ -3702,10 +3702,10 @@ hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
@@ -3723,10 +3723,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -3752,9 +3752,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
@@ -3771,10 +3771,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
@@ -3786,9 +3786,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
@@ -3796,8 +3796,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
@@ -3818,8 +3818,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
@@ -3828,9 +3828,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -3847,10 +3847,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
@@ -3862,9 +3862,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("6"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("6"))]
@@ -3872,8 +3872,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -3888,8 +3888,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
@@ -3898,9 +3898,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
@@ -3917,10 +3917,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
@@ -3936,10 +3936,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
@@ -3961,10 +3961,10 @@ rule: 2892 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
@@ -3983,10 +3983,10 @@ rule: 2915 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
@@ -4003,10 +4003,10 @@ rule: 2894 4
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -4032,9 +4032,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
@@ -4051,10 +4051,10 @@ rule: 2888 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
@@ -4066,9 +4066,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
@@ -4076,8 +4076,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -4092,8 +4092,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
@@ -4102,9 +4102,9 @@ hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -4120,10 +4120,10 @@ rule: 2880 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -4137,15 +4137,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -4163,10 +4163,10 @@ rule: 2891 7
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -4210,10 +4210,10 @@ rule: 2914 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
@@ -4231,10 +4231,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
@@ -4260,9 +4260,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
@@ -4279,10 +4279,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
@@ -4294,9 +4294,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
@@ -4304,8 +4304,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -4331,9 +4331,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
@@ -4350,10 +4350,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
@@ -4365,9 +4365,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("40"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("40"))]
@@ -4375,8 +4375,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
@@ -4391,8 +4391,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
@@ -4401,9 +4401,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
@@ -4420,10 +4420,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
@@ -4439,10 +4439,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("40"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
@@ -4456,10 +4456,10 @@ hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
@@ -4477,10 +4477,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -4506,9 +4506,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
@@ -4525,10 +4525,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
@@ -4540,9 +4540,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
@@ -4550,8 +4550,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
@@ -4572,8 +4572,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
@@ -4582,9 +4582,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -4601,10 +4601,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
@@ -4616,9 +4616,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("5"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("5"))]
@@ -4626,8 +4626,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -4642,8 +4642,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
@@ -4652,9 +4652,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
@@ -4671,10 +4671,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
@@ -4690,10 +4690,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
@@ -4715,10 +4715,10 @@ rule: 2892 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
@@ -4737,10 +4737,10 @@ rule: 2915 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
@@ -4757,10 +4757,10 @@ rule: 2894 4
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -4786,9 +4786,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
@@ -4805,10 +4805,10 @@ rule: 2888 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
@@ -4820,9 +4820,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
@@ -4830,8 +4830,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -4846,8 +4846,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
@@ -4856,9 +4856,9 @@ hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -4874,10 +4874,10 @@ rule: 2880 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -4891,15 +4891,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -4917,10 +4917,10 @@ rule: 2891 7
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -4964,10 +4964,10 @@ rule: 2914 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
@@ -4985,10 +4985,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
@@ -5014,9 +5014,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
@@ -5033,10 +5033,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
@@ -5048,9 +5048,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
@@ -5058,8 +5058,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -5085,9 +5085,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
@@ -5104,10 +5104,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
@@ -5119,9 +5119,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("45"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("45"))]
@@ -5129,8 +5129,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
@@ -5145,8 +5145,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
@@ -5155,9 +5155,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
@@ -5174,10 +5174,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
@@ -5193,10 +5193,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("45"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
@@ -5210,10 +5210,10 @@ hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
@@ -5231,10 +5231,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -5260,9 +5260,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
@@ -5279,10 +5279,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
@@ -5294,9 +5294,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
@@ -5304,8 +5304,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
@@ -5326,8 +5326,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
@@ -5336,9 +5336,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -5355,10 +5355,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
@@ -5370,9 +5370,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("4"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("4"))]
@@ -5380,8 +5380,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -5396,8 +5396,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
@@ -5406,9 +5406,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
@@ -5425,10 +5425,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
@@ -5444,10 +5444,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("4"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
@@ -5469,10 +5469,10 @@ rule: 2892 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
@@ -5491,10 +5491,10 @@ rule: 2915 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
@@ -5511,10 +5511,10 @@ rule: 2894 4
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -5540,9 +5540,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
@@ -5559,10 +5559,10 @@ rule: 2888 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
@@ -5574,9 +5574,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
@@ -5584,8 +5584,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -5600,8 +5600,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
@@ -5610,9 +5610,9 @@ hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -5628,10 +5628,10 @@ rule: 2880 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -5645,15 +5645,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -5671,10 +5671,10 @@ rule: 2891 7
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -5718,10 +5718,10 @@ rule: 2914 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
@@ -5739,10 +5739,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
@@ -5768,9 +5768,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
@@ -5787,10 +5787,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
@@ -5802,9 +5802,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
@@ -5812,8 +5812,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -5839,9 +5839,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
@@ -5858,10 +5858,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
@@ -5873,9 +5873,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("49"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("49"))]
@@ -5883,8 +5883,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
@@ -5899,8 +5899,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
@@ -5909,9 +5909,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
@@ -5928,10 +5928,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
@@ -5947,10 +5947,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("49"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
@@ -5964,10 +5964,10 @@ hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
@@ -5985,10 +5985,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -6014,9 +6014,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
@@ -6033,10 +6033,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
@@ -6048,9 +6048,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
@@ -6058,8 +6058,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
@@ -6080,8 +6080,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
@@ -6090,9 +6090,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -6109,10 +6109,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
@@ -6124,9 +6124,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("3"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("3"))]
@@ -6134,8 +6134,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -6150,8 +6150,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
@@ -6160,9 +6160,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
@@ -6179,10 +6179,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
@@ -6198,10 +6198,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("3"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
@@ -6223,10 +6223,10 @@ rule: 2892 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
@@ -6245,10 +6245,10 @@ rule: 2915 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
@@ -6265,10 +6265,10 @@ rule: 2894 4
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -6294,9 +6294,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
@@ -6313,10 +6313,10 @@ rule: 2888 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
@@ -6328,9 +6328,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
@@ -6338,8 +6338,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -6354,8 +6354,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
@@ -6364,9 +6364,9 @@ hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -6382,10 +6382,10 @@ rule: 2880 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -6399,15 +6399,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -6425,10 +6425,10 @@ rule: 2891 7
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -6472,10 +6472,10 @@ rule: 2914 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
@@ -6493,10 +6493,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
@@ -6522,9 +6522,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
@@ -6541,10 +6541,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
@@ -6556,9 +6556,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
@@ -6566,8 +6566,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -6593,9 +6593,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
@@ -6612,10 +6612,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
@@ -6627,9 +6627,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("52"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("52"))]
@@ -6637,8 +6637,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
@@ -6653,8 +6653,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
@@ -6663,9 +6663,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
@@ -6682,10 +6682,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
@@ -6701,10 +6701,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("52"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
@@ -6718,10 +6718,10 @@ hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
@@ -6739,10 +6739,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -6768,9 +6768,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
@@ -6787,10 +6787,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
@@ -6802,9 +6802,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
@@ -6812,8 +6812,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
@@ -6834,8 +6834,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
@@ -6844,9 +6844,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -6863,10 +6863,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
@@ -6878,9 +6878,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("2"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("2"))]
@@ -6888,8 +6888,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -6904,8 +6904,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
@@ -6914,9 +6914,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
@@ -6933,10 +6933,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
@@ -6952,10 +6952,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
@@ -6977,10 +6977,10 @@ rule: 2892 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
@@ -6999,10 +6999,10 @@ rule: 2915 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
@@ -7019,10 +7019,10 @@ rule: 2894 4
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -7048,9 +7048,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
@@ -7067,10 +7067,10 @@ rule: 2888 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
@@ -7082,9 +7082,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
@@ -7092,8 +7092,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -7108,8 +7108,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
@@ -7118,9 +7118,9 @@ hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -7136,10 +7136,10 @@ rule: 2880 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -7153,15 +7153,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -7179,10 +7179,10 @@ rule: 2891 7
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -7226,10 +7226,10 @@ rule: 2914 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),dotk{}())]
@@ -7247,10 +7247,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())]
@@ -7276,9 +7276,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
@@ -7295,10 +7295,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
@@ -7310,9 +7310,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
@@ -7320,8 +7320,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -7347,9 +7347,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
@@ -7366,10 +7366,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
@@ -7381,9 +7381,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("54"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("54"))]
@@ -7391,8 +7391,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
@@ -7407,8 +7407,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
@@ -7417,9 +7417,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("55"))]
@@ -7436,10 +7436,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("55")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("55"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("55"))]
@@ -7455,10 +7455,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("54"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))]
   VarX = kore[\dv{SortId{}}("sum")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum"))]
@@ -7472,10 +7472,10 @@ hook result: kore[inj{SortMap{}, SortKItem{}}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),dotk{}())]
@@ -7493,10 +7493,10 @@ rule: 2912 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -7522,9 +7522,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
@@ -7541,10 +7541,10 @@ rule: 2884 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
@@ -7556,9 +7556,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
@@ -7566,8 +7566,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))),dotk{}())]
@@ -7588,8 +7588,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
@@ -7598,9 +7598,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -7617,10 +7617,10 @@ rule: 2885 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1")))),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2903 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
@@ -7632,9 +7632,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("-1"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("1"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("1"))]
@@ -7642,8 +7642,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("-1"))]
@@ -7658,8 +7658,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-1"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
@@ -7668,9 +7668,9 @@ hook result: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -7687,10 +7687,10 @@ rule: 2890 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2912 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -7706,10 +7706,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))]
   VarI = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarX = kore[\dv{SortId{}}("n")]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
         arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
       arg: kore[inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n"))]
@@ -7731,10 +7731,10 @@ rule: 2892 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),dotk{}())]
@@ -7753,10 +7753,10 @@ rule: 2915 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),dotk{}())]
@@ -7773,10 +7773,10 @@ rule: 2894 4
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
     rule: 3014 1
       VarK = kore[kseq{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),dotk{}())]
@@ -7802,9 +7802,9 @@ rule: 2893 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -7821,10 +7821,10 @@ rule: 2888 6
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2909 1
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -7836,9 +7836,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
   VarK0 = kore[inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0"))]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -7846,8 +7846,8 @@ hook: BOOL.and (0)
     arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortInt{}, SortKResult{}}(\dv{SortInt{}}("0"))]
@@ -7862,8 +7862,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))]
   VarI1 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   VarI2 = kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
     arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
   arg: kore[inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))]
@@ -7872,9 +7872,9 @@ hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -7890,10 +7890,10 @@ rule: 2880 5
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")))),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2894 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("true"))]
@@ -7907,15 +7907,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))]
   Var'Unds'DotVar2 = kore[kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}())]
   VarT = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
 hook result: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1")))))))))),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),dotk{}())),dotk{}()))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
   rule: 3015 1
     VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]
@@ -7933,10 +7933,10 @@ rule: 2891 7
 config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortAExp{}}(\dv{SortInt{}}("0")))),Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("sum"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("sum")),inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")))),Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(\dv{SortId{}}("n"),Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortId{}, SortAExp{}}(\dv{SortId{}}("n")),Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(\dv{SortInt{}}("1"))))))))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("sum")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("55"))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("n")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
 side condition entry: 2915 1
   VarHOLE = kore[inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false"))]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("true"))]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),dotk{}())]
     rule: 3015 1
       VarKResult = kore[inj{SortBool{}, SortKResult{}}(\dv{SortBool{}}("false"))]

--- a/test/output/imp-slow-proof/imp-slow-proof.out.diff
+++ b/test/output/imp-slow-proof/imp-slow-proof.out.diff
@@ -1,30 +1,30 @@
 version: 8
-hook: MAP.element (0)
-  function: Lbl'UndsPipe'-'-GT-Unds'{} (0)
+hook: MAP.element ()
+  function: Lbl'UndsPipe'-'-GT-Unds'{} ()
     arg: kore[74]
     arg: kore[1787]
   arg: kore[74]
   arg: kore[1787]
 hook result: kore[1924]
-hook: MAP.unit (0)
-  function: Lbl'Stop'Map{} (0)
+hook: MAP.unit ()
+  function: Lbl'Stop'Map{} ()
 hook result: kore[51]
-hook: MAP.concat (0)
-  function: Lbl'Unds'Map'Unds'{} (0)
+hook: MAP.concat ()
+  function: Lbl'Unds'Map'Unds'{} ()
     arg: kore[51]
     arg: kore[1924]
   arg: kore[51]
   arg: kore[1924]
 hook result: kore[1924]
-function: LblinitGeneratedTopCell{} (0)
+function: LblinitGeneratedTopCell{} ()
   arg: kore[1924]
 rule: 2969 1
   VarInit = kore[1924]
-function: LblinitTCell{} (0:0)
+function: LblinitTCell{} (0)
   arg: kore[1924]
 rule: 2972 1
   VarInit = kore[1924]
-function: LblinitKCell{} (0:0)
+function: LblinitKCell{} (0)
   arg: kore[1924]
 rule: 2970 1
   VarInit = kore[1924]
@@ -39,12 +39,12 @@ function: Lblproject'Coln'Pgm{} (0:0)
   arg: kore[1807]
 rule: 3070 1
   VarK = kore[1754]
-function: LblinitStateCell{} (0:1)
+function: LblinitStateCell{} (1)
 rule: 2971 0
-hook: MAP.unit (0:0)
-  function: Lbl'Stop'Map{} (0:0)
+hook: MAP.unit (0)
+  function: Lbl'Stop'Map{} (0)
 hook result: kore[51]
-function: LblinitGeneratedCounterCell{} (0:1)
+function: LblinitGeneratedCounterCell{} (1)
 rule: 2968 0
 config: kore[1372]
 rule: 2919 5
@@ -53,11 +53,11 @@ rule: 2919 5
   Var'Unds'Gen1 = kore[51]
   VarX = kore[23]
   VarXs = kore[186]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
     arg: kore[51]
-    hook: MAP.element (0:0:1:0:1)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:1)
+    hook: MAP.element (0:1:0:1)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:1)
         arg: kore[55]
         arg: kore[57]
       arg: kore[55]
@@ -74,11 +74,11 @@ rule: 2919 5
   Var'Unds'Gen1 = kore[175]
   VarX = kore[25]
   VarXs = kore[98]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
     arg: kore[175]
-    hook: MAP.element (0:0:1:0:1)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:1)
+    hook: MAP.element (0:1:0:1)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:1)
         arg: kore[57]
         arg: kore[57]
       arg: kore[57]
@@ -111,10 +111,10 @@ rule: 2914 5
 config: kore[1904]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -130,10 +130,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[58]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[55]
         arg: kore[58]
       arg: kore[55]
@@ -147,10 +147,10 @@ hook result: kore[344]
 config: kore[1712]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -166,10 +166,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[57]
         arg: kore[57]
       arg: kore[57]
@@ -191,10 +191,10 @@ rule: 2892 6
 config: kore[2724]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[288]
     rule: 3014 1
       VarK = kore[288]
@@ -213,10 +213,10 @@ rule: 2915 6
 config: kore[2864]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[235]
     rule: 3014 1
       VarK = kore[235]
@@ -233,10 +233,10 @@ rule: 2894 4
 config: kore[2894]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -262,9 +262,9 @@ rule: 2893 6
 config: kore[2915]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -281,10 +281,10 @@ rule: 2888 6
 config: kore[2897]
 side condition entry: 2909 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -296,9 +296,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -306,8 +306,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -322,8 +322,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[58]
     arg: kore[57]
   arg: kore[58]
@@ -332,9 +332,9 @@ hook result: kore[63]
 config: kore[2742]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[83]
   rule: 3015 1
     VarKResult = kore[65]
@@ -350,10 +350,10 @@ rule: 2880 5
 config: kore[2745]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[83]
     rule: 3015 1
       VarKResult = kore[65]
@@ -367,15 +367,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 config: kore[2658]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[82]
   rule: 3015 1
     VarKResult = kore[64]
@@ -393,10 +393,10 @@ rule: 2891 7
 config: kore[2551]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[82]
     rule: 3015 1
       VarKResult = kore[64]
@@ -440,10 +440,10 @@ rule: 2914 5
 config: kore[2163]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[231]
     rule: 3014 1
       VarK = kore[231]
@@ -461,10 +461,10 @@ rule: 2912 5
 config: kore[2245]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3014 1
       VarK = kore[77]
@@ -490,9 +490,9 @@ rule: 2893 6
 config: kore[2263]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -509,10 +509,10 @@ rule: 2884 6
 config: kore[2245]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -524,9 +524,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -534,8 +534,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -561,9 +561,9 @@ rule: 2893 6
 config: kore[2266]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -580,10 +580,10 @@ rule: 2885 6
 config: kore[2248]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -595,9 +595,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -605,8 +605,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -621,8 +621,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[58]
   arg: kore[57]
@@ -631,9 +631,9 @@ hook result: kore[58]
 config: kore[2092]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -650,10 +650,10 @@ rule: 2890 6
 config: kore[2043]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -669,10 +669,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[57]
         arg: kore[58]
       arg: kore[57]
@@ -686,10 +686,10 @@ hook result: kore[345]
 config: kore[1849]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[248]
     rule: 3014 1
       VarK = kore[248]
@@ -707,10 +707,10 @@ rule: 2912 5
 config: kore[1931]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -736,9 +736,9 @@ rule: 2893 6
 config: kore[1985]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -755,10 +755,10 @@ rule: 2884 6
 config: kore[1934]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -770,9 +770,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -780,8 +780,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[127]
     rule: 3014 1
       VarK = kore[127]
@@ -802,8 +802,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[338]
   Var'Unds'DotVar2 = kore[1392]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -812,9 +812,9 @@ hook result: kore[58]
 config: kore[1936]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -831,10 +831,10 @@ rule: 2885 6
 config: kore[1918]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -846,9 +846,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -856,8 +856,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -872,8 +872,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[58]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[58]
     arg: kore[58]
   arg: kore[58]
@@ -882,9 +882,9 @@ hook result: kore[57]
 config: kore[1760]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -901,10 +901,10 @@ rule: 2890 6
 config: kore[1711]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -920,10 +920,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[55]
         arg: kore[57]
       arg: kore[55]
@@ -945,10 +945,10 @@ rule: 2892 6
 config: kore[2724]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[288]
     rule: 3014 1
       VarK = kore[288]
@@ -967,10 +967,10 @@ rule: 2915 6
 config: kore[2864]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[235]
     rule: 3014 1
       VarK = kore[235]
@@ -987,10 +987,10 @@ rule: 2894 4
 config: kore[2894]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -1016,9 +1016,9 @@ rule: 2893 6
 config: kore[2914]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -1035,10 +1035,10 @@ rule: 2888 6
 config: kore[2896]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -1050,9 +1050,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -1060,8 +1060,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -1076,8 +1076,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -1086,9 +1086,9 @@ hook result: kore[63]
 config: kore[2742]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[83]
   rule: 3015 1
     VarKResult = kore[65]
@@ -1104,10 +1104,10 @@ rule: 2880 5
 config: kore[2745]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[83]
     rule: 3015 1
       VarKResult = kore[65]
@@ -1121,15 +1121,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 config: kore[2658]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[82]
   rule: 3015 1
     VarKResult = kore[64]
@@ -1147,10 +1147,10 @@ rule: 2891 7
 config: kore[2551]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[82]
     rule: 3015 1
       VarKResult = kore[64]
@@ -1194,10 +1194,10 @@ rule: 2914 5
 config: kore[2163]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[231]
     rule: 3014 1
       VarK = kore[231]
@@ -1215,10 +1215,10 @@ rule: 2912 5
 config: kore[2245]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3014 1
       VarK = kore[77]
@@ -1244,9 +1244,9 @@ rule: 2893 6
 config: kore[2264]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -1263,10 +1263,10 @@ rule: 2884 6
 config: kore[2246]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -1278,9 +1278,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -1288,8 +1288,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -1315,9 +1315,9 @@ rule: 2893 6
 config: kore[2266]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -1334,10 +1334,10 @@ rule: 2885 6
 config: kore[2248]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -1349,9 +1349,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -1359,8 +1359,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -1375,8 +1375,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[58]
     arg: kore[57]
   arg: kore[58]
@@ -1385,9 +1385,9 @@ hook result: kore[58]
 config: kore[2092]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -1404,10 +1404,10 @@ rule: 2890 6
 config: kore[2043]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -1423,10 +1423,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[57]
         arg: kore[58]
       arg: kore[57]
@@ -1440,10 +1440,10 @@ hook result: kore[344]
 config: kore[1848]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[248]
     rule: 3014 1
       VarK = kore[248]
@@ -1461,10 +1461,10 @@ rule: 2912 5
 config: kore[1930]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -1490,9 +1490,9 @@ rule: 2893 6
 config: kore[1983]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -1509,10 +1509,10 @@ rule: 2884 6
 config: kore[1932]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -1524,9 +1524,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -1534,8 +1534,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[127]
     rule: 3014 1
       VarK = kore[127]
@@ -1556,8 +1556,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -1566,9 +1566,9 @@ hook result: kore[58]
 config: kore[1934]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -1585,10 +1585,10 @@ rule: 2885 6
 config: kore[1916]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -1600,9 +1600,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -1610,8 +1610,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -1626,8 +1626,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[58]
   arg: kore[57]
@@ -1636,9 +1636,9 @@ hook result: kore[57]
 config: kore[1759]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -1655,10 +1655,10 @@ rule: 2890 6
 config: kore[1710]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -1674,10 +1674,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[55]
         arg: kore[57]
       arg: kore[55]
@@ -1699,10 +1699,10 @@ rule: 2892 6
 config: kore[2724]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[288]
     rule: 3014 1
       VarK = kore[288]
@@ -1721,10 +1721,10 @@ rule: 2915 6
 config: kore[2864]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[235]
     rule: 3014 1
       VarK = kore[235]
@@ -1741,10 +1741,10 @@ rule: 2894 4
 config: kore[2894]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -1770,9 +1770,9 @@ rule: 2893 6
 config: kore[2914]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -1789,10 +1789,10 @@ rule: 2888 6
 config: kore[2896]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -1804,9 +1804,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -1814,8 +1814,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -1830,8 +1830,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -1840,9 +1840,9 @@ hook result: kore[63]
 config: kore[2742]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[83]
   rule: 3015 1
     VarKResult = kore[65]
@@ -1858,10 +1858,10 @@ rule: 2880 5
 config: kore[2745]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[83]
     rule: 3015 1
       VarKResult = kore[65]
@@ -1875,15 +1875,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 config: kore[2658]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[82]
   rule: 3015 1
     VarKResult = kore[64]
@@ -1901,10 +1901,10 @@ rule: 2891 7
 config: kore[2551]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[82]
     rule: 3015 1
       VarKResult = kore[64]
@@ -1948,10 +1948,10 @@ rule: 2914 5
 config: kore[2163]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[231]
     rule: 3014 1
       VarK = kore[231]
@@ -1969,10 +1969,10 @@ rule: 2912 5
 config: kore[2245]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3014 1
       VarK = kore[77]
@@ -1998,9 +1998,9 @@ rule: 2893 6
 config: kore[2264]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -2017,10 +2017,10 @@ rule: 2884 6
 config: kore[2246]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -2032,9 +2032,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -2042,8 +2042,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -2069,9 +2069,9 @@ rule: 2893 6
 config: kore[2266]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -2088,10 +2088,10 @@ rule: 2885 6
 config: kore[2248]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -2103,9 +2103,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -2113,8 +2113,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -2129,8 +2129,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[58]
     arg: kore[57]
   arg: kore[58]
@@ -2139,9 +2139,9 @@ hook result: kore[58]
 config: kore[2092]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -2158,10 +2158,10 @@ rule: 2890 6
 config: kore[2043]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -2177,10 +2177,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[57]
         arg: kore[58]
       arg: kore[57]
@@ -2194,10 +2194,10 @@ hook result: kore[344]
 config: kore[1848]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[248]
     rule: 3014 1
       VarK = kore[248]
@@ -2215,10 +2215,10 @@ rule: 2912 5
 config: kore[1930]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -2244,9 +2244,9 @@ rule: 2893 6
 config: kore[1983]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -2263,10 +2263,10 @@ rule: 2884 6
 config: kore[1932]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -2278,9 +2278,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -2288,8 +2288,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[127]
     rule: 3014 1
       VarK = kore[127]
@@ -2310,8 +2310,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -2320,9 +2320,9 @@ hook result: kore[58]
 config: kore[1934]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -2339,10 +2339,10 @@ rule: 2885 6
 config: kore[1916]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -2354,9 +2354,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -2364,8 +2364,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -2380,8 +2380,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[58]
   arg: kore[57]
@@ -2390,9 +2390,9 @@ hook result: kore[57]
 config: kore[1759]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -2409,10 +2409,10 @@ rule: 2890 6
 config: kore[1710]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -2428,10 +2428,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[55]
         arg: kore[57]
       arg: kore[55]
@@ -2453,10 +2453,10 @@ rule: 2892 6
 config: kore[2724]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[288]
     rule: 3014 1
       VarK = kore[288]
@@ -2475,10 +2475,10 @@ rule: 2915 6
 config: kore[2864]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[235]
     rule: 3014 1
       VarK = kore[235]
@@ -2495,10 +2495,10 @@ rule: 2894 4
 config: kore[2894]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -2524,9 +2524,9 @@ rule: 2893 6
 config: kore[2914]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -2543,10 +2543,10 @@ rule: 2888 6
 config: kore[2896]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -2558,9 +2558,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -2568,8 +2568,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -2584,8 +2584,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -2594,9 +2594,9 @@ hook result: kore[63]
 config: kore[2742]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[83]
   rule: 3015 1
     VarKResult = kore[65]
@@ -2612,10 +2612,10 @@ rule: 2880 5
 config: kore[2745]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[83]
     rule: 3015 1
       VarKResult = kore[65]
@@ -2629,15 +2629,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 config: kore[2658]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[82]
   rule: 3015 1
     VarKResult = kore[64]
@@ -2655,10 +2655,10 @@ rule: 2891 7
 config: kore[2551]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[82]
     rule: 3015 1
       VarKResult = kore[64]
@@ -2702,10 +2702,10 @@ rule: 2914 5
 config: kore[2163]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[231]
     rule: 3014 1
       VarK = kore[231]
@@ -2723,10 +2723,10 @@ rule: 2912 5
 config: kore[2245]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3014 1
       VarK = kore[77]
@@ -2752,9 +2752,9 @@ rule: 2893 6
 config: kore[2264]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -2771,10 +2771,10 @@ rule: 2884 6
 config: kore[2246]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -2786,9 +2786,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -2796,8 +2796,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -2823,9 +2823,9 @@ rule: 2893 6
 config: kore[2266]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -2842,10 +2842,10 @@ rule: 2885 6
 config: kore[2248]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -2857,9 +2857,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -2867,8 +2867,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -2883,8 +2883,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[58]
     arg: kore[57]
   arg: kore[58]
@@ -2893,9 +2893,9 @@ hook result: kore[58]
 config: kore[2092]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -2912,10 +2912,10 @@ rule: 2890 6
 config: kore[2043]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -2931,10 +2931,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[57]
         arg: kore[58]
       arg: kore[57]
@@ -2948,10 +2948,10 @@ hook result: kore[344]
 config: kore[1848]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[248]
     rule: 3014 1
       VarK = kore[248]
@@ -2969,10 +2969,10 @@ rule: 2912 5
 config: kore[1930]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -2998,9 +2998,9 @@ rule: 2893 6
 config: kore[1983]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -3017,10 +3017,10 @@ rule: 2884 6
 config: kore[1932]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3032,9 +3032,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3042,8 +3042,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[127]
     rule: 3014 1
       VarK = kore[127]
@@ -3064,8 +3064,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -3074,9 +3074,9 @@ hook result: kore[58]
 config: kore[1934]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -3093,10 +3093,10 @@ rule: 2885 6
 config: kore[1916]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3108,9 +3108,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3118,8 +3118,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -3134,8 +3134,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[58]
   arg: kore[57]
@@ -3144,9 +3144,9 @@ hook result: kore[57]
 config: kore[1759]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -3163,10 +3163,10 @@ rule: 2890 6
 config: kore[1710]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3182,10 +3182,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[55]
         arg: kore[57]
       arg: kore[55]
@@ -3207,10 +3207,10 @@ rule: 2892 6
 config: kore[2724]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[288]
     rule: 3014 1
       VarK = kore[288]
@@ -3229,10 +3229,10 @@ rule: 2915 6
 config: kore[2864]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[235]
     rule: 3014 1
       VarK = kore[235]
@@ -3249,10 +3249,10 @@ rule: 2894 4
 config: kore[2894]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -3278,9 +3278,9 @@ rule: 2893 6
 config: kore[2914]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -3297,10 +3297,10 @@ rule: 2888 6
 config: kore[2896]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3312,9 +3312,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3322,8 +3322,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3338,8 +3338,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -3348,9 +3348,9 @@ hook result: kore[63]
 config: kore[2742]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[83]
   rule: 3015 1
     VarKResult = kore[65]
@@ -3366,10 +3366,10 @@ rule: 2880 5
 config: kore[2745]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[83]
     rule: 3015 1
       VarKResult = kore[65]
@@ -3383,15 +3383,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 config: kore[2658]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[82]
   rule: 3015 1
     VarKResult = kore[64]
@@ -3409,10 +3409,10 @@ rule: 2891 7
 config: kore[2551]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[82]
     rule: 3015 1
       VarKResult = kore[64]
@@ -3456,10 +3456,10 @@ rule: 2914 5
 config: kore[2163]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[231]
     rule: 3014 1
       VarK = kore[231]
@@ -3477,10 +3477,10 @@ rule: 2912 5
 config: kore[2245]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3014 1
       VarK = kore[77]
@@ -3506,9 +3506,9 @@ rule: 2893 6
 config: kore[2264]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -3525,10 +3525,10 @@ rule: 2884 6
 config: kore[2246]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -3540,9 +3540,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -3550,8 +3550,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -3577,9 +3577,9 @@ rule: 2893 6
 config: kore[2266]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -3596,10 +3596,10 @@ rule: 2885 6
 config: kore[2248]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -3611,9 +3611,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -3621,8 +3621,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3637,8 +3637,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[58]
     arg: kore[57]
   arg: kore[58]
@@ -3647,9 +3647,9 @@ hook result: kore[58]
 config: kore[2092]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -3666,10 +3666,10 @@ rule: 2890 6
 config: kore[2043]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -3685,10 +3685,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[57]
         arg: kore[58]
       arg: kore[57]
@@ -3702,10 +3702,10 @@ hook result: kore[344]
 config: kore[1848]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[248]
     rule: 3014 1
       VarK = kore[248]
@@ -3723,10 +3723,10 @@ rule: 2912 5
 config: kore[1930]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -3752,9 +3752,9 @@ rule: 2893 6
 config: kore[1983]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -3771,10 +3771,10 @@ rule: 2884 6
 config: kore[1932]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3786,9 +3786,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3796,8 +3796,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[127]
     rule: 3014 1
       VarK = kore[127]
@@ -3818,8 +3818,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -3828,9 +3828,9 @@ hook result: kore[58]
 config: kore[1934]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -3847,10 +3847,10 @@ rule: 2885 6
 config: kore[1916]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3862,9 +3862,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3872,8 +3872,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -3888,8 +3888,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[58]
   arg: kore[57]
@@ -3898,9 +3898,9 @@ hook result: kore[57]
 config: kore[1759]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -3917,10 +3917,10 @@ rule: 2890 6
 config: kore[1710]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -3936,10 +3936,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[55]
         arg: kore[57]
       arg: kore[55]
@@ -3961,10 +3961,10 @@ rule: 2892 6
 config: kore[2724]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[288]
     rule: 3014 1
       VarK = kore[288]
@@ -3983,10 +3983,10 @@ rule: 2915 6
 config: kore[2864]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[235]
     rule: 3014 1
       VarK = kore[235]
@@ -4003,10 +4003,10 @@ rule: 2894 4
 config: kore[2894]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -4032,9 +4032,9 @@ rule: 2893 6
 config: kore[2914]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -4051,10 +4051,10 @@ rule: 2888 6
 config: kore[2896]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -4066,9 +4066,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -4076,8 +4076,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -4092,8 +4092,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -4102,9 +4102,9 @@ hook result: kore[63]
 config: kore[2742]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[83]
   rule: 3015 1
     VarKResult = kore[65]
@@ -4120,10 +4120,10 @@ rule: 2880 5
 config: kore[2745]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[83]
     rule: 3015 1
       VarKResult = kore[65]
@@ -4137,15 +4137,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 config: kore[2658]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[82]
   rule: 3015 1
     VarKResult = kore[64]
@@ -4163,10 +4163,10 @@ rule: 2891 7
 config: kore[2551]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[82]
     rule: 3015 1
       VarKResult = kore[64]
@@ -4210,10 +4210,10 @@ rule: 2914 5
 config: kore[2163]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[231]
     rule: 3014 1
       VarK = kore[231]
@@ -4231,10 +4231,10 @@ rule: 2912 5
 config: kore[2245]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3014 1
       VarK = kore[77]
@@ -4260,9 +4260,9 @@ rule: 2893 6
 config: kore[2264]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -4279,10 +4279,10 @@ rule: 2884 6
 config: kore[2246]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -4294,9 +4294,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -4304,8 +4304,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -4331,9 +4331,9 @@ rule: 2893 6
 config: kore[2266]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -4350,10 +4350,10 @@ rule: 2885 6
 config: kore[2248]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -4365,9 +4365,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -4375,8 +4375,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -4391,8 +4391,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[58]
     arg: kore[57]
   arg: kore[58]
@@ -4401,9 +4401,9 @@ hook result: kore[58]
 config: kore[2092]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -4420,10 +4420,10 @@ rule: 2890 6
 config: kore[2043]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -4439,10 +4439,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[57]
         arg: kore[58]
       arg: kore[57]
@@ -4456,10 +4456,10 @@ hook result: kore[344]
 config: kore[1848]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[248]
     rule: 3014 1
       VarK = kore[248]
@@ -4477,10 +4477,10 @@ rule: 2912 5
 config: kore[1930]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -4506,9 +4506,9 @@ rule: 2893 6
 config: kore[1983]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -4525,10 +4525,10 @@ rule: 2884 6
 config: kore[1932]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -4540,9 +4540,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -4550,8 +4550,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[127]
     rule: 3014 1
       VarK = kore[127]
@@ -4572,8 +4572,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -4582,9 +4582,9 @@ hook result: kore[58]
 config: kore[1934]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -4601,10 +4601,10 @@ rule: 2885 6
 config: kore[1916]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -4616,9 +4616,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -4626,8 +4626,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -4642,8 +4642,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[58]
   arg: kore[57]
@@ -4652,9 +4652,9 @@ hook result: kore[57]
 config: kore[1759]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -4671,10 +4671,10 @@ rule: 2890 6
 config: kore[1710]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -4690,10 +4690,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[55]
         arg: kore[57]
       arg: kore[55]
@@ -4715,10 +4715,10 @@ rule: 2892 6
 config: kore[2724]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[288]
     rule: 3014 1
       VarK = kore[288]
@@ -4737,10 +4737,10 @@ rule: 2915 6
 config: kore[2864]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[235]
     rule: 3014 1
       VarK = kore[235]
@@ -4757,10 +4757,10 @@ rule: 2894 4
 config: kore[2894]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -4786,9 +4786,9 @@ rule: 2893 6
 config: kore[2914]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -4805,10 +4805,10 @@ rule: 2888 6
 config: kore[2896]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -4820,9 +4820,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -4830,8 +4830,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -4846,8 +4846,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -4856,9 +4856,9 @@ hook result: kore[63]
 config: kore[2742]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[83]
   rule: 3015 1
     VarKResult = kore[65]
@@ -4874,10 +4874,10 @@ rule: 2880 5
 config: kore[2745]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[83]
     rule: 3015 1
       VarKResult = kore[65]
@@ -4891,15 +4891,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 config: kore[2658]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[82]
   rule: 3015 1
     VarKResult = kore[64]
@@ -4917,10 +4917,10 @@ rule: 2891 7
 config: kore[2551]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[82]
     rule: 3015 1
       VarKResult = kore[64]
@@ -4964,10 +4964,10 @@ rule: 2914 5
 config: kore[2163]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[231]
     rule: 3014 1
       VarK = kore[231]
@@ -4985,10 +4985,10 @@ rule: 2912 5
 config: kore[2245]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3014 1
       VarK = kore[77]
@@ -5014,9 +5014,9 @@ rule: 2893 6
 config: kore[2264]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -5033,10 +5033,10 @@ rule: 2884 6
 config: kore[2246]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -5048,9 +5048,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -5058,8 +5058,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -5085,9 +5085,9 @@ rule: 2893 6
 config: kore[2266]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -5104,10 +5104,10 @@ rule: 2885 6
 config: kore[2248]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -5119,9 +5119,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -5129,8 +5129,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -5145,8 +5145,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[58]
     arg: kore[57]
   arg: kore[58]
@@ -5155,9 +5155,9 @@ hook result: kore[58]
 config: kore[2092]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -5174,10 +5174,10 @@ rule: 2890 6
 config: kore[2043]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -5193,10 +5193,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[57]
         arg: kore[58]
       arg: kore[57]
@@ -5210,10 +5210,10 @@ hook result: kore[344]
 config: kore[1848]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[248]
     rule: 3014 1
       VarK = kore[248]
@@ -5231,10 +5231,10 @@ rule: 2912 5
 config: kore[1930]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -5260,9 +5260,9 @@ rule: 2893 6
 config: kore[1983]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -5279,10 +5279,10 @@ rule: 2884 6
 config: kore[1932]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -5294,9 +5294,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -5304,8 +5304,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[127]
     rule: 3014 1
       VarK = kore[127]
@@ -5326,8 +5326,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -5336,9 +5336,9 @@ hook result: kore[58]
 config: kore[1934]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -5355,10 +5355,10 @@ rule: 2885 6
 config: kore[1916]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -5370,9 +5370,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -5380,8 +5380,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -5396,8 +5396,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[58]
   arg: kore[57]
@@ -5406,9 +5406,9 @@ hook result: kore[57]
 config: kore[1759]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -5425,10 +5425,10 @@ rule: 2890 6
 config: kore[1710]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -5444,10 +5444,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[55]
         arg: kore[57]
       arg: kore[55]
@@ -5469,10 +5469,10 @@ rule: 2892 6
 config: kore[2724]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[288]
     rule: 3014 1
       VarK = kore[288]
@@ -5491,10 +5491,10 @@ rule: 2915 6
 config: kore[2864]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[235]
     rule: 3014 1
       VarK = kore[235]
@@ -5511,10 +5511,10 @@ rule: 2894 4
 config: kore[2894]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -5540,9 +5540,9 @@ rule: 2893 6
 config: kore[2914]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -5559,10 +5559,10 @@ rule: 2888 6
 config: kore[2896]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -5574,9 +5574,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -5584,8 +5584,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -5600,8 +5600,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -5610,9 +5610,9 @@ hook result: kore[63]
 config: kore[2742]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[83]
   rule: 3015 1
     VarKResult = kore[65]
@@ -5628,10 +5628,10 @@ rule: 2880 5
 config: kore[2745]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[83]
     rule: 3015 1
       VarKResult = kore[65]
@@ -5645,15 +5645,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 config: kore[2658]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[82]
   rule: 3015 1
     VarKResult = kore[64]
@@ -5671,10 +5671,10 @@ rule: 2891 7
 config: kore[2551]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[82]
     rule: 3015 1
       VarKResult = kore[64]
@@ -5718,10 +5718,10 @@ rule: 2914 5
 config: kore[2163]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[231]
     rule: 3014 1
       VarK = kore[231]
@@ -5739,10 +5739,10 @@ rule: 2912 5
 config: kore[2245]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3014 1
       VarK = kore[77]
@@ -5768,9 +5768,9 @@ rule: 2893 6
 config: kore[2264]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -5787,10 +5787,10 @@ rule: 2884 6
 config: kore[2246]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -5802,9 +5802,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -5812,8 +5812,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -5839,9 +5839,9 @@ rule: 2893 6
 config: kore[2266]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -5858,10 +5858,10 @@ rule: 2885 6
 config: kore[2248]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -5873,9 +5873,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -5883,8 +5883,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -5899,8 +5899,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[58]
     arg: kore[57]
   arg: kore[58]
@@ -5909,9 +5909,9 @@ hook result: kore[58]
 config: kore[2092]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -5928,10 +5928,10 @@ rule: 2890 6
 config: kore[2043]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -5947,10 +5947,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[57]
         arg: kore[58]
       arg: kore[57]
@@ -5964,10 +5964,10 @@ hook result: kore[344]
 config: kore[1848]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[248]
     rule: 3014 1
       VarK = kore[248]
@@ -5985,10 +5985,10 @@ rule: 2912 5
 config: kore[1930]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -6014,9 +6014,9 @@ rule: 2893 6
 config: kore[1983]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -6033,10 +6033,10 @@ rule: 2884 6
 config: kore[1932]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6048,9 +6048,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6058,8 +6058,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[127]
     rule: 3014 1
       VarK = kore[127]
@@ -6080,8 +6080,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -6090,9 +6090,9 @@ hook result: kore[58]
 config: kore[1934]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -6109,10 +6109,10 @@ rule: 2885 6
 config: kore[1916]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6124,9 +6124,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6134,8 +6134,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -6150,8 +6150,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[58]
   arg: kore[57]
@@ -6160,9 +6160,9 @@ hook result: kore[57]
 config: kore[1759]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -6179,10 +6179,10 @@ rule: 2890 6
 config: kore[1710]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6198,10 +6198,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[55]
         arg: kore[57]
       arg: kore[55]
@@ -6223,10 +6223,10 @@ rule: 2892 6
 config: kore[2724]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[288]
     rule: 3014 1
       VarK = kore[288]
@@ -6245,10 +6245,10 @@ rule: 2915 6
 config: kore[2864]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[235]
     rule: 3014 1
       VarK = kore[235]
@@ -6265,10 +6265,10 @@ rule: 2894 4
 config: kore[2894]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -6294,9 +6294,9 @@ rule: 2893 6
 config: kore[2914]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -6313,10 +6313,10 @@ rule: 2888 6
 config: kore[2896]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6328,9 +6328,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6338,8 +6338,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6354,8 +6354,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -6364,9 +6364,9 @@ hook result: kore[63]
 config: kore[2742]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[83]
   rule: 3015 1
     VarKResult = kore[65]
@@ -6382,10 +6382,10 @@ rule: 2880 5
 config: kore[2745]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[83]
     rule: 3015 1
       VarKResult = kore[65]
@@ -6399,15 +6399,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 config: kore[2658]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[82]
   rule: 3015 1
     VarKResult = kore[64]
@@ -6425,10 +6425,10 @@ rule: 2891 7
 config: kore[2551]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[82]
     rule: 3015 1
       VarKResult = kore[64]
@@ -6472,10 +6472,10 @@ rule: 2914 5
 config: kore[2163]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[231]
     rule: 3014 1
       VarK = kore[231]
@@ -6493,10 +6493,10 @@ rule: 2912 5
 config: kore[2245]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3014 1
       VarK = kore[77]
@@ -6522,9 +6522,9 @@ rule: 2893 6
 config: kore[2264]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -6541,10 +6541,10 @@ rule: 2884 6
 config: kore[2246]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -6556,9 +6556,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -6566,8 +6566,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -6593,9 +6593,9 @@ rule: 2893 6
 config: kore[2266]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -6612,10 +6612,10 @@ rule: 2885 6
 config: kore[2248]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -6627,9 +6627,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -6637,8 +6637,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6653,8 +6653,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[58]
     arg: kore[57]
   arg: kore[58]
@@ -6663,9 +6663,9 @@ hook result: kore[58]
 config: kore[2092]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -6682,10 +6682,10 @@ rule: 2890 6
 config: kore[2043]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -6701,10 +6701,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[57]
         arg: kore[58]
       arg: kore[57]
@@ -6718,10 +6718,10 @@ hook result: kore[344]
 config: kore[1848]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[248]
     rule: 3014 1
       VarK = kore[248]
@@ -6739,10 +6739,10 @@ rule: 2912 5
 config: kore[1930]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -6768,9 +6768,9 @@ rule: 2893 6
 config: kore[1983]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -6787,10 +6787,10 @@ rule: 2884 6
 config: kore[1932]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6802,9 +6802,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6812,8 +6812,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[127]
     rule: 3014 1
       VarK = kore[127]
@@ -6834,8 +6834,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -6844,9 +6844,9 @@ hook result: kore[58]
 config: kore[1934]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -6863,10 +6863,10 @@ rule: 2885 6
 config: kore[1916]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6878,9 +6878,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6888,8 +6888,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -6904,8 +6904,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[58]
   arg: kore[57]
@@ -6914,9 +6914,9 @@ hook result: kore[57]
 config: kore[1759]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -6933,10 +6933,10 @@ rule: 2890 6
 config: kore[1710]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -6952,10 +6952,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[55]
         arg: kore[57]
       arg: kore[55]
@@ -6977,10 +6977,10 @@ rule: 2892 6
 config: kore[2724]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[288]
     rule: 3014 1
       VarK = kore[288]
@@ -6999,10 +6999,10 @@ rule: 2915 6
 config: kore[2864]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[235]
     rule: 3014 1
       VarK = kore[235]
@@ -7019,10 +7019,10 @@ rule: 2894 4
 config: kore[2894]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -7048,9 +7048,9 @@ rule: 2893 6
 config: kore[2914]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -7067,10 +7067,10 @@ rule: 2888 6
 config: kore[2896]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -7082,9 +7082,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -7092,8 +7092,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -7108,8 +7108,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -7118,9 +7118,9 @@ hook result: kore[63]
 config: kore[2742]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[83]
   rule: 3015 1
     VarKResult = kore[65]
@@ -7136,10 +7136,10 @@ rule: 2880 5
 config: kore[2745]
 side condition entry: 2894 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[83]
     rule: 3015 1
       VarKResult = kore[65]
@@ -7153,15 +7153,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[63]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[63]
 hook result: kore[62]
 config: kore[2658]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[82]
   rule: 3015 1
     VarKResult = kore[64]
@@ -7179,10 +7179,10 @@ rule: 2891 7
 config: kore[2551]
 side condition entry: 2915 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[82]
     rule: 3015 1
       VarKResult = kore[64]
@@ -7226,10 +7226,10 @@ rule: 2914 5
 config: kore[2163]
 side condition entry: 2912 1
   VarHOLE = kore[177]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[231]
     rule: 3014 1
       VarK = kore[231]
@@ -7247,10 +7247,10 @@ rule: 2912 5
 config: kore[2245]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3014 1
       VarK = kore[77]
@@ -7276,9 +7276,9 @@ rule: 2893 6
 config: kore[2264]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -7295,10 +7295,10 @@ rule: 2884 6
 config: kore[2246]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -7310,9 +7310,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[54]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -7320,8 +7320,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -7347,9 +7347,9 @@ rule: 2893 6
 config: kore[2266]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -7366,10 +7366,10 @@ rule: 2885 6
 config: kore[2248]
 side condition entry: 2903 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -7381,9 +7381,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[56]
   VarK0 = kore[57]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -7391,8 +7391,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -7407,8 +7407,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1549]
   VarI1 = kore[58]
   VarI2 = kore[57]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[58]
     arg: kore[57]
   arg: kore[58]
@@ -7417,9 +7417,9 @@ hook result: kore[58]
 config: kore[2092]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -7436,10 +7436,10 @@ rule: 2890 6
 config: kore[2043]
 side condition entry: 2912 1
   VarHOLE = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -7455,10 +7455,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[58]
   VarI = kore[58]
   VarX = kore[25]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[57]
         arg: kore[58]
       arg: kore[57]
@@ -7472,10 +7472,10 @@ hook result: kore[344]
 config: kore[1848]
 side condition entry: 2912 1
   VarHOLE = kore[194]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[248]
     rule: 3014 1
       VarK = kore[248]
@@ -7493,10 +7493,10 @@ rule: 2912 5
 config: kore[1930]
 side condition entry: 2903 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -7522,9 +7522,9 @@ rule: 2893 6
 config: kore[1983]
 side condition entry: 2884 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -7541,10 +7541,10 @@ rule: 2884 6
 config: kore[1932]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -7556,9 +7556,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[73]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -7566,8 +7566,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[127]
     rule: 3014 1
       VarK = kore[127]
@@ -7588,8 +7588,8 @@ rule: 2896 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[1391]
   VarI1 = kore[57]
-hook: INT.sub (0:0:0:0:0)
-  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0:0)
+hook: INT.sub (0:0:0:0)
+  function: Lbl'Unds'-Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -7598,9 +7598,9 @@ hook result: kore[58]
 config: kore[1934]
 side condition entry: 2885 1
   Var'Unds'Gen3 = kore[58]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[78]
   rule: 3015 1
     VarKResult = kore[60]
@@ -7617,10 +7617,10 @@ rule: 2885 6
 config: kore[1916]
 side condition entry: 2903 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -7632,9 +7632,9 @@ side condition exit: 2903 false
 side condition entry: 2904 2
   VarHOLE = kore[57]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -7642,8 +7642,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[78]
     rule: 3015 1
       VarKResult = kore[60]
@@ -7658,8 +7658,8 @@ rule: 2905 5
   Var'Unds'DotVar2 = kore[1217]
   VarI1 = kore[57]
   VarI2 = kore[58]
-hook: INT.add (0:0:0:0:0)
-  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0:0)
+hook: INT.add (0:0:0:0)
+  function: Lbl'UndsPlus'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[58]
   arg: kore[57]
@@ -7668,9 +7668,9 @@ hook result: kore[57]
 config: kore[1759]
 side condition entry: 2890 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -7687,10 +7687,10 @@ rule: 2890 6
 config: kore[1710]
 side condition entry: 2912 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -7706,10 +7706,10 @@ rule: 2913 6
   Var'Unds'Gen0 = kore[57]
   VarI = kore[57]
   VarX = kore[23]
-hook: MAP.concat (0:0:1:0)
-  function: Lbl'Unds'Map'Unds'{} (0:0:1:0)
-    hook: MAP.element (0:0:1:0:0)
-      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:0:1:0:0)
+hook: MAP.concat (0:1:0)
+  function: Lbl'Unds'Map'Unds'{} (0:1:0)
+    hook: MAP.element (0:1:0:0)
+      function: Lbl'UndsPipe'-'-GT-Unds'{} (0:1:0:0)
         arg: kore[55]
         arg: kore[57]
       arg: kore[55]
@@ -7731,10 +7731,10 @@ rule: 2892 6
 config: kore[2724]
 side condition entry: 2915 1
   VarHOLE = kore[234]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[288]
     rule: 3014 1
       VarK = kore[288]
@@ -7753,10 +7753,10 @@ rule: 2915 6
 config: kore[2864]
 side condition entry: 2894 1
   VarHOLE = kore[181]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[235]
     rule: 3014 1
       VarK = kore[235]
@@ -7773,10 +7773,10 @@ rule: 2894 4
 config: kore[2894]
 side condition entry: 2909 1
   VarHOLE = kore[54]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[75]
     rule: 3014 1
       VarK = kore[75]
@@ -7802,9 +7802,9 @@ rule: 2893 6
 config: kore[2914]
 side condition entry: 2888 1
   Var'Unds'Gen3 = kore[57]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[77]
   rule: 3015 1
     VarKResult = kore[59]
@@ -7821,10 +7821,10 @@ rule: 2888 6
 config: kore[2896]
 side condition entry: 2909 1
   VarHOLE = kore[56]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -7836,9 +7836,9 @@ side condition exit: 2909 false
 side condition entry: 2910 2
   VarHOLE = kore[56]
   VarK0 = kore[56]
-hook: BOOL.and (0)
-  hook: BOOL.and (0:0)
-    function: LblisKResult{} (0:0:0)
+hook: BOOL.and ()
+  hook: BOOL.and (0)
+    function: LblisKResult{} (0:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -7846,8 +7846,8 @@ hook: BOOL.and (0)
     arg: kore[62]
   hook result: kore[62]
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[77]
     rule: 3015 1
       VarKResult = kore[59]
@@ -7862,8 +7862,8 @@ rule: 2911 5
   Var'Unds'DotVar2 = kore[2194]
   VarI1 = kore[57]
   VarI2 = kore[57]
-hook: INT.le (0:0:0:0:0)
-  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0:0)
+hook: INT.le (0:0:0:0)
+  function: Lbl'Unds-LT-Eqls'Int'Unds'{} (0:0:0:0)
     arg: kore[57]
     arg: kore[57]
   arg: kore[57]
@@ -7872,9 +7872,9 @@ hook result: kore[62]
 config: kore[2741]
 side condition entry: 2880 1
   Var'Unds'Gen3 = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[82]
   rule: 3015 1
     VarKResult = kore[64]
@@ -7890,10 +7890,10 @@ rule: 2880 5
 config: kore[2744]
 side condition entry: 2894 1
   VarHOLE = kore[61]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[82]
     rule: 3015 1
       VarKResult = kore[64]
@@ -7907,15 +7907,15 @@ rule: 2895 4
   Var'Unds'DotVar1 = kore[337]
   Var'Unds'DotVar2 = kore[2111]
   VarT = kore[62]
-hook: BOOL.not (0:0:0:0:0)
+hook: BOOL.not (0:0:0:0)
   arg: kore[62]
 hook result: kore[63]
 config: kore[2659]
 side condition entry: 2891 1
   Var'Unds'Gen3 = kore[63]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  function: LblisKResult{} (0:1)
+  function: LblisKResult{} (1)
     arg: kore[83]
   rule: 3015 1
     VarKResult = kore[65]
@@ -7933,10 +7933,10 @@ rule: 2891 7
 config: kore[2552]
 side condition entry: 2915 1
   VarHOLE = kore[62]
-hook: BOOL.and (0)
+hook: BOOL.and ()
   arg: kore[62]
-  hook: BOOL.not (0:1)
-    function: LblisKResult{} (0:1:0)
+  hook: BOOL.not (1)
+    function: LblisKResult{} (1:0)
       arg: kore[83]
     rule: 3015 1
       VarKResult = kore[65]


### PR DESCRIPTION
This PR fixes 2 issues with the generation of locations for the hook and function proof hint events.

- The starting location stack is now the empty stack as opposed to the `"0"` stack. This is because the math team assumes that the first location in the stack corresponds to an argument of the top cell in the configuration and not the top cell constructor.
- The previous method for skipping locations that correspond to injections, namely skipping a location when the child of a term is an injection, was leading to errors when it combined with the injection compaction optimization. Specifically, the method could lead to skipping an extra location in the case where the algorithm needed to generate code for possibly applying an injection compaction. We change the algorithm for skipping locations, so that we skip a location for every child of an injection term.