### PR TITLE
Using `map` instead of `unordered_map` to ensure reproducibility of kore definition generation

### DIFF
--- a/include/kllvm/ast/attribute_set.h
+++ b/include/kllvm/ast/attribute_set.h
@@ -1,10 +1,10 @@
 #ifndef KLLVM_ATTRIBUTES_H
 #define KLLVM_ATTRIBUTES_H
 
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
-#include <map>
 
 namespace kllvm {
 
@@ -29,8 +29,8 @@ class kore_composite_pattern;
  */
 class attribute_set {
 public:
-  using storage_t = std::map<
-      std::string, std::shared_ptr<kore_composite_pattern>>;
+  using storage_t
+      = std::map<std::string, std::shared_ptr<kore_composite_pattern>>;
 
   enum class key {
     Alias,

--- a/include/kllvm/ast/attribute_set.h
+++ b/include/kllvm/ast/attribute_set.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
+#include <map>
 
 namespace kllvm {
 
@@ -29,7 +29,7 @@ class kore_composite_pattern;
  */
 class attribute_set {
 public:
-  using storage_t = std::unordered_map<
+  using storage_t = std::map<
       std::string, std::shared_ptr<kore_composite_pattern>>;
 
   enum class key {


### PR DESCRIPTION
We have seen that the `definition.kore` has been produced in a different order depending on the OS, which creates a flaky error for some tools like `llvm-komplie-compute-ordinal` and `llvm-kompile-compute-loc`, an error on #1053 MacOS tests, and some frontend errors as well. 

This PR aims to fix that issue by replacing the data structure used to store the attributes.