### PR TITLE
Revert "add libunwind as dependency (#1081)"

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -27,9 +27,8 @@ RUN     apt-get update                    \
           libfmt-dev                      \
           libgmp-dev                      \
           libmpfr-dev                     \
-          libjemalloc-dev                 \
-          libunwind-dev                   \
           libyaml-dev                     \
+          libjemalloc-dev                 \
           openjdk-${JDK_VERSION}-jdk      \
           curl                            \
           maven                           \

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -1,7 +1,7 @@
 FROM archlinux:base
 
 RUN pacman -Syyu --noconfirm && \
-    pacman -S --noconfirm base-devel git cmake clang llvm lld flex boost gmp mpfr jemalloc libunwind libyaml curl maven pkg-config python3
+    pacman -S --noconfirm base-devel git cmake clang llvm lld flex boost gmp mpfr libyaml jemalloc curl maven pkg-config python3
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,6 @@ sudo apt install      \
   libgmp-dev          \
   libjemalloc-dev     \
   libmpfr-dev         \
-  libunwind-dev       \
   libyaml-dev         \
   lld-15              \
   llvm-15-tools       \
@@ -41,7 +40,6 @@ brew install  \
   git         \
   gmp         \
   jemalloc    \
-  libunwind   \
   libyaml     \
   llvm@15     \
   maven       \

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -217,7 +217,7 @@ if [ "$main" = "static" ]; then
 elif [[ "$main" =~ "python" ]]; then
   # Don't link jemalloc when building a python library; it clashes with the
   # pymalloc implementation that Python expects you to use.
-  all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi" "-lunwind")
+  all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi")
   flags+=("-fPIC" "-shared" "-I${INCDIR}" "-fvisibility=hidden")
 
   read -r -a python_include_flags <<< "$("${python_cmd}" -m pybind11 --includes)"
@@ -239,11 +239,11 @@ elif [ "$main" = "c" ]; then
 
   # Avoid jemalloc for similar reasons as Python; we don't know who is loading
   # this library so don't want to impose it.
-  all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi" "-lunwind")
+  all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi")
   flags+=("-fPIC" "-shared" "$start_whole_archive" "$LIBDIR/libkllvmcruntime.a" "$end_whole_archive")
   clangpp_args+=("-o" "${output_file}")
 else
-  all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi" "-ljemalloc" "-lunwind")
+  all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi" "-ljemalloc")
 fi
 
 if $link; then

--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -1,5 +1,5 @@
 { lib, src, cmake, flex, fmt, pkg-config, llvm, libllvm, libcxx, stdenv, boost, gmp
-, jemalloc, libffi, libiconv, libunwind, libyaml, mpfr, ncurses, python310, unixtools,
+, jemalloc, libffi, libiconv, libyaml, mpfr, ncurses, python310, unixtools,
 # Runtime dependencies:
 host,
 # Options:
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake flex llvm pkg-config ];
   buildInputs = [ libyaml ];
   propagatedBuildInputs = [
-    boost fmt gmp libunwind jemalloc libffi mpfr ncurses python-env unixtools.xxd
+    boost fmt gmp jemalloc libffi mpfr ncurses python-env unixtools.xxd
   ] ++ lib.optional stdenv.isDarwin libiconv;
 
   dontStrip = true;
@@ -40,7 +40,6 @@ stdenv.mkDerivation {
       --replace '"-liconv"' '"-L${libiconv}/lib" "-liconv"' \
       --replace '"-lncurses"' '"-L${ncurses}/lib" "-lncurses"' \
       --replace '"-ltinfo"' '"-L${ncurses}/lib" "-ltinfo"' \
-      --replace '"-lunwind"' '"-L${libunwind}/lib" "-lunwind"' \
       --replace '"-L@BREW_PREFIX@/opt/libffi/lib"' ' ' \
       --replace '-L@BREW_PREFIX@/lib' '-L${libcxx}/lib' \
       --replace '-I "$(dirname "$0")"/../include/kllvm' \

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -12,7 +12,7 @@ let
   clang = llvmPackages.clangNoLibcxx;
 
   llvm-backend = prev.callPackage ./llvm-backend.nix {
-    inherit (llvmPackages) llvm libllvm libcxx libunwind;
+    inherit (llvmPackages) llvm libllvm libcxx;
     stdenv = llvmPackages.stdenv;
     cmakeBuildType = prev.llvm-backend-build-type;
     src = prev.llvm-backend-src;

--- a/package/debian/control.jammy
+++ b/package/debian/control.jammy
@@ -2,7 +2,7 @@ Source: k-llvm-backend
 Section: devel
 Priority: optional
 Maintainer: Bruce Collie <bruce.collie@runtimeverification.com>
-Build-Depends: clang-15 , cmake , debhelper (>=10) , flex , libboost-dev , libboost-test-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libunwind-dev , libyaml-dev , llvm-15-tools , pkg-config , python3 , python3-dev , xxd
+Build-Depends: clang-15 , cmake , debhelper (>=10) , flex , libboost-dev , libboost-test-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , llvm-15-tools , pkg-config , python3 , python3-dev , xxd
 Standards-Version: 3.9.6
 Homepage: https://github.com/runtimeverification/llvm-backend
 
@@ -10,7 +10,7 @@ Package: k-llvm-backend
 Architecture: any
 Section: devel
 Priority: optional
-Depends: clang-15 , flex , libboost-dev , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libunwind-dev , libyaml-0-2 , lld-15 , llvm-15 , pkg-config
+Depends: clang-15 , flex , libboost-dev , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , lld-15 , llvm-15 , pkg-config
 Description: K Framework LLVM backend
  Fast concrete execution backend for programming language semantics implemented using the K Framework.
 Homepage: https://github.com/runtimeverification/llvm-backend

--- a/package/debian/control.noble
+++ b/package/debian/control.noble
@@ -2,7 +2,7 @@ Source: k-llvm-backend
 Section: devel
 Priority: optional
 Maintainer: Bruce Collie <bruce.collie@runtimeverification.com>
-Build-Depends: clang-17 , cmake , debhelper (>=10) , flex , libboost-dev , libboost-test-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libunwind-dev , libyaml-dev , llvm-17-tools , pkg-config , python3 , python3-dev , xxd
+Build-Depends: clang-17 , cmake , debhelper (>=10) , flex , libboost-dev , libboost-test-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , llvm-17-tools , pkg-config , python3 , python3-dev , xxd
 Standards-Version: 3.9.6
 Homepage: https://github.com/runtimeverification/llvm-backend
 
@@ -10,7 +10,7 @@ Package: k-llvm-backend
 Architecture: any
 Section: devel
 Priority: optional
-Depends: clang-17 , flex , libboost-dev , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libunwind-dev , libyaml-0-2 , lld-17 , llvm-17 , pkg-config
+Depends: clang-17 , flex , libboost-dev , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , lld-17 , llvm-17 , pkg-config
 Description: K Framework LLVM backend
  Fast concrete execution backend for programming language semantics implemented using the K Framework.
 Homepage: https://github.com/runtimeverification/llvm-backend


### PR DESCRIPTION
This reverts commit d86e338b81987c3a332864555ef506703c511e34.

The PR breaks the K release: https://github.com/runtimeverification/k/actions/runs/9414468293/job/25935024808; I'll aim to get a macOS smoke test added that would have caught this before getting so far through the process.