### PR TITLE
llvm-kompile --profile-matching

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -40,7 +40,10 @@ Options:
   --mutable-bytes                   Use the faster, unsound (mutable) semantics for objects of sort
                                     Bytes at run time, rather than the slower, sound
                                     (immutable) that are enabled by default.
-  --hidden-visibility               Set the visibility of all global symbols in generated code to "hidden"
+  --hidden-visibility               Set the visibility of all global symbols in generated code to
+                                    "hidden"
+  --profile-matching                Instrument interpeter to emit a profile of time spent in
+                                    top-level rule matching on stderr.
   -O[0123]                          Set the optimization level for code generation.
 
 Any option not listed above will be passed through to clang; use '--' to
@@ -185,6 +188,10 @@ while [[ $# -gt 0 ]]; do
     --hidden-visibility)
       codegen_flags+=("--hidden-visibility")
       kompile_clang_flags+=("--hidden-visibility")
+      shift
+      ;;
+    --profile-matching)
+      codegen_flags+=("--profile-matching")
       shift
       ;;
     -O*)

--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -405,6 +405,7 @@ private:
   value_type cat_;
   llvm::PHINode *fail_subject_, *fail_pattern_, *fail_sort_;
   llvm::AllocaInst *has_search_results_;
+  bool profile_matching_;
 
   std::map<var_type, llvm::AllocaInst *> symbols_{};
 
@@ -422,7 +423,7 @@ public:
       llvm::AllocaInst *choice_buffer, llvm::AllocaInst *choice_depth,
       llvm::Module *module, value_type cat, llvm::PHINode *fail_subject,
       llvm::PHINode *fail_pattern, llvm::PHINode *fail_sort,
-      llvm::AllocaInst *has_search_results)
+      llvm::AllocaInst *has_search_results, bool profile_matching = false)
       : definition_(definition)
       , current_block_(entry_block)
       , failure_block_(failure_block)
@@ -435,7 +436,8 @@ public:
       , fail_subject_(fail_subject)
       , fail_pattern_(fail_pattern)
       , fail_sort_(fail_sort)
-      , has_search_results_(has_search_results) { }
+      , has_search_results_(has_search_results)
+      , profile_matching_(profile_matching) { }
 
   /* adds code to the specified basic block to take a single step based on
      the specified decision tree and return the result of taking that step. */
@@ -464,10 +466,10 @@ void make_anywhere_function(
 
 void make_step_function(
     kore_definition *definition, llvm::Module *module, decision_node *dt,
-    bool search);
+    bool search, bool profile_matching);
 void make_step_function(
     kore_axiom_declaration *axiom, kore_definition *definition,
-    llvm::Module *module, partial_step res);
+    llvm::Module *module, partial_step res, bool profile_matching);
 void make_match_reason_function(
     kore_definition *definition, llvm::Module *module,
     kore_axiom_declaration *axiom, decision_node *dt);

--- a/runtime/util/CMakeLists.txt
+++ b/runtime/util/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(util STATIC
   match_log.cpp
   search.cpp
   util.cpp
+  clock.cpp
 )
 
 install(

--- a/runtime/util/clock.cpp
+++ b/runtime/util/clock.cpp
@@ -1,0 +1,22 @@
+#include <cstdint>
+#include <ctime>
+#include <iostream>
+
+static struct timespec start { };
+
+extern "C" {
+void start_clock() {
+  clock_gettime(CLOCK_MONOTONIC, &start);
+}
+
+void stop_clock(uint64_t ordinal) {
+  struct timespec stop { };
+  clock_gettime(CLOCK_MONOTONIC, &stop);
+  int64_t diff_s = stop.tv_sec - start.tv_sec;
+  int64_t diff_ns = stop.tv_nsec - start.tv_nsec;
+
+  uint64_t diff_ns_total = diff_s * 1000000000 + diff_ns;
+
+  std::cerr << ordinal << " " << diff_ns_total << std::endl;
+}
+}

--- a/scripts/matching-profile/join-with-locations
+++ b/scripts/matching-profile/join-with-locations
@@ -1,0 +1,5 @@
+#!/bin/bash
+while read -r ordinal time; do
+  loc=$(llvm-kompile-compute-loc "$2" $ordinal)
+  echo "${loc##*/} $time"
+done < "$1"

--- a/scripts/matching-profile/join-with-locations
+++ b/scripts/matching-profile/join-with-locations
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Converts a table of ordinals and seconds to a table of source/location and seconds. Strips directory from file paths.
 while read -r ordinal time; do
   loc=$(llvm-kompile-compute-loc "$2" $ordinal)
   echo "${loc##*/} $time"

--- a/scripts/matching-profile/matching-profile-formatter
+++ b/scripts/matching-profile/matching-profile-formatter
@@ -1,0 +1,3 @@
+#!/bin/bash
+sum=$(cat "$1" | awk '{sum += $2} END { print sum }')
+tac "$1" | awk '{perc_local=$2 / '"$sum"' * 100; perc += perc_local; print $1 " " $2 " " perc_local " " perc}'

--- a/scripts/matching-profile/matching-profile-formatter
+++ b/scripts/matching-profile/matching-profile-formatter
@@ -1,3 +1,4 @@
 #!/bin/bash
+# Sorts table of locations and seconds in reverse order and displays it with individual and cumulative percentages.
 sum=$(cat "$1" | awk '{sum += $2} END { print sum }')
 tac "$1" | awk '{perc_local=$2 / '"$sum"' * 100; perc += perc_local; print $1 " " $2 " " perc_local " " perc}'

--- a/scripts/matching-profile/sum-matching-profile
+++ b/scripts/matching-profile/sum-matching-profile
@@ -1,3 +1,3 @@
 #!/bin/bash
-# aggregates data from --profile-matching and sums together identical ordinals, yielding table with ordinals and seconds
+# Aggregates data from --profile-matching and sums together identical ordinals, yielding table with ordinals and seconds.
 cat "$1" | awk '{sum[$1] += $2} END { for (i in sum) print i, sum[i]}' | sort -n -k2 | awk '{ print $1, $2 / 1000000000}'

--- a/scripts/matching-profile/sum-matching-profile
+++ b/scripts/matching-profile/sum-matching-profile
@@ -1,0 +1,3 @@
+#!/bin/bash
+# aggregates data from --profile-matching and sums together identical ordinals, yielding table with ordinals and seconds
+cat "$1" | awk '{sum[$1] += $2} END { for (i in sum) print i, sum[i]}' | sort -n -k2 | awk '{ print $1, $2 / 1000000000}'

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -78,6 +78,12 @@ cl::opt<bool> safe_partial(
              "exception."),
     cl::init(false), cl::cat(codegen_tool_cat));
 
+cl::opt<bool> profile_matching(
+    "profile-matching",
+    cl::desc("Instrument k_step functions with code to profile time spent "
+             "matching when applying each rule."),
+    cl::init(false), cl::cat(codegen_tool_cat));
+
 namespace {
 
 fs::path dt_dir() {
@@ -174,7 +180,8 @@ int main(int argc, char **argv) {
             definition->get_hooked_sorts());
         make_apply_rule_function(
             axiom, definition.get(), mod.get(), residuals.residuals);
-        make_step_function(axiom, definition.get(), mod.get(), residuals);
+        make_step_function(
+            axiom, definition.get(), mod.get(), residuals, profile_matching);
       } else {
         make_apply_rule_function(axiom, definition.get(), mod.get(), true);
       }
@@ -195,11 +202,11 @@ int main(int argc, char **argv) {
   auto *dt = parse_yamldecision_tree(
       mod.get(), decision_tree, definition->get_all_symbols(),
       definition->get_hooked_sorts());
-  make_step_function(definition.get(), mod.get(), dt, false);
+  make_step_function(definition.get(), mod.get(), dt, false, profile_matching);
   auto *dt_search = parse_yamldecision_tree(
       mod.get(), dt_dir() / "dt-search.yaml", definition->get_all_symbols(),
       definition->get_hooked_sorts());
-  make_step_function(definition.get(), mod.get(), dt_search, true);
+  make_step_function(definition.get(), mod.get(), dt_search, true, false);
 
   auto index = read_index_file();
   for (auto const &entry : definition->get_symbols()) {


### PR DESCRIPTION
We add a new flag to `llvm-kompile` which, when enabled, instruments the `k_step` function and the optimized `step_<ordinal>` functions with calls to a new translation unit, clock.cpp, which contains some very basic use of `clock_gettime` in order to determine how much time is being spent doing pattern matching in order to try to apply each rewrite step. The resulting file contains data about the ordinal of the rule that applied and the time it took to determine that that rule should apply. It emits this data on stderr in a tabular format that can be read easily by a computer. This information is useful in determining how to optimize pattern matching in cases where it is still not clear where time is being spent even after `kompile -O3 --iterated-threshold 1` is passed. When the flag is not passed to the code generator, no instrumentation is emitted, meaning this is zero-overhead unless it is enabled.