### PR TITLE
Disable LTO when building Debian packages

### DIFF
--- a/package/debian/rules.jammy
+++ b/package/debian/rules.jammy
@@ -18,6 +18,7 @@ override_dh_auto_build:
 		-S . \
 		-B build \
 		-DCMAKE_BUILD_TYPE=Release \
+		-DK_LLVM_BACKEND_LTO=OFF \
 		-DCMAKE_INSTALL_PREFIX=$(PREFIX)
 	cmake --build build
 

--- a/package/debian/rules.noble
+++ b/package/debian/rules.noble
@@ -18,6 +18,7 @@ override_dh_auto_build:
 		-S . \
 		-B build \
 		-DCMAKE_BUILD_TYPE=Release \
+		-DK_LLVM_BACKEND_LTO=OFF \
 		-DCMAKE_INSTALL_PREFIX=$(PREFIX) \
 		-DCMAKE_C_COMPILER=/usr/bin/clang-17 \
 		-DCMAKE_CXX_COMPILER=/usr/bin/clang++-17


### PR DESCRIPTION
This PR explicitly disables LTO via the backend's own option when building Debian packages, rather than relying on the Debian Makefile infrastructure to propagate the appropriate flags down through CMake. We already do the same thing when building via Nix.

The issue here manifests strangely (https://github.com/runtimeverification/llvm-backend/issues/1038). In this case, what's happening is that LTO being enabled causes the runtime's static libraries to get built as archives of `.bc` files rather than actual objects. These bitcode files then contain inline assembly directives based on the C++ code's directives, which contain absolute paths referencing the _build system_ rather than the _runtime system_. We therefore need to disable LTO so that the assembly directives are resolved fully when the Debian package is built, rather than when it's shipped.

Fixes https://github.com/runtimeverification/llvm-backend/issues/1038