### PR TITLE
--hidden-visibility flag to llvm-kompile

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -40,6 +40,7 @@ Options:
   --mutable-bytes                   Use the faster, unsound (mutable) semantics for objects of sort
                                     Bytes at run time, rather than the slower, sound
                                     (immutable) that are enabled by default.
+  --hidden-visibility               Set the visibility of all global symbols in generated code to "hidden"
   -O[0123]                          Set the optimization level for code generation.
 
 Any option not listed above will be passed through to clang; use '--' to
@@ -179,6 +180,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --mutable-bytes)
       codegen_flags+=("--mutable-bytes")
+      shift
+      ;;
+    --hidden-visibility)
+      kompile_clang_flags+=("--hidden-visibility")
       shift
       ;;
     -O*)

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -183,6 +183,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --hidden-visibility)
+      codegen_flags+=("--hidden-visibility")
       kompile_clang_flags+=("--hidden-visibility")
       shift
       ;;

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -151,6 +151,12 @@ if ! $save_temps; then
   trap 'rm -rf "$tmpdir"' INT TERM EXIT
 fi
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  set_visibility_hidden="$LIBDIR/libSetVisibilityHidden.dylib"
+else
+  set_visibility_hidden="$LIBDIR/libSetVisibilityHidden.so"
+fi
+
 # When building the Python AST module, there's no runtime and no main file, so
 # we skip this entire step. The library code is just C++, so we can skip
 # straight to invoking the C++ compiler.
@@ -167,7 +173,7 @@ if [ "$main" != "python_ast" ]; then
       fi
       if $visibility_hidden; then
         modhidden="$tmpdir/hidden.bc"
-        run @OPT@ "$modopt" -load-pass-plugin "$LIBDIR/libSetVisibilityHidden.so" -set-visibility-hidden -o "$modhidden"
+        run @OPT@ "$modopt" -load-pass-plugin "$set_visibility_hidden" -set-visibility-hidden -o "$modhidden"
         modopt="$modhidden"
       fi
       run @LLC@ \
@@ -180,7 +186,7 @@ if [ "$main" != "python_ast" ]; then
         tmp="$tmpdir/$(basename "$file").o"
         if $visibility_hidden; then
           tmphidden="$tmpdir/$(basename "$file").hidden.bc"
-	  run @OPT@ "$file" -load-pass-plugin "$LIBDIR/libSetVisibilityHidden.so" -set-visibility-hidden -o "$tmphidden"
+	  run @OPT@ "$file" -load-pass-plugin "$set_visibility_hidden" -set-visibility-hidden -o "$tmphidden"
 	  file="$tmphidden"
         fi
         run @LLC@ \

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -165,6 +165,11 @@ if [ "$main" != "python_ast" ]; then
       if ! $link; then
         modasm="$output_file"
       fi
+      if $visibility_hidden; then
+        modhidden="$tmpdir/hidden.bc"
+        run @OPT@ "$modopt" -load-pass-plugin "$LIBDIR/SetVisibilityHidden.so" -set-visibility-hidden -o "$modhidden"
+        modopt="$modhidden"
+      fi
       run @LLC@ \
         "$modopt" -mtriple=@BACKEND_TARGET_TRIPLE@ \
         -filetype=obj "$llc_opt_flags" "${llc_flags[@]}" -o "$modasm"
@@ -173,6 +178,11 @@ if [ "$main" != "python_ast" ]; then
     if $link; then
       for file in "$LIBDIR"/llvm/*.ll; do
         tmp="$tmpdir/$(basename "$file").o"
+        if $visibility_hidden; then
+          tmphidden="$tmpdir/$(basename "$file").hidden.bc"
+	  run @OPT@ "$file" -load-pass-plugin "$LIBDIR/SetVisibilityHidden.so" -set-visibility-hidden -o "$tmphidden"
+	  file="$tmphidden"
+        fi
         run @LLC@ \
           "$file" -mtriple=@BACKEND_TARGET_TRIPLE@ \
           -filetype=obj "$llc_opt_flags" "${llc_flags[@]}" -o "$tmp"

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -167,7 +167,7 @@ if [ "$main" != "python_ast" ]; then
       fi
       if $visibility_hidden; then
         modhidden="$tmpdir/hidden.bc"
-        run @OPT@ "$modopt" -load-pass-plugin "$LIBDIR/SetVisibilityHidden.so" -set-visibility-hidden -o "$modhidden"
+        run @OPT@ "$modopt" -load-pass-plugin "$LIBDIR/libSetVisibilityHidden.so" -set-visibility-hidden -o "$modhidden"
         modopt="$modhidden"
       fi
       run @LLC@ \
@@ -180,7 +180,7 @@ if [ "$main" != "python_ast" ]; then
         tmp="$tmpdir/$(basename "$file").o"
         if $visibility_hidden; then
           tmphidden="$tmpdir/$(basename "$file").hidden.bc"
-	  run @OPT@ "$file" -load-pass-plugin "$LIBDIR/SetVisibilityHidden.so" -set-visibility-hidden -o "$tmphidden"
+	  run @OPT@ "$file" -load-pass-plugin "$LIBDIR/libSetVisibilityHidden.so" -set-visibility-hidden -o "$tmphidden"
 	  file="$tmphidden"
         fi
         run @LLC@ \

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -14,6 +14,7 @@ shift; shift; shift
 flags=()
 llc_flags=()
 llc_opt_flags="-O0"
+visibility_hidden=false
 link=true
 export verbose=false
 export profile=false
@@ -95,6 +96,10 @@ while [[ $# -gt 0 ]]; do
       keep_arg=false
       python_output_dir="$2";
       shift; shift;
+      ;;
+    --hidden-visibility)
+      visibility_hidden=true
+      shift
       ;;
     *)
       ;;

--- a/include/kllvm/codegen/ApplyPasses.h
+++ b/include/kllvm/codegen/ApplyPasses.h
@@ -6,7 +6,7 @@
 
 namespace kllvm {
 
-void apply_kllvm_opt_passes(llvm::Module &);
+void apply_kllvm_opt_passes(llvm::Module &, bool hidden_visibility);
 
 void generate_object_file(llvm::Module &, llvm::raw_ostream &);
 

--- a/include/kllvm/codegen/SetVisibilityHidden.h
+++ b/include/kllvm/codegen/SetVisibilityHidden.h
@@ -11,20 +11,20 @@
 
 namespace kllvm {
 
-bool runSetVisibilityHidden(llvm::Module &M);
+bool run_set_visibility_hidden(llvm::Module &m);
 
-struct LegacySetVisibilityHidden : llvm::ModulePass {
+struct legacy_set_visibility_hidden : llvm::ModulePass {
   static char ID;
-  LegacySetVisibilityHidden()
+  legacy_set_visibility_hidden()
       : llvm::ModulePass(ID) { }
-  bool runOnModule(llvm::Module &M) override {
-    return runSetVisibilityHidden(M);
+  bool runOnModule(llvm::Module &m) override {
+    return run_set_visibility_hidden(m);
   }
 };
 
-struct SetVisibilityHidden : llvm::PassInfoMixin<SetVisibilityHidden> {
-  llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &) {
-    if (!runSetVisibilityHidden(M))
+struct set_visibility_hidden : llvm::PassInfoMixin<set_visibility_hidden> {
+  llvm::PreservedAnalyses run(llvm::Module &m, llvm::ModuleAnalysisManager &) {
+    if (!run_set_visibility_hidden(m))
       return llvm::PreservedAnalyses::all();
     return llvm::PreservedAnalyses::none();
   }

--- a/include/kllvm/codegen/SetVisibilityHidden.h
+++ b/include/kllvm/codegen/SetVisibilityHidden.h
@@ -23,9 +23,11 @@ struct legacy_set_visibility_hidden : llvm::ModulePass {
 };
 
 struct set_visibility_hidden : llvm::PassInfoMixin<set_visibility_hidden> {
-  llvm::PreservedAnalyses run(llvm::Module &m, llvm::ModuleAnalysisManager &) {
-    if (!run_set_visibility_hidden(m))
+  static llvm::PreservedAnalyses
+  run(llvm::Module &m, llvm::ModuleAnalysisManager &) {
+    if (!run_set_visibility_hidden(m)) {
       return llvm::PreservedAnalyses::all();
+    }
     return llvm::PreservedAnalyses::none();
   }
 };

--- a/include/kllvm/codegen/SetVisibilityHidden.h
+++ b/include/kllvm/codegen/SetVisibilityHidden.h
@@ -14,6 +14,7 @@ namespace kllvm {
 bool run_set_visibility_hidden(llvm::Module &m);
 
 struct legacy_set_visibility_hidden : llvm::ModulePass {
+  // NOLINTNEXTLINE(*-identifier-naming)
   static char ID;
   legacy_set_visibility_hidden()
       : llvm::ModulePass(ID) { }

--- a/include/kllvm/codegen/SetVisibilityHidden.h
+++ b/include/kllvm/codegen/SetVisibilityHidden.h
@@ -1,0 +1,35 @@
+#ifndef SET_VISIBILITY_HIDDEN_H
+#define SET_VISIBILITY_HIDDEN_H
+
+#include "llvm/IR/Function.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/Pass.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace kllvm {
+
+bool runSetVisibilityHidden(llvm::Module &M);
+
+struct LegacySetVisibilityHidden : llvm::ModulePass {
+  static char ID;
+  LegacySetVisibilityHidden()
+      : llvm::ModulePass(ID) { }
+  bool runOnModule(llvm::Module &M) override {
+    return runSetVisibilityHidden(M);
+  }
+};
+
+struct SetVisibilityHidden : llvm::PassInfoMixin<SetVisibilityHidden> {
+  llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &) {
+    if (!runSetVisibilityHidden(M))
+      return llvm::PreservedAnalyses::all();
+    return llvm::PreservedAnalyses::none();
+  }
+};
+
+} // namespace kllvm
+
+#endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(ast)
 add_subdirectory(binary)
 add_subdirectory(codegen)
 add_subdirectory(printer)
+add_subdirectory(set-visibility-hidden)
 
 separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
 add_definitions(${LLVM_DEFINITIONS_LIST})

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -1,5 +1,6 @@
 #include <kllvm/codegen/ApplyPasses.h>
 #include <kllvm/codegen/Options.h>
+#include <kllvm/codegen/SetVisibilityHidden.h>
 
 #include "runtime/header.h"
 
@@ -35,11 +36,14 @@ CodeGenOpt::Level get_opt_level() {
   }
 }
 
-void apply_kllvm_opt_passes(llvm::Module &mod) {
+void apply_kllvm_opt_passes(llvm::Module &mod, bool hidden_visibility) {
   auto pm = legacy::PassManager();
 
   pm.add(createPromoteMemoryToRegisterPass());
   pm.add(createTailCallEliminationPass());
+  if (hidden_visibility) {
+    pm.add(new LegacySetVisibilityHidden());
+  }
 
   pm.run(mod);
 }

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -42,7 +42,7 @@ void apply_kllvm_opt_passes(llvm::Module &mod, bool hidden_visibility) {
   pm.add(createPromoteMemoryToRegisterPass());
   pm.add(createTailCallEliminationPass());
   if (hidden_visibility) {
-    pm.add(new LegacySetVisibilityHidden());
+    pm.add(new legacy_set_visibility_hidden());
   }
 
   pm.run(mod);

--- a/lib/set-visibility-hidden/CMakeLists.txt
+++ b/lib/set-visibility-hidden/CMakeLists.txt
@@ -11,5 +11,7 @@ install(
   LIBRARY DESTINATION lib/kllvm
 )
 
-separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
-add_definitions(${LLVM_DEFINITIONS_LIST})
+llvm_config(SetVisibilityHidden
+  USE_SHARED true
+  core irreader passes
+)

--- a/lib/set-visibility-hidden/CMakeLists.txt
+++ b/lib/set-visibility-hidden/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(SetVisibilityHiddenInternal
+  SetVisibilityHidden.cpp
+)
+
+add_library(SetVisibilityHidden MODULE
+  SetVisibilityHidden.cpp
+)
+
+install(
+  TARGETS SetVisibilityHiddenInternal SetVisibilityHidden
+  LIBRARY DESTINATION lib/kllvm
+)

--- a/lib/set-visibility-hidden/CMakeLists.txt
+++ b/lib/set-visibility-hidden/CMakeLists.txt
@@ -10,3 +10,6 @@ install(
   TARGETS SetVisibilityHiddenInternal SetVisibilityHidden
   LIBRARY DESTINATION lib/kllvm
 )
+
+separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
+add_definitions(${LLVM_DEFINITIONS_LIST})

--- a/lib/set-visibility-hidden/SetVisibilityHidden.cpp
+++ b/lib/set-visibility-hidden/SetVisibilityHidden.cpp
@@ -3,15 +3,16 @@
 using namespace llvm;
 
 namespace kllvm {
-__attribute__((visibility("default"))) bool runSetVisibilityHidden(Module &M) {
+__attribute__((visibility("default"))) bool
+run_set_visibility_hidden(Module &m) {
   bool dirty = false;
-  for (auto &global : M.globals()) {
+  for (auto &global : m.globals()) {
     if (!global.isDeclaration()) {
       global.setVisibility(GlobalValue::HiddenVisibility);
       dirty = true;
     }
   }
-  for (auto &func : M.functions()) {
+  for (auto &func : m.functions()) {
     if (!func.isDeclaration()) {
       func.setVisibility(GlobalValue::HiddenVisibility);
       dirty = true;
@@ -24,26 +25,27 @@ __attribute__((visibility("default"))) bool runSetVisibilityHidden(Module &M) {
 
 using namespace kllvm;
 
-__attribute__((visibility("default"))) char LegacySetVisibilityHidden::ID = 0;
+__attribute__((visibility("default"))) char legacy_set_visibility_hidden::ID
+    = 0;
 
-static RegisterPass<LegacySetVisibilityHidden>
-    X("set-visibility-hidden", "Set visibility of all global values to hidden",
+static RegisterPass<legacy_set_visibility_hidden>
+    x("set-visibility-hidden", "Set visibility of all global values to hidden",
       false /* Only looks at CFG */, false /* Analysis Pass */);
 
 /* New PM Registration */
 llvm::PassPluginLibraryInfo getSetVisibilityHiddenPluginInfo() {
   return {
       LLVM_PLUGIN_API_VERSION, "SetVisibilityHidden", LLVM_VERSION_STRING,
-      [](PassBuilder &PB) {
-        PB.registerPipelineStartEPCallback(
-            [](llvm::ModulePassManager &PM, OptimizationLevel Level) {
-              PM.addPass(SetVisibilityHidden());
+      [](PassBuilder &pb) {
+        pb.registerPipelineStartEPCallback(
+            [](llvm::ModulePassManager &pm, OptimizationLevel level) {
+              pm.addPass(set_visibility_hidden());
             });
-        PB.registerPipelineParsingCallback(
-            [](StringRef Name, llvm::ModulePassManager &PM,
+        pb.registerPipelineParsingCallback(
+            [](StringRef name, llvm::ModulePassManager &pm,
                ArrayRef<llvm::PassBuilder::PipelineElement>) {
-              if (Name == "set-visibility-hidden") {
-                PM.addPass(SetVisibilityHidden());
+              if (name == "set-visibility-hidden") {
+                pm.addPass(set_visibility_hidden());
                 return true;
               }
               return false;

--- a/lib/set-visibility-hidden/SetVisibilityHidden.cpp
+++ b/lib/set-visibility-hidden/SetVisibilityHidden.cpp
@@ -33,7 +33,7 @@ static RegisterPass<legacy_set_visibility_hidden>
       false /* Only looks at CFG */, false /* Analysis Pass */);
 
 /* New PM Registration */
-llvm::PassPluginLibraryInfo getSetVisibilityHiddenPluginInfo() {
+llvm::PassPluginLibraryInfo get_set_visibility_hidden_plugin_info() {
   return {
       LLVM_PLUGIN_API_VERSION, "SetVisibilityHidden", LLVM_VERSION_STRING,
       [](PassBuilder &pb) {
@@ -57,6 +57,6 @@ llvm::PassPluginLibraryInfo getSetVisibilityHiddenPluginInfo() {
 extern "C" __attribute__((visibility("default")))
 LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
 llvmGetPassPluginInfo() {
-  return getSetVisibilityHiddenPluginInfo();
+  return get_set_visibility_hidden_plugin_info();
 }
 #endif

--- a/lib/set-visibility-hidden/SetVisibilityHidden.cpp
+++ b/lib/set-visibility-hidden/SetVisibilityHidden.cpp
@@ -1,0 +1,60 @@
+#include <kllvm/codegen/SetVisibilityHidden.h>
+
+using namespace llvm;
+
+namespace kllvm {
+__attribute__((visibility("default"))) bool runSetVisibilityHidden(Module &M) {
+  bool dirty = false;
+  for (auto &global : M.globals()) {
+    if (!global.isDeclaration()) {
+      global.setVisibility(GlobalValue::HiddenVisibility);
+      dirty = true;
+    }
+  }
+  for (auto &func : M.functions()) {
+    if (!func.isDeclaration()) {
+      func.setVisibility(GlobalValue::HiddenVisibility);
+      dirty = true;
+    }
+  }
+  return dirty;
+}
+
+} // namespace kllvm
+
+using namespace kllvm;
+
+__attribute__((visibility("default"))) char LegacySetVisibilityHidden::ID = 0;
+
+static RegisterPass<LegacySetVisibilityHidden>
+    X("set-visibility-hidden", "Set visibility of all global values to hidden",
+      false /* Only looks at CFG */, false /* Analysis Pass */);
+
+/* New PM Registration */
+llvm::PassPluginLibraryInfo getSetVisibilityHiddenPluginInfo() {
+  return {
+      LLVM_PLUGIN_API_VERSION, "SetVisibilityHidden", LLVM_VERSION_STRING,
+      [](PassBuilder &PB) {
+        PB.registerPipelineStartEPCallback(
+            [](llvm::ModulePassManager &PM, OptimizationLevel Level) {
+              PM.addPass(SetVisibilityHidden());
+            });
+        PB.registerPipelineParsingCallback(
+            [](StringRef Name, llvm::ModulePassManager &PM,
+               ArrayRef<llvm::PassBuilder::PipelineElement>) {
+              if (Name == "set-visibility-hidden") {
+                PM.addPass(SetVisibilityHidden());
+                return true;
+              }
+              return false;
+            });
+      }};
+}
+
+#ifndef LLVM_BYE_LINK_INTO_TOOLS
+extern "C" __attribute__((visibility("default")))
+LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return getSetVisibilityHiddenPluginInfo();
+}
+#endif

--- a/tools/llvm-kompile-codegen/CMakeLists.txt
+++ b/tools/llvm-kompile-codegen/CMakeLists.txt
@@ -2,7 +2,7 @@ kllvm_add_tool(llvm-kompile-codegen
   main.cpp
 )
 
-target_link_libraries(llvm-kompile-codegen PUBLIC Codegen Parser AST gmp mpfr yaml)
+target_link_libraries(llvm-kompile-codegen PUBLIC Codegen Parser AST SetVisibilityHiddenInternal gmp mpfr yaml)
 
 install(
   TARGETS llvm-kompile-codegen

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -66,6 +66,11 @@ cl::opt<bool> mutable_bytes(
     cl::desc("Enable unsound reference semantics for objects of sort Bytes"),
     cl::init(false), cl::cat(codegen_tool_cat));
 
+cl::opt<bool> hidden_visibility(
+    "hidden-visibility",
+    cl::desc("Set visibility of all global symbols to hidden"), cl::init(false),
+    cl::cat(codegen_tool_cat));
+
 cl::opt<bool> safe_partial(
     "safe-partial",
     cl::desc("Do not terminate the process when a partial function is "

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -230,7 +230,7 @@ int main(int argc, char **argv) {
   }
 
   if (!no_optimize) {
-    apply_kllvm_opt_passes(*mod);
+    apply_kllvm_opt_passes(*mod, hidden_visibility);
   }
 
   perform_output([&](auto &os) {


### PR DESCRIPTION
This flag is used to assist with the process of building an application that links against more than one llvm backend semantics.

It can be used in roughly the following way:

1. Compile the llvm backend with the `clang++` flag `-fvisibility=hidden`.
2. Run `llvm-kompile definition.kore dt library --hidden-visibility -- -shared entry.cpp -o definition.so` in the kompiled directory.
3. Link `definition.so` into your application. It will have all the symbols of `entry.cpp` and `entry.cpp` will be able to access any symbol in the semantics, but those internal symbols will not be visible to the application.

The application can do this with multiple semantics and there will be no linker issue. I have tested some basic examples that show that each semantics can separately apply its own rewrite rules. There is no test in this PR because the test harness does not allow us to rebuild the llvm backend with a particular set of build flags just for one test, and it didn't seem worth it to put all that effort in just for one test. When we create downstream projects that use this feature, we will be sure to include tests for this feature in those repositories.