### PR TITLE
have clang tidy report non const globals

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,7 +24,6 @@ Checks:
   -bugprone-lambda-function-name
   cppcoreguidelines-*
   -cppcoreguidelines-avoid-magic-numbers
-  -cppcoreguidelines-avoid-non-const-global-variables
   -cppcoreguidelines-narrowing-conversions
   -cppcoreguidelines-no-malloc
   -cppcoreguidelines-owning-memory


### PR DESCRIPTION
Right now I'm just creating this PR to get CI to report to me all the non-const global variables in the llvm backend runtime. I will come up with a slightly less intrusive version of this change later in order to address the issue moving forward once I have dealt with the global variables I need to deal with in a separate PR.

Don't merge this.