### PR TITLE
[DNM] set the linkage of some symbols to internal

### DIFF
--- a/debug/kgdb.py
+++ b/debug/kgdb.py
@@ -375,13 +375,13 @@ class termPrinter:
         self.kompiled_dir = getKompiledDir()
 
     def getSymbolNameForTag(self, tag):
-        return gdb.lookup_global_symbol("table_getSymbolNameForTag").value()[tag]
+        return gdb.lookup_static_symbol("table_getSymbolNameForTag").value()[tag]
 
     def isSymbolABinder(self, tag):
-        return gdb.lookup_global_symbol("table_isSymbolABinder").value()[tag]
+        return gdb.lookup_static_symbol("table_isSymbolABinder").value()[tag]
 
     def getLayoutData(self, layout):
-        return gdb.lookup_global_symbol("layout_" + str(layout)).value()
+        return gdb.lookup_static_symbol("layout_" + str(layout)).value()
 
     def to_string(self):
         try:
@@ -610,7 +610,7 @@ class termPrinter:
             argData = layoutData['args'] + i
             arg = subject.cast(self.long_int) + int(argData.dereference()['offset'])
             cat = argData.dereference()['cat']
-            sort = gdb.lookup_global_symbol("table_getArgumentSortsForTag").value()[tag][i].string("iso-8859-1")
+            sort = gdb.lookup_static_symbol("table_getArgumentSortsForTag").value()[tag][i].string("iso-8859-1")
             if cat == @MAP_LAYOUT@:
                 self.appendMap(arg.cast(self.map_ptr), sort)
             elif cat == @RANGEMAP_LAYOUT@:
@@ -751,7 +751,7 @@ Does not actually take a step if matching succeeds.
             gdb.lookup_global_symbol("resetMatchReason").value()()
             if (len(argv) != 2):
                 raise gdb.GdbError("k match takes two arguments.")
-            fun = gdb.lookup_global_symbol(argv[0] + '.match')
+            fun = gdb.lookup_static_symbol(argv[0] + '.match')
             if fun is None:
                 raise gdb.GdbError("Rule with label " + argv[0] + " does not exist.")
             try:

--- a/lib/codegen/CreateStaticTerm.cpp
+++ b/lib/codegen/CreateStaticTerm.cpp
@@ -39,6 +39,7 @@ llvm::Constant *create_static_term::not_injection_case(
   llvm::Constant *block
       = module_->getOrInsertGlobal(kore_string.str(), block_type);
   auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(block);
+  global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
 
   if (!global_var->hasInitializer()) {
     std::vector<llvm::Constant *> block_vals;
@@ -155,6 +156,7 @@ create_static_term::create_token(value_type sort, std::string contents) {
         "int_" + contents, llvm::StructType::getTypeByName(
                                module_->getContext(), int_wrapper_struct));
     auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
     if (!global_var->hasInitializer()) {
       mpz_t value;
       char const *data_start
@@ -167,6 +169,7 @@ create_static_term::create_token(value_type sort, std::string contents) {
       llvm::Constant *limbs = module_->getOrInsertGlobal(
           "int_" + contents + "_limbs", limbs_type);
       auto *limbs_var = llvm::dyn_cast<llvm::GlobalVariable>(limbs);
+      limbs_var->setLinkage(llvm::GlobalValue::InternalLinkage);
       std::vector<llvm::Constant *> allocd_limbs;
       for (size_t i = 0; i < size; i++) {
         allocd_limbs.push_back(llvm::ConstantInt::get(
@@ -210,6 +213,7 @@ create_static_term::create_token(value_type sort, std::string contents) {
         "float_" + contents, llvm::StructType::getTypeByName(
                                  module_->getContext(), float_wrapper_struct));
     auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
     if (!global_var->hasInitializer()) {
       size_t prec = 0;
       size_t exp = 0;
@@ -251,6 +255,7 @@ create_static_term::create_token(value_type sort, std::string contents) {
       llvm::Constant *limbs = module_->getOrInsertGlobal(
           "float_" + contents + "_limbs", limbs_type);
       auto *limbs_var = llvm::dyn_cast<llvm::GlobalVariable>(limbs);
+      limbs_var->setLinkage(llvm::GlobalValue::InternalLinkage);
       std::vector<llvm::Constant *> allocd_limbs;
       for (size_t i = 0; i < size; i++) {
         allocd_limbs.push_back(llvm::ConstantInt::get(
@@ -323,6 +328,7 @@ create_static_term::create_token(value_type sort, std::string contents) {
     llvm::Constant *global
         = module_->getOrInsertGlobal("token_" + escape(contents), string_type);
     auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
     if (!global_var->hasInitializer()) {
       llvm::StructType *block_header_type = llvm::StructType::getTypeByName(
           module_->getContext(), blockheader_struct);

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1078,6 +1078,7 @@ bool make_function(
   llvm::FunctionType *func_type
       = llvm::FunctionType::get(return_type, param_types, false);
   llvm::Function *apply_rule = get_or_insert_function(module, name, func_type);
+  apply_rule->setLinkage(llvm::GlobalValue::InternalLinkage);
   init_debug_axiom(axiom->attributes());
   std::string debug_name = name;
   if (axiom->attributes().contains(attribute_set::key::Label)) {
@@ -1192,6 +1193,7 @@ std::string make_apply_rule_function(
       false, true, axiom, ".rhs");
 
   llvm::Function *apply_rule = get_or_insert_function(module, name, func_type);
+  apply_rule->setLinkage(llvm::GlobalValue::InternalLinkage);
   init_debug_axiom(axiom->attributes());
   init_debug_function(
       name, name,
@@ -1243,6 +1245,7 @@ std::string make_apply_rule_function(
   llvm::Function *step = get_or_insert_function(
       module, "step_" + std::to_string(axiom->get_ordinal()),
       llvm::FunctionType::get(block_type, types, false));
+  step->setLinkage(llvm::GlobalValue::InternalLinkage);
   auto *retval
       = llvm::CallInst::Create(step, args, "", creator.get_current_block());
   set_debug_loc(retval);

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -1136,6 +1136,11 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> step_function_header(
   auto *root_ty = llvm::ArrayType::get(
       llvm::Type::getInt8PtrTy(module->getContext()), 256);
   auto *arr = module->getOrInsertGlobal("gc_roots", root_ty);
+  auto *global_var = llvm::cast<llvm::GlobalVariable>(arr);
+  global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
+  if (!global_var->hasInitializer()) {
+    global_var->setInitializer(llvm::ConstantAggregateZero::get(root_ty));
+  }
   std::vector<std::pair<llvm::Value *, llvm::Type *>> root_ptrs;
   std::vector<llvm::Value *> are_block;
   llvm::Instruction *are_block_val = llvm::CallInst::CreateMalloc(

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -1136,10 +1136,10 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> step_function_header(
   auto *root_ty = llvm::ArrayType::get(
       llvm::Type::getInt8PtrTy(module->getContext()), 256);
   auto *arr = module->getOrInsertGlobal("gc_roots", root_ty);
-  auto *global_var = llvm::cast<llvm::GlobalVariable>(arr);
-  global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
-  if (!global_var->hasInitializer()) {
-    global_var->setInitializer(llvm::ConstantAggregateZero::get(root_ty));
+  auto *arr_var = llvm::cast<llvm::GlobalVariable>(arr);
+  arr_var->setLinkage(llvm::GlobalValue::InternalLinkage);
+  if (!arr_var->hasInitializer()) {
+    arr_var->setInitializer(llvm::ConstantAggregateZero::get(root_ty));
   }
   std::vector<std::pair<llvm::Value *, llvm::Type *>> root_ptrs;
   std::vector<llvm::Value *> are_block;

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -693,6 +693,7 @@ llvm::Constant *decision::string_literal(std::string const &str) {
   auto *global
       = module_->getOrInsertGlobal("str_lit_" + str, str_cst->getType());
   auto *global_var = llvm::cast<llvm::GlobalVariable>(global);
+  global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
   if (!global_var->hasInitializer()) {
     global_var->setInitializer(str_cst);
   }
@@ -1190,6 +1191,7 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> step_function_header(
   auto *layout = module->getOrInsertGlobal(
       "layout_item_rule_" + std::to_string(ordinal), layout_arr->getType());
   auto *global_var = llvm::cast<llvm::GlobalVariable>(layout);
+  global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
   if (!global_var->hasInitializer()) {
     global_var->setInitializer(layout_arr);
   }
@@ -1329,6 +1331,7 @@ void make_match_reason_function_wrapper(
   std::string wrapper_name = "match_" + std::to_string(axiom->get_ordinal());
   llvm::Function *match_func
       = get_or_insert_function(module, wrapper_name, func_type);
+  match_func->setLinkage(llvm::GlobalValue::InternalLinkage);
   std::string debug_name = name;
   if (axiom->attributes().contains(attribute_set::key::Label)) {
     debug_name = axiom->attributes().get_string(attribute_set::key::Label)
@@ -1360,6 +1363,7 @@ void make_match_reason_function(
       llvm::Type::getVoidTy(module->getContext()), {block_type}, false);
   std::string name = "intern_match_" + std::to_string(axiom->get_ordinal());
   llvm::Function *match_func = get_or_insert_function(module, name, func_type);
+  match_func->setLinkage(llvm::GlobalValue::InternalLinkage);
   std::string debug_name = name;
   if (axiom->attributes().contains(attribute_set::key::Label)) {
     debug_name
@@ -1480,6 +1484,7 @@ void make_step_function(
       = llvm::FunctionType::get(block_type, arg_types, false);
   std::string name = "step_" + std::to_string(axiom->get_ordinal());
   llvm::Function *match_func = get_or_insert_function(module, name, func_type);
+  match_func->setLinkage(llvm::GlobalValue::InternalLinkage);
   reset_debug_loc();
   init_debug_function(
       name, name, get_debug_function_type(block_debug_type, debug_types),

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -1363,7 +1363,6 @@ void make_match_reason_function(
       llvm::Type::getVoidTy(module->getContext()), {block_type}, false);
   std::string name = "intern_match_" + std::to_string(axiom->get_ordinal());
   llvm::Function *match_func = get_or_insert_function(module, name, func_type);
-  match_func->setLinkage(llvm::GlobalValue::InternalLinkage);
   std::string debug_name = name;
   if (axiom->attributes().contains(attribute_set::key::Label)) {
     debug_name

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -54,6 +54,7 @@ static llvm::Constant *get_symbol_name_ptr(
   auto *global = module->getOrInsertGlobal(
       fmt::format("sym_name_{}", name), str->getType());
   auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+  global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
   if (!global_var->hasInitializer()) {
     global_var->setInitializer(str);
   }
@@ -140,6 +141,7 @@ static void emit_data_table_for_symbol(
   auto *table_type = llvm::ArrayType::get(ty, syms.size());
   auto *table = module->getOrInsertGlobal("table_" + name, table_type);
   auto *global_var = llvm::cast<llvm::GlobalVariable>(table);
+  global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
   init_debug_global(
       "table_" + name,
       get_array_debug_type(
@@ -438,6 +440,7 @@ emit_get_tag_for_fresh_sort(kore_definition *definition, llvm::Module *module) {
     auto *global
         = module->getOrInsertGlobal("sort_name_" + name, str->getType());
     auto *global_var = llvm::cast<llvm::GlobalVariable>(global);
+    global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
     if (!global_var->hasInitializer()) {
       global_var->setInitializer(str);
     }
@@ -509,6 +512,7 @@ static void emit_get_token(kore_definition *definition, llvm::Module *module) {
     auto *global
         = module->getOrInsertGlobal("sort_name_" + name, str->getType());
     auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
     if (!global_var->hasInitializer()) {
       global_var->setInitializer(str);
     }
@@ -536,6 +540,7 @@ static void emit_get_token(kore_definition *definition, llvm::Module *module) {
       auto *str = llvm::ConstantDataArray::getString(ctx, "true", false);
       auto *global = module->getOrInsertGlobal("bool_true", str->getType());
       auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+      global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
       if (!global_var->hasInitializer()) {
         global_var->setInitializer(str);
       }
@@ -967,6 +972,7 @@ static void get_visitor(
     auto *global = module->getOrInsertGlobal(
         fmt::format("sort_name_{}", sort_name), str->getType());
     auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
     if (!global_var->hasInitializer()) {
       global_var->setInitializer(str);
     }
@@ -1147,6 +1153,7 @@ static llvm::Constant *get_layout_data(
   auto *global = module->getOrInsertGlobal(
       "layout_item_" + std::to_string(layout), arr->getType());
   auto *global_var = llvm::cast<llvm::GlobalVariable>(global);
+  global_var->setLinkage(llvm::GlobalValue::InternalLinkage);
   if (!global_var->hasInitializer()) {
     global_var->setInitializer(arr);
   }
@@ -1159,6 +1166,7 @@ static llvm::Constant *get_layout_data(
       name,
       llvm::StructType::getTypeByName(module->getContext(), layout_struct));
   auto *global_var2 = llvm::cast<llvm::GlobalVariable>(global2);
+  global_var2->setLinkage(llvm::GlobalValue::InternalLinkage);
   init_debug_global(name, get_forward_decl(layout_struct), global_var2);
   if (!global_var2->hasInitializer()) {
     global_var2->setInitializer(llvm::ConstantStruct::get(
@@ -1248,6 +1256,7 @@ static void emit_sort_table(kore_definition *def, llvm::Module *mod) {
     auto *subtable = module->getOrInsertGlobal(
         fmt::format("sorts_{}", ast_to_string(*symbol)), subtable_type);
     auto *subtable_var = llvm::dyn_cast<llvm::GlobalVariable>(subtable);
+    subtable_var->setLinkage(llvm::GlobalValue::InternalLinkage);
     init_debug_global(
         "sorts_" + symbol->get_name(),
         get_array_debug_type(

--- a/lib/codegen/Metadata.cpp
+++ b/lib/codegen/Metadata.cpp
@@ -30,7 +30,7 @@ void add_boolean_flag(
   }
 
   if (debug) {
-    init_debug_global(strict_bytes, get_bool_debug_type(), global_var);
+    init_debug_global(name, get_bool_debug_type(), global_var);
   }
 }
 

--- a/runtime/take_steps.ll
+++ b/runtime/take_steps.ll
@@ -16,8 +16,6 @@ declare void @write_uint64_to_file(i8*, i64)
 @current_interval = thread_local global i64 0
 @GC_THRESHOLD = thread_local global i64 @GC_THRESHOLD@
 
-@gc_roots = global [256 x i8 *] zeroinitializer
-
 define void @set_gc_threshold(i64 %threshold) {
   store i64 %threshold, i64* @GC_THRESHOLD
   ret void


### PR DESCRIPTION
Each semantics exports a large number of semantics-specific global symbols. If we want to create applications which link in libraries for multiple semantics of the llvm backend, this is a problem, because symbols will collide with one another.

This PR is the first step of attempting to resolve this problem. Some symbols that are currently externally visible can simply be replaced with internal linkage in llvm, thus allowing them to be automatically renamed by the linker when they occur in multiple semantics.

Note that this does not fully resolve the problem. There are still two other classes of symbols that are an issue:

1. symbols that are generated to interface the code generator with the runtime, which the runtime needs to be able to call, but which need to be made somehow local to the semantics.
2. symbols which are intended to be part of the public API of the semantics, and thus need to be callable by applications which link against these libraries.

These will require a more complex solution that will come in a follow-up pull request.

Don't merge this yet. I am experimenting with another solution right now.