### PR TITLE
Fix typo in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
     name: 'Publish Release'
     runs-on: ubuntu-latest
     environment: production
-    needs: build-ubuntu-packages
+    needs: build-ubuntu-package
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4


### PR DESCRIPTION
In #1072, we changed the names of some workflow steps. This introduced a typo in the release workflow that's been preventing us from cutting releases; this PR is a straightforward fix for that typo.