### PR TITLE
Write streaming event parser for proof hints

### DIFF
--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -234,6 +234,13 @@ public:
       unsigned indent = 0U) const;
 };
 
+enum class llvm_event_type { pre_trace, initial_config, trace };
+
+struct annotated_llvm_event {
+  llvm_event_type type;
+  llvm_event event;
+};
+
 class llvm_rewrite_trace {
 private:
   uint32_t version_{};

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -658,6 +658,23 @@ public:
   std::optional<llvm_rewrite_trace>
   parse_proof_trace_from_file(std::string const &filename);
   std::optional<llvm_rewrite_trace> parse_proof_trace(std::string const &data);
+
+  friend class llvm_rewrite_trace_iterator;
+};
+
+class llvm_rewrite_trace_iterator {
+private:
+  uint32_t version_{};
+  proof_trace_buffer &buffer_;
+  llvm_event_type type_ = llvm_event_type::pre_trace;
+  proof_trace_parser parser_;
+
+public:
+  llvm_rewrite_trace_iterator(
+      proof_trace_buffer &buffer, kore_header const &header);
+  [[nodiscard]] uint32_t get_version() const { return version_; }
+  std::optional<annotated_llvm_event> const get_next_event(void);
+  void print(std::ostream &out, bool expand_terms, unsigned indent = 0U);
 };
 
 } // namespace kllvm

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -234,10 +234,10 @@ public:
       unsigned indent = 0U) const;
 };
 
-enum class llvm_event_type { pre_trace, initial_config, trace };
+enum class llvm_event_type { PreTrace, InitialConfig, Trace };
 
 struct annotated_llvm_event {
-  llvm_event_type type;
+  llvm_event_type type{};
   llvm_event event;
 };
 
@@ -666,14 +666,14 @@ class llvm_rewrite_trace_iterator {
 private:
   uint32_t version_{};
   proof_trace_buffer &buffer_;
-  llvm_event_type type_ = llvm_event_type::pre_trace;
+  llvm_event_type type_ = llvm_event_type::PreTrace;
   proof_trace_parser parser_;
 
 public:
   llvm_rewrite_trace_iterator(
       proof_trace_buffer &buffer, kore_header const &header);
   [[nodiscard]] uint32_t get_version() const { return version_; }
-  std::optional<annotated_llvm_event> const get_next_event(void);
+  std::optional<annotated_llvm_event> get_next_event();
   void print(std::ostream &out, bool expand_terms, unsigned indent = 0U);
 };
 

--- a/lib/binary/ProofTraceParser.cpp
+++ b/lib/binary/ProofTraceParser.cpp
@@ -115,6 +115,59 @@ void llvm_event::print(
   }
 }
 
+llvm_rewrite_trace_iterator::llvm_rewrite_trace_iterator(
+    proof_trace_buffer &buffer, kore_header const &header)
+    : buffer_(buffer)
+    , parser_(false, false, header) {
+  if (!parser_.parse_header(buffer_, version_)) {
+    throw std::runtime_error("invalid header");
+  }
+}
+
+std::optional<annotated_llvm_event> const
+llvm_rewrite_trace_iterator::get_next_event(void) {
+  if (buffer_.eof()) {
+    return std::nullopt;
+  }
+  switch (type_) {
+  case llvm_event_type::pre_trace: {
+    if (buffer_.has_word() && buffer_.peek_word() != config_sentinel) {
+      llvm_event event;
+      if (!parser_.parse_event(buffer_, event)) {
+        throw std::runtime_error("could not parse pre-trace event");
+      }
+      return {{type_, event}};
+    }
+    uint64_t pattern_len = 0;
+    auto config = parser_.parse_config(buffer_, pattern_len);
+    if (!config) {
+      throw std::runtime_error("could not parse config event");
+    }
+    llvm_event config_event;
+    config_event.setkore_pattern(config, pattern_len);
+    type_ = llvm_event_type::trace;
+    return {{llvm_event_type::initial_config, config_event}};
+  }
+  case llvm_event_type::trace: {
+    llvm_event event;
+    if (!parser_.parse_event(buffer_, event)) {
+      throw std::runtime_error("could not parse trace event");
+    }
+    return {{type_, event}};
+  }
+  default: throw std::runtime_error("should be unreachable");
+  }
+}
+
+void llvm_rewrite_trace_iterator::print(
+    std::ostream &out, bool expand_terms, unsigned ind) {
+  std::string indent(ind * indent_size, ' ');
+  out << fmt::format("{}version: {}\n", indent, version_);
+  while (auto event = get_next_event()) {
+    event.value().event.print(out, expand_terms, false, ind);
+  }
+}
+
 void llvm_rewrite_trace::print(
     std::ostream &out, bool expand_terms, unsigned ind) const {
   std::string indent(ind * indent_size, ' ');

--- a/lib/binary/ProofTraceParser.cpp
+++ b/lib/binary/ProofTraceParser.cpp
@@ -119,18 +119,18 @@ llvm_rewrite_trace_iterator::llvm_rewrite_trace_iterator(
     proof_trace_buffer &buffer, kore_header const &header)
     : buffer_(buffer)
     , parser_(false, false, header) {
-  if (!parser_.parse_header(buffer_, version_)) {
+  if (!proof_trace_parser::parse_header(buffer_, version_)) {
     throw std::runtime_error("invalid header");
   }
 }
 
-std::optional<annotated_llvm_event> const
-llvm_rewrite_trace_iterator::get_next_event(void) {
+std::optional<annotated_llvm_event>
+llvm_rewrite_trace_iterator::get_next_event() {
   if (buffer_.eof()) {
     return std::nullopt;
   }
   switch (type_) {
-  case llvm_event_type::pre_trace: {
+  case llvm_event_type::PreTrace: {
     if (buffer_.has_word() && buffer_.peek_word() != config_sentinel) {
       llvm_event event;
       if (!parser_.parse_event(buffer_, event)) {
@@ -145,10 +145,10 @@ llvm_rewrite_trace_iterator::get_next_event(void) {
     }
     llvm_event config_event;
     config_event.setkore_pattern(config, pattern_len);
-    type_ = llvm_event_type::trace;
-    return {{llvm_event_type::initial_config, config_event}};
+    type_ = llvm_event_type::Trace;
+    return {{llvm_event_type::InitialConfig, config_event}};
   }
-  case llvm_event_type::trace: {
+  case llvm_event_type::Trace: {
     llvm_event event;
     if (!parser_.parse_event(buffer_, event)) {
       throw std::runtime_error("could not parse trace event");

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -160,6 +160,12 @@ config.substitutions.extend([
             echo "kore-proof-trace error while parsing proof hint trace with expanded kore terms"
             exit 1
         fi
+        %kore-proof-trace --streaming-parser --verbose --expand-terms %t.header.bin $t.out.bin | diff - %test-proof-diff-out
+        result="$?"
+        if [ "$result" -ne 0 ]; then
+            echo "kore-proof-trace error while parsing proof hint trace with expanded kore terms and streaming parser"
+            exit 1
+        fi
     ''')),
 
     ('%check-dir-proof-out', one_line('''
@@ -173,6 +179,12 @@ config.substitutions.extend([
             result="$?"
             if [ "$result" -ne 0 ]; then
                 echo "kore-proof-trace error while parsing proof hint trace with expanded kore terms"
+                exit 1
+            fi
+            %kore-proof-trace --streaming-parser --verbose --expand-terms %t.header.bin $hint | diff - $out
+            result="$?"
+            if [ "$result" -ne 0 ]; then
+                echo "kore-proof-trace error while parsing proof hint trace with expanded kore terms and streaming parser"
                 exit 1
             fi
         done

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -160,7 +160,7 @@ config.substitutions.extend([
             echo "kore-proof-trace error while parsing proof hint trace with expanded kore terms"
             exit 1
         fi
-        %kore-proof-trace --streaming-parser --verbose --expand-terms %t.header.bin $t.out.bin | diff - %test-proof-diff-out
+        %kore-proof-trace --streaming-parser --verbose --expand-terms %t.header.bin %t.out.bin | diff - %test-proof-diff-out -q
         result="$?"
         if [ "$result" -ne 0 ]; then
             echo "kore-proof-trace error while parsing proof hint trace with expanded kore terms and streaming parser"

--- a/tools/kore-proof-trace/main.cpp
+++ b/tools/kore-proof-trace/main.cpp
@@ -48,13 +48,13 @@ int main(int argc, char **argv) {
       it.print(std::cout, expand_terms_in_output);
     }
     return 0;
-  } else {
-    proof_trace_parser parser(verbose_output, expand_terms_in_output, header);
-    auto trace = parser.parse_proof_trace_from_file(input_filename);
-    if (trace.has_value()) {
-      return 0;
-    }
-
-    return 1;
   }
+
+  proof_trace_parser parser(verbose_output, expand_terms_in_output, header);
+  auto trace = parser.parse_proof_trace_from_file(input_filename);
+  if (trace.has_value()) {
+    return 0;
+  }
+
+  return 1;
 }


### PR DESCRIPTION
This is a pretty straightforward diff. We can reuse the code for parsing events and the proof trace header, so we just need to create an entry point to the streaming parser that invokes the relevant parsing logic and returns events one at a time, and then write code to test it. We test it by modifying lit tests that test the proof hints so that they test both parsers. This means we get the advantage of the entire coverage set of tests that we imported from the math proof repo.