### PR TITLE
Update CI matrix for LLVM 18

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,7 @@
           builtins.listToAttrs (lib.imap0 (i: v: { name = "check_${toString i}"; value = v; }) checks);
 
         matrix = builtins.listToAttrs (lib.forEach (lib.cartesianProductOfSets {
-          llvm-version = [15 16 17];
+          llvm-version = [15 16 17 18];
           build-type = ["Debug" "Release" "RelWithDebInfo" "FastBuild" "GcStats"];
         }) (
           args:
@@ -117,20 +117,21 @@
         ));
       in with matrix; {
         packages = utils.lib.flattenTree {
-          inherit (llvm-backend-17-FastBuild) llvm-backend llvm-backend-matching llvm-kompile-testing;
-          default = llvm-backend-17-FastBuild.llvm-backend;
-          llvm-backend-release = llvm-backend-17-Release.llvm-backend;
+          inherit (llvm-backend-18-FastBuild) llvm-backend llvm-backend-matching llvm-kompile-testing;
+          default = llvm-backend-18-FastBuild.llvm-backend;
+          llvm-backend-release = llvm-backend-18-Release.llvm-backend;
         };
 
         checks = listToChecks [
-          llvm-backend-17-Debug.llvm-backend
-          llvm-backend-17-Release.llvm-backend
-          llvm-backend-17-RelWithDebInfo.llvm-backend
-          llvm-backend-17-GcStats.llvm-backend
+          llvm-backend-18-Debug.llvm-backend
+          llvm-backend-18-Release.llvm-backend
+          llvm-backend-18-RelWithDebInfo.llvm-backend
+          llvm-backend-18-GcStats.llvm-backend
 
           llvm-backend-15-FastBuild.integration-tests
           llvm-backend-16-FastBuild.integration-tests
           llvm-backend-17-FastBuild.integration-tests
+          llvm-backend-18-FastBuild.integration-tests
         ];
       }) // {
         # non-system suffixed items should go here


### PR DESCRIPTION
We have already made all the changes required to update the backend to LLVM 18:
- https://github.com/runtimeverification/llvm-backend/pull/1068
- https://github.com/runtimeverification/llvm-backend/pull/1070

This PR finalises the process by adding LLVM 18 to our CI matrix.