### PR TITLE
add flag to control whether gc should be enabled or not

### DIFF
--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -35,6 +35,8 @@ private:
   bool populate_static_set(kore_pattern *pattern);
   std::pair<llvm::Value *, bool> create_allocation(
       kore_pattern *pattern, std::string const &location_stack = "");
+  llvm::Value *disable_gc();
+  void enable_gc(llvm::Value *was_enabled);
 
 public:
   create_term(

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -111,6 +111,8 @@ size_t hash_k(block *);
 void k_hash(block *, void *);
 bool hash_enter(void);
 void hash_exit(void);
+
+extern bool gc_enabled;
 }
 
 __attribute__((always_inline)) constexpr uint64_t len_hdr(uint64_t hdr) {
@@ -225,7 +227,10 @@ struct kore_alloc_heap {
     if (during_gc()) {
       return ::operator new(size);
     }
+    bool enabled = gc_enabled;
+    gc_enabled = false;
     auto *result = (string *)kore_alloc_token(size + sizeof(blockheader));
+    gc_enabled = enabled;
     init_with_len(result, size);
     return result->data;
   }

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -673,8 +673,29 @@ llvm::Value *create_term::create_hook(
   }
   std::string hook_name = "hook_" + name.substr(0, name.find('.')) + "_"
                           + name.substr(name.find('.') + 1);
-  return create_function_call(
+  auto *old_val = disable_gc();
+  auto *result = create_function_call(
       hook_name, pattern, true, false, true, location_stack);
+  enable_gc(old_val);
+  return result;
+}
+
+llvm::Value *create_term::disable_gc() {
+  llvm::Constant *global
+      = module_->getOrInsertGlobal("gc_enabled", llvm::Type::getInt1Ty(ctx_));
+  auto *global_var = llvm::cast<llvm::GlobalVariable>(global);
+  auto *old_val = new llvm::LoadInst(
+      llvm::Type::getInt1Ty(ctx_), global_var, "was_enabled", current_block_);
+  new llvm::StoreInst(
+      llvm::ConstantInt::getFalse(ctx_), global_var, current_block_);
+  return old_val;
+}
+
+void create_term::enable_gc(llvm::Value *was_enabled) {
+  llvm::Constant *global
+      = module_->getOrInsertGlobal("gc_enabled", llvm::Type::getInt1Ty(ctx_));
+  auto *global_var = llvm::cast<llvm::GlobalVariable>(global);
+  new llvm::StoreInst(was_enabled, global_var, current_block_);
 }
 
 // We use tailcc calling convention for apply_rule_* and eval_* functions to

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -113,13 +113,19 @@ kore_resize_last_alloc(void *oldptr, size_t newrequest, size_t last_size) {
 }
 
 void *kore_alloc_mp(size_t requested) {
+  bool enabled = gc_enabled;
+  gc_enabled = false;
   auto *new_token = (string *)kore_alloc_token(sizeof(string) + requested);
+  gc_enabled = enabled;
   init_with_len(new_token, requested);
   return new_token->data;
 }
 
 void *kore_realloc_mp(void *ptr, size_t old_size, size_t new_size) {
+  bool enabled = gc_enabled;
+  gc_enabled = false;
   auto *new_token = (string *)kore_alloc_token(sizeof(string) + new_size);
+  gc_enabled = enabled;
   size_t min = old_size > new_size ? new_size : old_size;
   memcpy(new_token->data, ptr, min);
   init_with_len(new_token, new_size);

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -116,6 +116,8 @@ static void fresh_block(struct arena *arena) {
       BLOCK_SIZE - sizeof(memory_block_header));
 }
 
+bool gc_enabled;
+
 static __attribute__((noinline)) void *
 do_alloc_slow(size_t requested, struct arena *arena) {
   MEM_LOG(

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -98,6 +98,7 @@ struct construction {
 
 // NOLINTNEXTLINE(*-cognitive-complexity)
 extern "C" void *construct_initial_configuration(kore_pattern const *initial) {
+  gc_enabled = false;
   std::vector<std::variant<kore_pattern const *, construction>> work_list{
       initial};
   std::vector<void *> output;
@@ -156,6 +157,7 @@ extern "C" void *construct_initial_configuration(kore_pattern const *initial) {
     }
   }
 
+  gc_enabled = true;
   return output[0];
 }
 
@@ -163,6 +165,7 @@ extern "C" void *construct_initial_configuration(kore_pattern const *initial) {
 template <typename It>
 static void *
 deserialize_initial_configuration(It ptr, It end, binary_version version) {
+  gc_enabled = false;
   using namespace kllvm::detail;
   auto begin = ptr;
 
@@ -253,6 +256,7 @@ deserialize_initial_configuration(It ptr, It end, binary_version version) {
     }
   }
 
+  gc_enabled = true;
   assert(output.size() == 1 && "Output stack left in invalid state");
   return output.front();
 }

--- a/unittests/runtime-collections/lists.cpp
+++ b/unittests/runtime-collections/lists.cpp
@@ -63,6 +63,8 @@ block D1 = {{1}};
 block *DUMMY1 = &D1;
 }
 
+bool gc_enabled;
+
 BOOST_AUTO_TEST_SUITE(ListTest)
 
 BOOST_AUTO_TEST_CASE(element) {


### PR DESCRIPTION
This is one of a sequence of PRs designed to make progress towards generating stack maps so that we can trigger the GC during allocation rather than in between rewrite steps only. The first few PRs will be preliminaries that add small features that will be used by future PRs.

This PR adds a global variable that controls whether or not garbage collection is enabled. This boolean flag is disabled during certain call frames that it would be difficult to walk the stack of. In particular, we disable the flag during:

* allocations that occur inside immer
* calls to hooks
* allocations that occur inside GMP and MPFR
* construction of the initial configuration

The boolean flag is currently unused. It will be used in a future pull request to determine whether the allocator is allowed to trigger garbage collection at the current time.