### PR TITLE
Adding `llvm:cl::opt` support to `kore-rich-header`

### DIFF
--- a/tools/kore-rich-header/main.cpp
+++ b/tools/kore-rich-header/main.cpp
@@ -2,17 +2,44 @@
 #include <kllvm/binary/serializer.h>
 #include <kllvm/parser/KOREParser.h>
 
+#include <llvm/Support/CommandLine.h>
+
 #include <cstdint>
+#include <fstream>
 #include <iostream>
 
+using namespace llvm;
 using namespace kllvm;
 using namespace kllvm::parser;
 
+cl::OptionCategory rich_header_cat("kore-rich-header options");
+
+cl::opt<std::string> input(
+    cl::Positional, cl::desc("<kore-definition>"), cl::Required,
+    cl::cat(rich_header_cat));
+
+cl::opt<std::string> output(
+    "o", cl::desc("Output file path"), cl::value_desc("filepath"),
+    cl::cat(rich_header_cat));
+
+cl::alias output_alias(
+    "output", cl::desc("Alias for -o"), cl::value_desc("filepath"),
+    cl::cat(rich_header_cat), cl::aliasopt(output));
+
 int main(int argc, char **argv) {
-  char *filename = argv[1];
-  kore_parser parser(filename);
-  ptr<kore_definition> definition = parser.definition();
+  cl::HideUnrelatedOptions({&rich_header_cat});
+  cl::ParseCommandLineOptions(argc, argv);
+
+  kore_parser parser(input);
+  auto definition = parser.definition();
   definition->preprocess();
-  emit_kore_rich_header(std::cout, definition.get());
+
+  if (output.empty()) {
+    emit_kore_rich_header(std::cout, definition.get());
+  } else {
+    std::ofstream out(output);
+    emit_kore_rich_header(out, definition.get());
+  }
+
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/Pi-Squared-Inc/pi2/issues/1483

This simple PR addresses @Baltoli's suggestion to include `cl::opt` in the `kore-rich-header` to improve the user experience for a broader audience. I also added `-o/--output` support to improve the tool's usability and compatibility with other tools and scripts.