### PR TITLE
Update to new Nixpkgs version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,17 +52,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707163378,
-        "narHash": "sha256-oz+BzUDwtyircjjxv9aPYOS5gobxLCjD2il+gb/bCRo=",
+        "lastModified": 1716457947,
+        "narHash": "sha256-Y+exebcqeprnhEpoPJrEUZmNeO60qeOxkVHhqG/OEwQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2ffefe304d941bb98989847944f3b58e0adcdd5",
+        "rev": "69493a13eaea0dc4682fd07e8a084f17813dbeeb",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2ffefe304d941bb98989847944f3b58e0adcdd5",
+        "rev": "69493a13eaea0dc4682fd07e8a084f17813dbeeb",
         "type": "github"
       }
     },
@@ -120,11 +120,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1707492220,
-        "narHash": "sha256-KRndaUPzUumDlNcKF7KzA8F/EZKLYCvurh7Z13sw2PI=",
+        "lastModified": 1716459074,
+        "narHash": "sha256-IpahO+EkWdGl9QP7B2YXfJWpSfghjxgpz4ab47nRJY4=",
         "owner": "runtimeverification",
         "repo": "rv-nix-tools",
-        "rev": "abf86805a623948c941e603e2fc4c26a06ea6eb6",
+        "rev": "a65058865cda201de504f5546271b8e997a0be9c",
         "type": "github"
       },
       "original": {

--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -1,4 +1,4 @@
-{ lib, src, cmake, flex, fmt, pkg-config, llvm, libllvm, libcxxabi, stdenv, boost, gmp
+{ lib, src, cmake, flex, fmt, pkg-config, llvm, libllvm, libcxx, stdenv, boost, gmp
 , jemalloc, libffi, libiconv, libyaml, mpfr, ncurses, python310, unixtools,
 # Runtime dependencies:
 host,
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
       --replace '"-lncurses"' '"-L${ncurses}/lib" "-lncurses"' \
       --replace '"-ltinfo"' '"-L${ncurses}/lib" "-ltinfo"' \
       --replace '"-L@BREW_PREFIX@/opt/libffi/lib"' ' ' \
-      --replace '-L@BREW_PREFIX@/lib' '-L${libcxxabi}/lib' \
+      --replace '-L@BREW_PREFIX@/lib' '-L${libcxx}/lib' \
       --replace '-I "$(dirname "$0")"/../include/kllvm' \
                 '-I "$(dirname "$0")"/../include/kllvm -I ${boost.dev}/include -I ${fmt.dev}/include'
   '';

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -12,7 +12,7 @@ let
   clang = llvmPackages.clangNoLibcxx;
 
   llvm-backend = prev.callPackage ./llvm-backend.nix {
-    inherit (llvmPackages) llvm libllvm libcxxabi;
+    inherit (llvmPackages) llvm libllvm libcxx;
     stdenv = llvmPackages.stdenv;
     cmakeBuildType = prev.llvm-backend-build-type;
     src = prev.llvm-backend-src;


### PR DESCRIPTION
This will allow us to run LLVM 18 in CI; the only change needed to our Nix code here is a small difference in the API of the `llvmPackages_*` derivations.