### PR TITLE
add kore_clear function that clears alwaysgcspace on every step

### DIFF
--- a/include/kllvm/codegen/Util.h
+++ b/include/kllvm/codegen/Util.h
@@ -42,7 +42,7 @@ llvm::Function *get_or_insert_function(llvm::Module *module, Ts &&...args) {
 
 char const *get_collection_alloc_fn(sort_category cat);
 
-void insert_call_to_clear(llvm::BasicBlock *BB);
+void insert_call_to_clear(llvm::BasicBlock *bb);
 
 } // namespace kllvm
 

--- a/include/kllvm/codegen/Util.h
+++ b/include/kllvm/codegen/Util.h
@@ -42,6 +42,8 @@ llvm::Function *get_or_insert_function(llvm::Module *module, Ts &&...args) {
 
 char const *get_collection_alloc_fn(sort_category cat);
 
+void insert_call_to_clear(llvm::BasicBlock *BB);
+
 } // namespace kllvm
 
 #endif // KLLVM_UTIL_H

--- a/include/runtime/alloc.h
+++ b/include/runtime/alloc.h
@@ -37,6 +37,8 @@ void *kore_alloc_always_gc(size_t requested);
 // if the swapOld flag is set, it also swaps the two semispaces of the old
 // generation
 void kore_alloc_swap(bool swap_old);
+// resets the alwaysgcspace, freeing all memory allocated by it
+void kore_clear(void);
 // resizes the last allocation into the young generation
 void *kore_resize_last_alloc(void *oldptr, size_t newrequest, size_t last_size);
 // allocator hook for the GMP library

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -1156,6 +1156,7 @@ void make_step_function(
 
   init_choice_buffer(
       dt, module, block, pre_stuck, fail, &choice_buffer, &choice_depth, &jump);
+  insert_call_to_clear(block);
 
   llvm::AllocaInst *has_search_results = nullptr;
   if (search) {
@@ -1387,6 +1388,7 @@ void make_step_function(
   init_choice_buffer(
       res.dt, module, block, pre_stuck, fail, &choice_buffer, &choice_depth,
       &jump);
+  insert_call_to_clear(block);
 
   llvm::BranchInst::Create(stuck, pre_stuck);
   std::vector<llvm::PHINode *> phis;

--- a/lib/codegen/Util.cpp
+++ b/lib/codegen/Util.cpp
@@ -68,4 +68,13 @@ char const *get_collection_alloc_fn(sort_category cat) {
   }
 }
 
+void insert_call_to_clear(llvm::BasicBlock *block) {
+  llvm::Module *module = block->getParent()->getParent();
+  auto kore_clear = get_or_insert_function(
+      module, "kore_clear",
+      llvm::FunctionType::get(
+          llvm::Type::getVoidTy(module->getContext()), {}, false));
+  llvm::CallInst::Create(kore_clear, {}, "", block);
+}
+
 } // namespace kllvm

--- a/lib/codegen/Util.cpp
+++ b/lib/codegen/Util.cpp
@@ -69,12 +69,12 @@ char const *get_collection_alloc_fn(sort_category cat) {
 }
 
 void insert_call_to_clear(llvm::BasicBlock *bb) {
-  llvm::Module *module = block->getParent()->getParent();
+  llvm::Module *module = bb->getParent()->getParent();
   auto *kore_clear = get_or_insert_function(
       module, "kore_clear",
       llvm::FunctionType::get(
           llvm::Type::getVoidTy(module->getContext()), {}, false));
-  llvm::CallInst::Create(kore_clear, {}, "", block);
+  llvm::CallInst::Create(kore_clear, {}, "", bb);
 }
 
 } // namespace kllvm

--- a/lib/codegen/Util.cpp
+++ b/lib/codegen/Util.cpp
@@ -68,9 +68,9 @@ char const *get_collection_alloc_fn(sort_category cat) {
   }
 }
 
-void insert_call_to_clear(llvm::BasicBlock *block) {
+void insert_call_to_clear(llvm::BasicBlock *bb) {
   llvm::Module *module = block->getParent()->getParent();
-  auto kore_clear = get_or_insert_function(
+  auto *kore_clear = get_or_insert_function(
       module, "kore_clear",
       llvm::FunctionType::get(
           llvm::Type::getVoidTy(module->getContext()), {}, false));

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -58,10 +58,13 @@ bool youngspace_almost_full(size_t threshold) {
 
 void kore_alloc_swap(bool swap_old) {
   arena_swap_and_clear(&youngspace);
-  arena_clear(&alwaysgcspace);
   if (swap_old) {
     arena_swap_and_clear(&oldspace);
   }
+}
+
+void kore_clear() {
+  arena_clear(&alwaysgcspace);
 }
 
 void set_kore_memory_functions_for_gmp() {

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -354,6 +354,7 @@ void kore_collect(void **roots, uint8_t nroots, layoutitem *type_info) {
 
 void free_all_kore_mem() {
   kore_collect(nullptr, 0, nullptr);
+  kore_clear();
 }
 
 bool is_collection() {


### PR DESCRIPTION
This is one of a sequence of PRs designed to make progress towards generating stack maps so that we can trigger the GC during allocation rather than in between rewrite steps only. The first few PRs will be preliminaries that add small features that will be used by future PRs.

This PR separates koreCollect's logic for collecting the gc'd heap from its logic for resetting the alwaysgcspace arena. We separate the logic for resetting the alwaysgcspace arena into a new method, `kore_clear`. This function is no longer called by the garbage collector, but it is called after every rewrite step. This is a slight increase in overhead since we are clearing it more frequently, but the flip side is that it should have better locality which may improve the processor's dcache, since we are clearing it much more frequently. The clear itself is a very fast operation, only involving a few simple pointer operations.