### PR TITLE
Check out code when creating a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
       - name: 'Make release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This was a small oversight in #1034; we should have been checking out the repo's code to get access to `package/version`. Will fix the release build when merged.