### PR TITLE
.gitmodules: Change pybind11 URL from relative to absolute

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/Tencent/rapidjson
 [submodule "deps/pybind11"]
 	path = deps/pybind11
-	url = ../../pybind/pybind11
+	url = https://github.com/pybind/pybind11
 	branch = stable
 [submodule "deps/fmt"]
 	path = deps/fmt


### PR DESCRIPTION
All the other URLs are absolute, so logically this one should match. Additionally, the relative URL will break if someone's main remote is not on GitHub.