### PR TITLE
Drop intel macOS support in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,6 @@ jobs:
         include:
           - runner: [self-hosted, linux, normal]
             os: ubuntu-20.04
-          - runner: macos-12
-            os: macos-12
           - runner: MacM1
             os: self-macos-12
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
Part of: https://github.com/runtimeverification/k/issues/4368

We no longer want to support these machines, and so we should remove them from all the CI matrices that we're using across the organisation.