### PR TITLE
Don't invoke Maven every time we run a test

### DIFF
--- a/bin/llvm-kompile-testing
+++ b/bin/llvm-kompile-testing
@@ -11,7 +11,17 @@ trap 'rm -rf "$dt_dir"' INT TERM EXIT
 definition=$(realpath "$1")
 mode="$2"
 shift; shift
-( cd "@PROJECT_SOURCE_DIR@"/matching && mvn exec:java -Dexec.args="$definition qbaL $dt_dir 1" -q )
+
+matching_dir="@PROJECT_SOURCE_DIR@/matching"
+installed_jar="$matching_dir/target/llvm-backend-matching-1.0-SNAPSHOT-jar-with-dependencies.jar"
+
+if [ ! -f "$installed_jar" ]; then
+  echo "Pattern matching compiler isn't installed!"
+  echo "  looking for a jar file at $installed_jar"
+  exit 1
+fi
+
+java -jar "$installed_jar" "$definition" qbaL "$dt_dir" 1
 
 llvm_kompile_flags=()
 clang_flags=()

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -45,9 +45,11 @@ let
     mkdir -p "$out/bin"
     cp ${llvm-backend.src}/bin/llvm-kompile-testing "$out/bin"
     sed -i "$out/bin/llvm-kompile-testing" \
-        -e '/@PROJECT_SOURCE_DIR@/ c ${java} -jar ${jar} $definition qbaL $dt_dir 1'
+        -e 's!installed_jar=.*!installed_jar="${jar}"!g'
     substituteInPlace $out/bin/llvm-kompile-testing \
-      --replace 'llvm-kompile' '${llvm-backend}/bin/llvm-kompile'
+      --replace 'llvm-kompile' '${llvm-backend}/bin/llvm-kompile' \
+      --replace 'java -jar "$installed_jar" "$definition" qbaL "$dt_dir" 1' \
+                '${java} -jar "$installed_jar" "$definition" qbaL "$dt_dir" 1'
     chmod +x "$out/bin/llvm-kompile-testing"
     patchShebangs "$out/bin/llvm-kompile-testing"
   '';


### PR DESCRIPTION
Previously, the testing script would invoke Maven every time it compiled a pattern-matching tree; this was slow and made the CI process prone to intermittent network failures. This PR addresses the issue by instead directly invoking the compiled JAR file that we already built with Maven.

Fixes https://github.com/runtimeverification/llvm-backend/issues/1055