### PR TITLE
Update llvm-krun: removing `set -x`

### DIFF
--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-set -x
 
 params=()
 pretty=()


### PR DESCRIPTION
An unnecessary `set -x` got upstream and is messing up with the CI test's visualization. This PR deletes it.