### PR TITLE
Move simple CI jobs to latest Ubuntu version

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   formatting-check:
     name: Formatting Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Check that C and C++ code is correctly formatted
@@ -22,7 +22,7 @@ jobs:
 
   shell-check:
     name: Shell check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: ludeeus/action-shellcheck@2.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - runner: [self-hosted, linux, normal]
-            os: ubuntu-20.04
+            os: ubuntu-24.04
           - runner: MacM1
             os: self-macos-12
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
These jobs were previously running on an old version of Ubuntu, the image for which will be deprecated at some point. This PR just bumps them to use a newer version; the jobs aren't interacting with the OS in any meaningful way so this won't be a breaking change.