### PR TITLE
Fixes for MInts

### DIFF
--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -1313,8 +1313,13 @@ static void emit_return_sort_table(kore_definition *def, llvm::Module *mod) {
     auto *char_type = llvm::Type::getInt8Ty(ctx);
     auto *str_type = llvm::ArrayType::get(char_type, sort_str.size() + 1);
 
+    auto *str = llvm::ConstantDataArray::getString(ctx, sort_str, true);
     auto *sort_name
         = module->getOrInsertGlobal("sort_name_" + sort_str, str_type);
+    auto *global_var = llvm::cast<llvm::GlobalVariable>(sort_name);
+    if (!global_var->hasInitializer()) {
+      global_var->setInitializer(str);
+    }
 
     auto *i64_type = llvm::Type::getInt64Ty(ctx);
     auto *zero = llvm::ConstantInt::get(i64_type, 0);

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -207,6 +207,9 @@ static void emit_data_for_symbol(
     if (is_eval && !is_func) {
       continue;
     }
+    if (is_eval && !symbol->get_sort()->is_concrete()) {
+      continue;
+    }
     auto *case_block
         = llvm::BasicBlock::Create(ctx, "tag" + std::to_string(tag), func);
     auto *branch = llvm::BranchInst::Create(merge_block, case_block);

--- a/test/defn/mint.kore
+++ b/test/defn/mint.kore
@@ -1,0 +1,2582 @@
+// RUN: %interpreter
+// RUN: %run | diff - %test-diff-out
+// RUN: %run-binary | diff - %test-diff-out
+// RUN: %run-binary-out | diff - <(echo -n)
+[topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/test.k)")]
+
+module BASIC-K
+    sort SortK{} []
+    sort SortKItem{} []
+endmodule
+[]
+module KSEQ
+    import BASIC-K []
+    symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol dotk{}() : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol append{}(SortK{}, SortK{}) : SortK{} [function{}(), functional{}()]
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, dotk{}()),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                TAIL:SortK{},
+                \top{SortK{}}()
+            )
+        )
+    ) []
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, kseq{}(K:SortKItem{}, KS:SortK{})),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                kseq{}(K:SortKItem{}, append{}(KS:SortK{}, TAIL:SortK{})),
+                \top{SortK{}}()
+            )
+        )
+    ) []
+endmodule
+[]
+module INJ
+    symbol inj{From, To}(From) : To [sortInjection{}()]
+    axiom {S1, S2, S3, R} \equals{S3, R}(inj{S2, S3}(inj{S1, S2}(T:S1)), inj{S1, S3}(T:S1)) [simplification{}()]
+endmodule
+[]
+module K
+    import KSEQ []
+    import INJ []
+    alias weakExistsFinally{A}(A) : A where weakExistsFinally{A}(@X:A) := @X:A []
+    alias weakAlwaysFinally{A}(A) : A where weakAlwaysFinally{A}(@X:A) := @X:A []
+    alias allPathGlobally{A}(A) : A where allPathGlobally{A}(@X:A) := @X:A []
+endmodule
+[]
+
+module TEST
+
+// imports
+  import K []
+
+// sorts
+  sort SortKCellOpt{} []
+  sort Sort32{} [nat{}("32")]
+  sort SortKCell{} []
+  hooked-sort SortMap{} [concat{}(Lbl'Unds'Map'Unds'{}()), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(218,3,218,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Map{}())]
+  sort SortGeneratedCounterCellOpt{} []
+  sort SortKConfigVar{} [hasDomainValues{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(40,3,40,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/kast.md)"), token{}()]
+  hooked-sort SortInt{} [hasDomainValues{}(), hook{}("INT.Int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1198,3,1198,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-sort SortSet{} [concat{}(Lbl'Unds'Set'Unds'{}()), element{}(LblSetItem{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(700,3,700,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Set{}())]
+  hooked-sort SortBool{} [hasDomainValues{}(), hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1077,3,1077,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-sort SortMInt{SortS0} [hasDomainValues{}(), hook{}("MINT.MInt")]
+  sort SortGeneratedTopCellFragment{} []
+  hooked-sort SortList{} [concat{}(Lbl'Unds'List'Unds'{}()), element{}(LblListItem{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(913,3,913,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'List{}())]
+  sort SortGeneratedTopCell{} []
+  sort SortGeneratedCounterCell{} []
+  sort Sort64{} [nat{}("64")]
+
+// symbols
+  hooked-symbol Lbl--MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.neg"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2951,34,2951,108)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvuminus"), total{}()]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [function{}(), functional{}(), hook{}("LIST.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(937,19,937,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("smt_seq_nil"), symbol'Kywd'{}(".List"), total{}()]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [function{}(), functional{}(), hook{}("MAP.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(248,18,248,96)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(".Map"), total{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [function{}(), functional{}(), hook{}("SET.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(729,18,729,90)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(".Set"), total{}()]
+  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [cell{}(), constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortKCell{}, SortGeneratedCounterCell{}) : SortGeneratedTopCell{} [cell{}(), constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortKCellOpt{}, SortGeneratedCounterCellOpt{}) : SortGeneratedTopCellFragment{} [constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [cell{}(), constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(527,17,527,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/kast.md)")]
+  hooked-symbol LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{SortWidth}(SortInt{}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.integer"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2886,34,2886,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("int2bv"), total{}()]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [function{}(), hook{}("LIST.get"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(965,20,965,91)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("List:get")]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [function{}(), hook{}("LIST.range"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1012,19,1012,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("List:range")]
+  hooked-symbol LblList'Coln'set{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [function{}(), hook{}("LIST.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(974,19,974,108)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("List:set")]
+  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [function{}(), functional{}(), hook{}("LIST.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(945,19,945,124)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("smt_seq_elem"), symbol'Kywd'{}("ListItem"), total{}()]
+  hooked-symbol LblMInt2Signed'LParUndsRParUnds'MINT'Unds'Int'Unds'MInt{SortWidth}(SortMInt{SortWidth}) : SortInt{} [function{}(), functional{}(), hook{}("MINT.svalue"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2883,26,2883,91)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblMInt2Unsigned'LParUndsRParUnds'MINT'Unds'Int'Unds'MInt{SortWidth}(SortMInt{SortWidth}) : SortInt{} [function{}(), functional{}(), hook{}("MINT.uvalue"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2884,26,2884,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bv2int"), total{}()]
+  hooked-symbol LblMap'Coln'choice{}(SortMap{}) : SortKItem{} [function{}(), hook{}("MAP.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,20,393,101)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Map:choice")]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [function{}(), hook{}("MAP.lookup"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(271,20,271,105)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Map:lookup")]
+  hooked-symbol LblMap'Coln'lookupOrDefault{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [function{}(), functional{}(), hook{}("MAP.lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(281,20,281,134)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Map:lookupOrDefault"), total{}()]
+  hooked-symbol LblMap'Coln'update{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,18,290,132)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Map:update"), total{}()]
+  hooked-symbol LblSet'Coln'choice{}(SortSet{}) : SortKItem{} [function{}(), hook{}("SET.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(804,20,804,95)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Set:choice")]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [function{}(), functional{}(), hook{}("SET.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(769,18,769,106)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Set:difference"), total{}()]
+  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [function{}(), functional{}(), hook{}("SET.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(777,19,777,94)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Set:in"), total{}()]
+  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [function{}(), functional{}(), hook{}("SET.element"), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(737,18,737,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("SetItem"), total{}()]
+  hooked-symbol Lbl'UndsPerc'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.tmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1246,18,1246,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("mod"), symbol'Kywd'{}("_%Int_")]
+  hooked-symbol Lbl'UndsPerc'sMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.srem"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2955,34,2955,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvsrem")]
+  hooked-symbol Lbl'UndsPerc'uMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.urem"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2957,34,2957,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvurem")]
+  hooked-symbol Lbl'UndsAnd-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1257,18,1257,125)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("andInt"), symbol'Kywd'{}("_&Int_"), total{}()]
+  hooked-symbol Lbl'UndsAnd-'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2966,34,2966,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvand"), total{}()]
+  hooked-symbol Lbl'UndsStar'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.mul"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1242,18,1242,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("*"), symbol'Kywd'{}("_*Int_"), total{}()]
+  hooked-symbol Lbl'UndsStar'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.mul"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2953,34,2953,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvmul"), total{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.add"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1251,18,1251,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("+"), symbol'Kywd'{}("_+Int_"), total{}()]
+  hooked-symbol Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.add"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2959,34,2959,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvadd"), total{}()]
+  hooked-symbol Lbl'Unds'-Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.sub"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1252,18,1252,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("-"), symbol'Kywd'{}("_-Int_"), total{}()]
+  hooked-symbol Lbl'Unds'-MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.sub"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2960,34,2960,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvsub"), total{}()]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,18,311,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'UndsSlsh'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.tdiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1245,18,1245,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("div"), symbol'Kywd'{}("_/Int_")]
+  hooked-symbol Lbl'UndsSlsh'sMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.sdiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2954,34,2954,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvsdiv")]
+  hooked-symbol Lbl'UndsSlsh'uMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.udiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2956,34,2956,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvudiv")]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.shl"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1255,18,1255,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("shlInt"), symbol'Kywd'{}("_<<Int_")]
+  hooked-symbol Lbl'Unds-LT--LT-'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.shl"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2962,34,2962,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvshl")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1313,19,1313,105)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("<="), symbol'Kywd'{}("_<=Int_"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [function{}(), functional{}(), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,19,383,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [function{}(), functional{}(), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(786,19,786,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.sle"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2983,27,2983,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvsle"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.ule"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2984,27,2984,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvule"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1314,19,1314,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("<"), symbol'Kywd'{}("_<Int_"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.slt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2981,27,2981,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvslt"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.ult"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2982,27,2982,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvult"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1118,19,1118,126)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("distinct"), symbol'Kywd'{}("_=/=Bool_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1318,19,1318,118)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("distinct"), symbol'Kywd'{}("_=/=Int_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [function{}(), functional{}(), hook{}("KEQUAL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2287,19,2287,138)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("distinct"), symbol'Kywd'{}("_=/=K_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'MInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2990,27,2990,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("distinct"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1117,19,1117,118)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("="), symbol'Kywd'{}("_==Bool_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1317,19,1317,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("="), symbol'Kywd'{}("_==Int_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [function{}(), functional{}(), hook{}("KEQUAL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2286,19,2286,127)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("="), symbol'Kywd'{}("_==K_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'MInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2989,27,2989,105)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("="), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1315,19,1315,105)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}(">="), symbol'Kywd'{}("_>=Int_"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.sge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2987,27,2987,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvsge"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.uge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2988,27,2988,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvuge"), total{}()]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.shr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1254,18,1254,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("shrInt"), symbol'Kywd'{}("_>>Int_")]
+  hooked-symbol Lbl'Unds-GT--GT-'aMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.ashr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2963,34,2963,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvashr")]
+  hooked-symbol Lbl'Unds-GT--GT-'lMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.lshr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2964,34,2964,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvlshr")]
+  hooked-symbol Lbl'Unds-GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1316,19,1316,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}(">"), symbol'Kywd'{}("_>Int_"), total{}()]
+  hooked-symbol Lbl'Unds-GT-'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.sgt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2985,27,2985,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvsgt"), total{}()]
+  hooked-symbol Lbl'Unds-GT-'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.ugt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2986,27,2986,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvugt"), total{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [element{}(LblListItem{}()), function{}(), functional{}(), hook{}("LIST.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(929,19,929,180)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("smt_seq_concat"), symbol'Kywd'{}("_List_"), total{}(), unit{}(Lbl'Stop'List{}())]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), function{}(), hook{}("MAP.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,18,240,165)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_Map_"), unit{}(Lbl'Stop'Map{}())]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [element{}(LblSetItem{}()), function{}(), hook{}("SET.concat"), idem{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(721,18,721,157)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_Set_"), unit{}(Lbl'Stop'Set{}())]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(299,18,299,109)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_[_<-undef]"), total{}()]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUnds'{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.powmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1240,18,1240,131)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(mod (^ #1 #2) #3)"), symbol'Kywd'{}("_^%Int__")]
+  hooked-symbol Lbl'UndsXor-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.pow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1239,18,1239,109)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("^"), symbol'Kywd'{}("_^Int_")]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1110,19,1110,138)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("and"), symbol'Kywd'{}("_andBool_"), total{}()]
+  hooked-symbol Lbl'Unds'andThenBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.andThen"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1111,19,1111,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("and"), symbol'Kywd'{}("_andThenBool_"), total{}()]
+  hooked-symbol Lbl'Unds'divInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.ediv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1248,18,1248,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("div"), symbol'Kywd'{}("_divInt_")]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1327,19,1327,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Unds'impliesBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.implies"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1115,19,1115,145)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("=>"), symbol'Kywd'{}("_impliesBool_"), total{}()]
+  hooked-symbol Lbl'Unds'inList'Unds'{}(SortKItem{}, SortList{}) : SortBool{} [function{}(), functional{}(), hook{}("LIST.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1021,19,1021,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_inList_"), total{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [function{}(), functional{}(), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(357,19,357,89)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds'modInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.emod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1249,18,1249,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("mod"), symbol'Kywd'{}("_modInt_")]
+  hooked-symbol Lbl'Unds'orBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1113,19,1113,135)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("or"), symbol'Kywd'{}("_orBool_"), total{}()]
+  hooked-symbol Lbl'Unds'orElseBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.orElse"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1114,19,1114,143)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("or"), symbol'Kywd'{}("_orElseBool_"), total{}()]
+  hooked-symbol Lbl'Unds'xorBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1112,19,1112,138)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("xor"), symbol'Kywd'{}("_xorBool_"), total{}()]
+  hooked-symbol Lbl'Unds'xorInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1259,18,1259,127)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("xorInt"), symbol'Kywd'{}("_xorInt_"), total{}()]
+  hooked-symbol Lbl'Unds'xorMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2968,34,2968,118)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvxor"), total{}()]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.element"), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(257,18,257,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_|->_"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1261,18,1261,123)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("orInt"), symbol'Kywd'{}("_|Int_"), total{}()]
+  hooked-symbol Lbl'UndsPipe'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2970,34,2970,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvor"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [function{}(), functional{}(), hook{}("SET.union"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(748,18,748,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.abs"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1278,18,1278,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (< #1 0) (- 0 #1) #1)"), total{}()]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.bitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1303,18,1303,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblbitwidthMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'MInt{SortWidth}(SortMInt{SortWidth}) : SortInt{} [function{}(), functional{}(), hook{}("MINT.bitwidth"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2866,26,2866,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [function{}(), hook{}("LIST.fill"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1002,19,1002,100)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [freshGenerator{}(), function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1441,18,1441,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol LblgetGeneratedCounterCell{}(SortGeneratedTopCell{}) : SortGeneratedCounterCell{} [function{}()]
+  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [function{}(), functional{}(), total{}()]
+  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [function{}()]
+  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [function{}()]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [function{}(), functional{}(), hook{}("SET.intersection"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(759,18,759,90)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol Lblis32{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol Lblis64{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisBool{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisInt{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisK{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisList{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisMInt'LBra'32'RBra'{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisMInt'LBra'64'RBra'{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisMap{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  hooked-symbol Lblite{SortSort}(SortBool{}, SortSort, SortSort) : SortSort [function{}(), functional{}(), hook{}("KEQUAL.ite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2291,26,2291,132)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("ite"), symbol'Kywd'{}("ite"), total{}()]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(SortMap{}) : SortSet{} [function{}(), functional{}(), hook{}("MAP.keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,18,341,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [function{}(), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,19,349,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), hook{}("INT.log2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1289,18,1289,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lblm32'LParRParUnds'TEST'Unds'MInt{}() : SortMInt{Sort32{}} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(8,23,8,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/test.k)")]
+  symbol Lblm64'LParRParUnds'TEST'Unds'MInt{}() : SortMInt{Sort64{}} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,23,9,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/test.k)")]
+  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'Unds'List'Unds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [function{}(), hook{}("LIST.make"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(983,19,983,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.max"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1270,18,1270,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (< #1 #2) #2 #1)"), total{}()]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.min"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1269,18,1269,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (< #1 #2) #1 #2)"), total{}()]
+  symbol LblnoGeneratedCounterCell{}() : SortGeneratedCounterCellOpt{} [constructor{}(), functional{}(), injective{}()]
+  symbol LblnoKCell{}() : SortKCellOpt{} [constructor{}(), functional{}(), injective{}()]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1109,19,1109,131)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("not"), symbol'Kywd'{}("notBool_"), total{}()]
+  symbol Lblproject'Coln'Bool{}(SortK{}) : SortBool{} [function{}()]
+  symbol Lblproject'Coln'GeneratedCounterCell{}(SortK{}) : SortGeneratedCounterCell{} [function{}()]
+  symbol Lblproject'Coln'GeneratedCounterCellOpt{}(SortK{}) : SortGeneratedCounterCellOpt{} [function{}()]
+  symbol Lblproject'Coln'GeneratedTopCell{}(SortK{}) : SortGeneratedTopCell{} [function{}()]
+  symbol Lblproject'Coln'GeneratedTopCellFragment{}(SortK{}) : SortGeneratedTopCellFragment{} [function{}()]
+  symbol Lblproject'Coln'Int{}(SortK{}) : SortInt{} [function{}()]
+  symbol Lblproject'Coln'K{}(SortK{}) : SortK{} [function{}()]
+  symbol Lblproject'Coln'KCell{}(SortK{}) : SortKCell{} [function{}()]
+  symbol Lblproject'Coln'KCellOpt{}(SortK{}) : SortKCellOpt{} [function{}()]
+  symbol Lblproject'Coln'KItem{}(SortK{}) : SortKItem{} [function{}()]
+  symbol Lblproject'Coln'List{}(SortK{}) : SortList{} [function{}()]
+  symbol Lblproject'Coln'MInt'LBra'32'RBra'{}(SortK{}) : SortMInt{Sort32{}} [function{}()]
+  symbol Lblproject'Coln'MInt'LBra'64'RBra'{}(SortK{}) : SortMInt{Sort64{}} [function{}()]
+  symbol Lblproject'Coln'Map{}(SortK{}) : SortMap{} [function{}()]
+  symbol Lblproject'Coln'Set{}(SortK{}) : SortSet{} [function{}()]
+  hooked-symbol LblpushList{}(SortKItem{}, SortList{}) : SortList{} [function{}(), functional{}(), hook{}("LIST.push"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(953,19,953,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("pushList"), total{}()]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), hook{}("INT.rand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1337,18,1337,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.removeAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,18,333,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblroundMInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'MInt{SortWidth1, SortWidth2}(SortMInt{SortWidth2}) : SortMInt{SortWidth1} [function{}(), functional{}(), hook{}("MINT.round"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3015,44,3015,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblsMaxMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.smax"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3000,34,3000,140)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (bvslt #1 #2) #2 #1)"), total{}()]
+  hooked-symbol LblsMinMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.smin"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3001,34,3001,140)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (bvslt #1 #2) #1 #2)"), total{}()]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.signExtendBitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1304,18,1304,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(SortSet{}) : SortInt{} [function{}(), functional{}(), hook{}("SET.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(794,18,794,76)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblsizeList{}(SortList{}) : SortInt{} [function{}(), functional{}(), hook{}("LIST.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1029,18,1029,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("smt_seq_len"), symbol'Kywd'{}("sizeList"), total{}()]
+  hooked-symbol LblsizeMap{}(SortMap{}) : SortInt{} [function{}(), functional{}(), hook{}("MAP.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(373,18,373,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("sizeMap"), total{}()]
+  symbol LblsmaxMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2897,18,2897,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblsminMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2896,18,2896,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblsoverflowMInt'LParUndsCommUndsRParUnds'MINT'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2913,19,2913,62)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT-COMMON'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [function{}(), hook{}("INT.srand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1338,16,1338,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LbluMaxMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.umax"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3002,34,3002,140)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (bvult #1 #2) #2 #1)"), total{}()]
+  hooked-symbol LbluMinMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.umin"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3003,34,3003,140)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (bvult #1 #2) #1 #2)"), total{}()]
+  symbol LblumaxMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2899,18,2899,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LbluminMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2898,18,2898,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LbluoverflowMInt'LParUndsCommUndsRParUnds'MINT'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2914,19,2914,62)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [function{}(), hook{}("LIST.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(993,19,993,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(324,18,324,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [function{}(), hook{}("MAP.values"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(365,19,365,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Tild'Int'Unds'{}(SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1237,18,1237,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("notInt"), symbol'Kywd'{}("~Int_"), total{}()]
+  hooked-symbol Lbl'Tild'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2950,34,2950,104)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvnot"), total{}()]
+
+// generated axioms
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCellOpt{}, SortKItem{}} (From:SortKCellOpt{}))) [subsort{SortKCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, inj{SortKCell{}, SortKCellOpt{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMap{}, SortKItem{}} (From:SortMap{}))) [subsort{SortMap{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCell{}, SortKItem{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSet{}, SortKItem{}} (From:SortSet{}))) [subsort{SortSet{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (From:SortGeneratedCounterCellOpt{}))) [subsort{SortGeneratedCounterCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortList{}, SortKItem{}} (From:SortList{}))) [subsort{SortList{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCell{}, SortKItem{}} (From:SortGeneratedTopCell{}))) [subsort{SortGeneratedTopCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBool{}, SortKItem{}} (From:SortBool{}))) [subsort{SortBool{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMInt{Sort32{}}, SortKItem{}} (From:SortMInt{Sort32{}}))) [subsort{SortMInt{Sort32{}}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (From:SortGeneratedTopCellFragment{}))) [subsort{SortGeneratedTopCellFragment{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMInt{Sort64{}}, SortKItem{}} (From:SortMInt{Sort64{}}))) [subsort{SortMInt{Sort64{}}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKConfigVar{}, SortKItem{}} (From:SortKConfigVar{}))) [subsort{SortKConfigVar{}, SortKItem{}}()] // subsort
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl--MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Stop'Set{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, Lbl'-LT-'generatedCounter'-GT-'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedCounterCell{}} (\and{SortGeneratedCounterCell{}} (Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{}), Lbl'-LT-'generatedCounter'-GT-'{}(Y0:SortInt{})), Lbl'-LT-'generatedCounter'-GT-'{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCell{}, \equals{SortGeneratedTopCell{}, R} (Val:SortGeneratedTopCell{}, Lbl'-LT-'generatedTop'-GT-'{}(K0:SortKCell{}, K1:SortGeneratedCounterCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCell{}} (\and{SortGeneratedTopCell{}} (Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}), Lbl'-LT-'generatedTop'-GT-'{}(Y0:SortKCell{}, Y1:SortGeneratedCounterCell{})), Lbl'-LT-'generatedTop'-GT-'{}(\and{SortKCell{}} (X0:SortKCell{}, Y0:SortKCell{}), \and{SortGeneratedCounterCell{}} (X1:SortGeneratedCounterCell{}, Y1:SortGeneratedCounterCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCellFragment{}, \equals{SortGeneratedTopCellFragment{}, R} (Val:SortGeneratedTopCellFragment{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(K0:SortKCellOpt{}, K1:SortGeneratedCounterCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCellFragment{}} (\and{SortGeneratedTopCellFragment{}} (Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}), Lbl'-LT-'generatedTop'-GT-'-fragment{}(Y0:SortKCellOpt{}, Y1:SortGeneratedCounterCellOpt{})), Lbl'-LT-'generatedTop'-GT-'-fragment{}(\and{SortKCellOpt{}} (X0:SortKCellOpt{}, Y0:SortKCellOpt{}), \and{SortGeneratedCounterCellOpt{}} (X1:SortGeneratedCounterCellOpt{}, Y1:SortGeneratedCounterCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, Lbl'-LT-'k'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{SortWidth}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblMInt2Signed'LParUndsRParUnds'MINT'Unds'Int'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblMInt2Unsigned'LParUndsRParUnds'MINT'Unds'Int'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, LblMap'Coln'lookupOrDefault{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblMap'Coln'update{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortKItem{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'UndsAnd-'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'UndsStar'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'Unds'-MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'MInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'MInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:SortList{},K2:SortList{}),K3:SortList{}),Lbl'Unds'List'Unds'{}(K1:SortList{},Lbl'Unds'List'Unds'{}(K2:SortList{},K3:SortList{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(K:SortList{},Lbl'Stop'List{}()),K:SortList{}) [unit{}()] // right unit
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Stop'List{}(),K:SortList{}),K:SortList{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K:SortMap{},Lbl'Stop'Map{}()),K:SortMap{}) [unit{}()] // right unit
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),K:SortMap{}),K:SortMap{}) [unit{}()] // left unit
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},Lbl'Stop'Set{}()),K:SortSet{}) [unit{}()] // right unit
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Stop'Set{}(),K:SortSet{}),K:SortSet{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'inList'Unds'{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(K0:SortKItem{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'Unds'xorMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortKItem{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'UndsPipe'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblbitwidthMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, LblinitGeneratedCounterCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lblis32{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lblis64{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBool{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCellFragment{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKConfigVar{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisList{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMInt'LBra'32'RBra'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMInt'LBra'64'RBra'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMap{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisSet{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R, SortSort} \exists{R} (Val:SortSort, \equals{SortSort, R} (Val:SortSort, Lblite{SortSort}(K0:SortBool{}, K1:SortSort, K2:SortSort))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, LblnoGeneratedCounterCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, LblnoKCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblpushList{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R, SortWidth1, SortWidth2} \exists{R} (Val:SortMInt{SortWidth1}, \equals{SortMInt{SortWidth1}, R} (Val:SortMInt{SortWidth1}, LblroundMInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'MInt{SortWidth1, SortWidth2}(K0:SortMInt{SortWidth2}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, LblsMaxMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, LblsMinMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblsizeList{}(K0:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblsizeMap{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, LbluMaxMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, LbluMinMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'Unds'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'Tild'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCellOpt{}} (LblnoGeneratedCounterCell{}(), \exists{SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{})), \bottom{SortGeneratedCounterCellOpt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCell{}} (\exists{SortGeneratedTopCell{}} (X0:SortKCell{}, \exists{SortGeneratedTopCell{}} (X1:SortGeneratedCounterCell{}, Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}))), \bottom{SortGeneratedTopCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCellFragment{}} (\exists{SortGeneratedTopCellFragment{}} (X0:SortKCellOpt{}, \exists{SortGeneratedTopCellFragment{}} (X1:SortGeneratedCounterCellOpt{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}))), \bottom{SortGeneratedTopCellFragment{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKCellOpt{}} (LblnoKCell{}(), \exists{SortKCellOpt{}} (Val:SortKCell{}, inj{SortKCell{}, SortKCellOpt{}} (Val:SortKCell{})), \bottom{SortKCellOpt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \exists{SortKItem{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (Val:SortGeneratedCounterCell{})), \exists{SortKItem{}} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (Val:SortGeneratedCounterCellOpt{})), \exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \exists{SortKItem{}} (Val:SortKConfigVar{}, inj{SortKConfigVar{}, SortKItem{}} (Val:SortKConfigVar{})), \exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \exists{SortKItem{}} (Val:SortMInt{Sort32{}}, inj{SortMInt{Sort32{}}, SortKItem{}} (Val:SortMInt{Sort32{}})), \exists{SortKItem{}} (Val:SortMInt{Sort64{}}, inj{SortMInt{Sort64{}}, SortKItem{}} (Val:SortMInt{Sort64{}})), \exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \bottom{SortKItem{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortMInt{Sort32{}}} (\top{SortMInt{Sort32{}}}(), \bottom{SortMInt{Sort32{}}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortMInt{Sort64{}}} (\top{SortMInt{Sort64{}}}(), \bottom{SortMInt{Sort64{}}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+
+// rules
+// rule `_=/=Bool_`(B1,B2)=>`notBool_`(`_==Bool_`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f), org.kframework.attributes.Location(Location(1159,8,1159,57)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB1:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB2:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(VarB1:SortBool{},VarB2:SortBool{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1159,8,1159,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_=/=Int_`(I1,I2)=>`notBool_`(`_==Int_`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3), org.kframework.attributes.Location(Location(1438,8,1438,53)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Int'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1438,8,1438,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c), org.kframework.attributes.Location(Location(2316,8,2316,45)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarK2:SortK{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2316,8,2316,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_andBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497), org.kframework.attributes.Location(Location(1132,8,1132,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1132,8,1132,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(72139ee1f2b9362a47514de6503329ccf3c27e74e3ebfa0c0fe26321ec13f281), org.kframework.attributes.Location(Location(1131,8,1131,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("72139ee1f2b9362a47514de6503329ccf3c27e74e3ebfa0c0fe26321ec13f281"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1131,8,1131,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_andBool_`(_Gen0,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd61c826168aab115cd7f528702e8187ca16195bdcf29f42f33a32c83afebb12), org.kframework.attributes.Location(Location(1133,8,1133,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fd61c826168aab115cd7f528702e8187ca16195bdcf29f42f33a32c83afebb12"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1133,8,1133,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f), org.kframework.attributes.Location(Location(1130,8,1130,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1130,8,1130,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_andThenBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d), org.kframework.attributes.Location(Location(1137,8,1137,36)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1137,8,1137,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_andThenBool_`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2cfb33affb9c668d39a4a7267156085e1dbd3584fc7925b1aa9a1672bb9eab9f), org.kframework.attributes.Location(Location(1136,8,1136,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(VarK:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2cfb33affb9c668d39a4a7267156085e1dbd3584fc7925b1aa9a1672bb9eab9f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1136,8,1136,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_andThenBool_`(_Gen0,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(198861009d03d8f5220000f16342962720be289ca0d49b12953fb2693e2fea01), org.kframework.attributes.Location(Location(1138,8,1138,36)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("198861009d03d8f5220000f16342962720be289ca0d49b12953fb2693e2fea01"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1138,8,1138,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_andThenBool_`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689), org.kframework.attributes.Location(Location(1135,8,1135,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1135,8,1135,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_divInt_`(I1,I2)=>`_/Int_`(`_-Int_`(I1,`_modInt_`(I1,I2)),I2) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4), org.kframework.attributes.Location(Location(1427,8,1428,23)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      Lbl'Unds'divInt'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsSlsh'Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1427,8,1428,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_dividesInt__INT-COMMON_Bool_Int_Int`(I1,I2)=>`_==Int_`(`_%Int_`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5), org.kframework.attributes.Location(Location(1439,8,1439,58)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       Lbl'UndsEqlsEqls'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0")),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1439,8,1439,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_impliesBool_`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(93b8d798abd6d9999e0e733384ad161e9a0bd2f074623a742afdc63964380aba), org.kframework.attributes.Location(Location(1157,8,1157,45)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(VarB:SortBool{}),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("93b8d798abd6d9999e0e733384ad161e9a0bd2f074623a742afdc63964380aba"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1157,8,1157,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_impliesBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b4994db7b40b72dc09ac8d5d036263b215c37d45f45d764251d8b607a7592ba), org.kframework.attributes.Location(Location(1156,8,1156,39)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2b4994db7b40b72dc09ac8d5d036263b215c37d45f45d764251d8b607a7592ba"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1156,8,1156,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_impliesBool_`(#token("false","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e), org.kframework.attributes.Location(Location(1155,8,1155,40)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1155,8,1155,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_impliesBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d), org.kframework.attributes.Location(Location(1154,8,1154,36)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1154,8,1154,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_modInt_`(I1,I2)=>`_%Int_`(`_+Int_`(`_%Int_`(I1,`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(44257f63a99a0583c2d10058edbff90118966e30914b3a637b8315212c681bc4), concrete, org.kframework.attributes.Location(Location(1430,5,1433,23)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)]), simplification]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \equals{SortInt{},R} (
+      Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsPerc'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("44257f63a99a0583c2d10058edbff90118966e30914b3a637b8315212c681bc4"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1430,5,1433,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a5bb27ab54700cb845d17b12e0b0a4cbd5c8944272bcbe0d15ccc0b44d0049ff), org.kframework.attributes.Location(Location(1147,8,1147,32)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a5bb27ab54700cb845d17b12e0b0a4cbd5c8944272bcbe0d15ccc0b44d0049ff"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1147,8,1147,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(942af273100b5a3c1fb3d0c8cc92b0bf845a7b34444c5a6c35b7d3fe72bef48e), org.kframework.attributes.Location(Location(1145,8,1145,34)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("942af273100b5a3c1fb3d0c8cc92b0bf845a7b34444c5a6c35b7d3fe72bef48e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1145,8,1145,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b), org.kframework.attributes.Location(Location(1146,8,1146,32)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1146,8,1146,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_orBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2), org.kframework.attributes.Location(Location(1144,8,1144,34)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1144,8,1144,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_orElseBool_`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(13cf42d440f9a7a360a8136ee4b35ae7b99501f515322d214c3b866691f4713b), org.kframework.attributes.Location(Location(1152,8,1152,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(VarK:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("13cf42d440f9a7a360a8136ee4b35ae7b99501f515322d214c3b866691f4713b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1152,8,1152,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orElseBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2459cad4fbb946a5c7f71565601afeeec79f05f41497b1f7ef547578c88f3158), org.kframework.attributes.Location(Location(1150,8,1150,33)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2459cad4fbb946a5c7f71565601afeeec79f05f41497b1f7ef547578c88f3158"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1150,8,1150,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orElseBool_`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf), org.kframework.attributes.Location(Location(1151,8,1151,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1151,8,1151,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_orElseBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6), org.kframework.attributes.Location(Location(1149,8,1149,33)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1149,8,1149,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_xorBool_`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f), org.kframework.attributes.Location(Location(1142,8,1142,38)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1142,8,1142,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_xorBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(69f518203376930fb76ce51df5dd0c6c81d19f71eba3a1852afa5301d02eb4fa), org.kframework.attributes.Location(Location(1141,8,1141,38)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("69f518203376930fb76ce51df5dd0c6c81d19f71eba3a1852afa5301d02eb4fa"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1141,8,1141,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_xorBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf), org.kframework.attributes.Location(Location(1140,8,1140,38)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1140,8,1140,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_|Set__SET_Set_Set_Set`(S1,S2)=>`_Set_`(S1,`Set:difference`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c384edb8f3875244a593dda6163c3dee1bce5485e4e1848892aebc2bab67d2e9), concrete, org.kframework.attributes.Location(Location(749,8,749,45)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortSet{}, R} (
+            X0:SortSet{},
+            VarS1:SortSet{}
+          ),\and{R} (
+          \in{SortSet{}, R} (
+            X1:SortSet{},
+            VarS2:SortSet{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortSet{},R} (
+      Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(X0:SortSet{},X1:SortSet{}),
+     \and{SortSet{}} (
+       Lbl'Unds'Set'Unds'{}(VarS1:SortSet{},LblSet'Coln'difference{}(VarS2:SortSet{},VarS1:SortSet{})),
+        \top{SortSet{}}())))
+  [UNIQUE'Unds'ID{}("c384edb8f3875244a593dda6163c3dee1bce5485e4e1848892aebc2bab67d2e9"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(749,8,749,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_modInt_`(`_>>Int_`(I,IDX),`_<<Int_`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119), org.kframework.attributes.Location(Location(1423,8,1423,85)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'modInt'Unds'{}(Lbl'Unds-GT--GT-'Int'Unds'{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1423,8,1423,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `freshInt(_)_INT_Int_Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b), org.kframework.attributes.Location(Location(1442,8,1442,28)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       VarI:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1442,8,1442,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule getGeneratedCounterCell(`<generatedTop>`(_DotVar0,Cell))=>Cell requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortGeneratedTopCell{}, R} (
+            X0:SortGeneratedTopCell{},
+            Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'DotVar0:SortKCell{},VarCell:SortGeneratedCounterCell{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblgetGeneratedCounterCell{}(X0:SortGeneratedTopCell{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarCell:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3")]
+
+// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblinitGeneratedCounterCell{}(),
+     \and{SortGeneratedCounterCell{}} (
+       Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")),
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553")]
+
+// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initKCell(Init),initGeneratedCounterCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4cbc9d1da6e6bfe3605113d64379a38394b46b474e41d7bf884f8912546543b1), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      LblinitGeneratedTopCell{}(X0:SortMap{}),
+     \and{SortGeneratedTopCell{}} (
+       Lbl'-LT-'generatedTop'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}()),
+        \top{SortGeneratedTopCell{}}())))
+  [UNIQUE'Unds'ID{}("4cbc9d1da6e6bfe3605113d64379a38394b46b474e41d7bf884f8912546543b1")]
+
+// rule initKCell(Init)=>`<k>`(`project:KItem`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar"))))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(888ac40929773fd17d5b9fd1e9d0be94791665a663f07907d894c31dccc871a5), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCell{},R} (
+      LblinitKCell{}(X0:SortMap{}),
+     \and{SortKCell{}} (
+       Lbl'-LT-'k'-GT-'{}(kseq{}(Lblproject'Coln'KItem{}(kseq{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))),dotk{}())),dotk{}())),
+        \top{SortKCell{}}())))
+  [UNIQUE'Unds'ID{}("888ac40929773fd17d5b9fd1e9d0be94791665a663f07907d894c31dccc871a5")]
+
+// rule is32(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b6c7003f49587e95f0164c9ae9b680b0a9d11acf104c290a80f71528ed55d131), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:Sort32{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{Sort32{}, SortKItem{}}(Var'Unds'Gen1:Sort32{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      Lblis32{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b6c7003f49587e95f0164c9ae9b680b0a9d11acf104c290a80f71528ed55d131"), owise{}()]
+
+// rule is32(inj{32,KItem}(32))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e547145cb81e2b210057c88cbe98f55fca55926d7aac87779aa38e44d1517d3d)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{Sort32{}, SortKItem{}}(Var32:Sort32{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblis32{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e547145cb81e2b210057c88cbe98f55fca55926d7aac87779aa38e44d1517d3d")]
+
+// rule is64(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(309d69e30e85e46cd3add95f1586a34f6ffee4e05119b363eba7aefa4798bd0f), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:Sort64{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{Sort64{}, SortKItem{}}(Var'Unds'Gen0:Sort64{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      Lblis64{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("309d69e30e85e46cd3add95f1586a34f6ffee4e05119b363eba7aefa4798bd0f"), owise{}()]
+
+// rule is64(inj{64,KItem}(64))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a5ccaf5af9a65df630230e540092eb2765cb936a3b6be9e3ae0b84f1998ee1b0)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{Sort64{}, SortKItem{}}(Var64:Sort64{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblis64{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a5ccaf5af9a65df630230e540092eb2765cb936a3b6be9e3ae0b84f1998ee1b0")]
+
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(495da551d13b205c8648618471ccfca028707f98eff21e6b11d591515ed6f29a), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortBool{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'Gen0:SortBool{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("495da551d13b205c8648618471ccfca028707f98eff21e6b11d591515ed6f29a"), owise{}()]
+
+// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarBool:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77")]
+
+// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b0c8eb86594a387398bf96f2dbf773cff29d14b8a45c5f6701f205bf3d2f33ba), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedCounterCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedCounterCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b0c8eb86594a387398bf96f2dbf773cff29d14b8a45c5f6701f205bf3d2f33ba"), owise{}()]
+
+// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarGeneratedCounterCell:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c")]
+
+// rule isGeneratedCounterCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(84cfc8e964ec28b1912ffec4e6f5fccfcbad2256a1cba113622d99b11c13afd6), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortGeneratedCounterCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'Gen0:SortGeneratedCounterCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("84cfc8e964ec28b1912ffec4e6f5fccfcbad2256a1cba113622d99b11c13afd6"), owise{}()]
+
+// rule isGeneratedCounterCellOpt(inj{GeneratedCounterCellOpt,KItem}(GeneratedCounterCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarGeneratedCounterCellOpt:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12")]
+
+// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ccb9226d9e6c0e476485f098ef162c6c2206ed3af1d8336ea3ae859b86bc4a8b), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedTopCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedTopCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ccb9226d9e6c0e476485f098ef162c6c2206ed3af1d8336ea3ae859b86bc4a8b"), owise{}()]
+
+// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarGeneratedTopCell:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2")]
+
+// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(98049f5819962c7ee2b01436957b6cf8460b106979fa2c24f4c606bbf6cb1592), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedTopCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedTopCellFragment{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("98049f5819962c7ee2b01436957b6cf8460b106979fa2c24f4c606bbf6cb1592"), owise{}()]
+
+// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271")]
+
+// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(105572a4ac107eeb518b37c4d6ed3e28732b83afb0ba085d02d339c4fc2140a0), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortInt{}, SortKItem{}}(Var'Unds'Gen0:SortInt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("105572a4ac107eeb518b37c4d6ed3e28732b83afb0ba085d02d339c4fc2140a0"), owise{}()]
+
+// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarInt:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5")]
+
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisK{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847")]
+
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d30be57718b4b3745eaf2e99f875cfec7d5be2ff76bacde8a89bd4ab659d857f), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKCell{}, SortKItem{}}(Var'Unds'Gen1:SortKCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d30be57718b4b3745eaf2e99f875cfec7d5be2ff76bacde8a89bd4ab659d857f"), owise{}()]
+
+// rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2695222b1238f711f8a356c0a1bc0ac418d7bd78fd3282e7c60882e2631a46df)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCell{}, SortKItem{}}(VarKCell:SortKCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2695222b1238f711f8a356c0a1bc0ac418d7bd78fd3282e7c60882e2631a46df")]
+
+// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a3f84195242c98b432c7c63a4189f4276cc3189445c5cf37ce08d9a6547b1f7), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'Gen1:SortKCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9a3f84195242c98b432c7c63a4189f4276cc3189445c5cf37ce08d9a6547b1f7"), owise{}()]
+
+// rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1516473b1e153a368c273997543a4378ad451e5e828db8e289f4447f7e5228a5)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarKCellOpt:SortKCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("1516473b1e153a368c273997543a4378ad451e5e828db8e289f4447f7e5228a5")]
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f68a616e301c35586f68e97b729ae274278c3ef8fe6634711cfd3e1746bc0bc2), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortKConfigVar{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKConfigVar{}, SortKItem{}}(Var'Unds'Gen0:SortKConfigVar{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f68a616e301c35586f68e97b729ae274278c3ef8fe6634711cfd3e1746bc0bc2"), owise{}()]
+
+// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKConfigVar{}, SortKItem{}}(VarKConfigVar:SortKConfigVar{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd")]
+
+// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(83812b6b9e31a764d66d89fd1c7e65b9b162d52c5aebfe99b1536e200a9590c2), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKItem{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(Var'Unds'Gen1:SortKItem{},dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("83812b6b9e31a764d66d89fd1c7e65b9b162d52c5aebfe99b1536e200a9590c2"), owise{}()]
+
+// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarKItem:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c")]
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a9489adcf0279eca74c012bb1130bb9d30372cfbebc8e4ab4b173656c4d6613), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortList{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortList{}, SortKItem{}}(Var'Unds'Gen1:SortList{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9a9489adcf0279eca74c012bb1130bb9d30372cfbebc8e4ab4b173656c4d6613"), owise{}()]
+
+// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarList:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446")]
+
+// rule `isMInt{32}`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5ad5ec67f05c4eba78ea6a7e38a5f63918bac62891c41b9c9965d5e7a2c1af24), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortMInt{Sort32{}},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMInt{Sort32{}}, SortKItem{}}(Var'Unds'Gen0:SortMInt{Sort32{}}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'32'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5ad5ec67f05c4eba78ea6a7e38a5f63918bac62891c41b9c9965d5e7a2c1af24"), owise{}()]
+
+// rule `isMInt{32}`(inj{MInt,KItem}(MInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bd6d624dbb3664bd095d9e098bf283ae682fbbf3212ddb36c60430d3b3a52f50)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort32{}}, SortKItem{}}(VarMInt:SortMInt{Sort32{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'32'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("bd6d624dbb3664bd095d9e098bf283ae682fbbf3212ddb36c60430d3b3a52f50")]
+
+// rule `isMInt{64}`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cb62dfeb7ce13fecc41740092599566cb2fcc11688f0571c23cf42732b214656), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortMInt{Sort64{}},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMInt{Sort64{}}, SortKItem{}}(Var'Unds'Gen0:SortMInt{Sort64{}}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'64'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("cb62dfeb7ce13fecc41740092599566cb2fcc11688f0571c23cf42732b214656"), owise{}()]
+
+// rule `isMInt{64}`(inj{MInt,KItem}(MInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(63035413b949c0bac193564937cd502a2c3aa53182ed2de338fa33c703cbf28f)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort64{}}, SortKItem{}}(VarMInt:SortMInt{Sort64{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'64'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("63035413b949c0bac193564937cd502a2c3aa53182ed2de338fa33c703cbf28f")]
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(6f30a2087d0b19640df005437bc3f4665f41282666a72821b17b16c99ed5afee), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortMap{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMap{}, SortKItem{}}(Var'Unds'Gen0:SortMap{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("6f30a2087d0b19640df005437bc3f4665f41282666a72821b17b16c99ed5afee"), owise{}()]
+
+// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarMap:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795")]
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b5aadccd9b89faba72816867187d48d279d8c27c8bda1a1b3b0658bd82bb783), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortSet{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'Gen1:SortSet{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2b5aadccd9b89faba72816867187d48d279d8c27c8bda1a1b3b0658bd82bb783"), owise{}()]
+
+// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarSet:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80")]
+
+// rule ite{K}(C,B1,_Gen0)=>B1 requires C ensures #token("true","Bool") [UNIQUE_ID(1ff8f4d71e4c13084eed473b08740da83c4cc7f1875d340d86dc72124c48b4a0), org.kframework.attributes.Location(Location(2318,8,2318,59)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        VarC:SortBool{},
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarB1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lblite{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB1:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("1ff8f4d71e4c13084eed473b08740da83c4cc7f1875d340d86dc72124c48b4a0"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2318,8,2318,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule ite{K}(C,_Gen0,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [UNIQUE_ID(2f3f58a93926913fc5ca147dfd8d3d612508bc8ff67412ef10935df7c09554d5), org.kframework.attributes.Location(Location(2319,8,2319,67)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        LblnotBool'Unds'{}(VarC:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            VarB2:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lblite{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB2:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("2f3f58a93926913fc5ca147dfd8d3d612508bc8ff67412ef10935df7c09554d5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2319,8,2319,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `m32()_TEST_MInt`(.KList)=>#token("0p32","MInt{32}") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9016ea0bcc2dd28bcd997bb8354249662cb9cf4c372e00a46429a3a2dc82723e), org.kframework.attributes.Location(Location(10,8,10,21)), org.kframework.attributes.Source(Source(/home/dwightguth/test/test.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortMInt{Sort32{}},R} (
+      Lblm32'LParRParUnds'TEST'Unds'MInt{}(),
+     \and{SortMInt{Sort32{}}} (
+       \dv{SortMInt{Sort32{}}}("0p32"),
+        \top{SortMInt{Sort32{}}}())))
+  [UNIQUE'Unds'ID{}("9016ea0bcc2dd28bcd997bb8354249662cb9cf4c372e00a46429a3a2dc82723e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(10,8,10,21)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/test.k)")]
+
+// rule `m64()_TEST_MInt`(.KList)=>#token("0p64","MInt{64}") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b9f8187e33bd652d2937157ee5ba84f54967708b592017158929c360741f6062), org.kframework.attributes.Location(Location(11,8,11,21)), org.kframework.attributes.Source(Source(/home/dwightguth/test/test.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortMInt{Sort64{}},R} (
+      Lblm64'LParRParUnds'TEST'Unds'MInt{}(),
+     \and{SortMInt{Sort64{}}} (
+       \dv{SortMInt{Sort64{}}}("0p64"),
+        \top{SortMInt{Sort64{}}}())))
+  [UNIQUE'Unds'ID{}("b9f8187e33bd652d2937157ee5ba84f54967708b592017158929c360741f6062"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(11,8,11,21)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/test.k)")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I1 requires `_<=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6), org.kframework.attributes.Location(Location(1435,8,1435,57)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI1:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1435,8,1435,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I2 requires `_>=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3), org.kframework.attributes.Location(Location(1436,8,1436,57)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI2:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1436,8,1436,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415), org.kframework.attributes.Location(Location(1128,8,1128,29)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1128,8,1128,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c), org.kframework.attributes.Location(Location(1127,8,1127,29)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1127,8,1127,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `project:Bool`(inj{Bool,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarK:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblproject'Coln'Bool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54")]
+
+// rule `project:GeneratedCounterCell`(inj{GeneratedCounterCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarK:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      Lblproject'Coln'GeneratedCounterCell{}(X0:SortK{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarK:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217")]
+
+// rule `project:GeneratedCounterCellOpt`(inj{GeneratedCounterCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarK:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCellOpt{},R} (
+      Lblproject'Coln'GeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortGeneratedCounterCellOpt{}} (
+       VarK:SortGeneratedCounterCellOpt{},
+        \top{SortGeneratedCounterCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca")]
+
+// rule `project:GeneratedTopCell`(inj{GeneratedTopCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarK:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      Lblproject'Coln'GeneratedTopCell{}(X0:SortK{}),
+     \and{SortGeneratedTopCell{}} (
+       VarK:SortGeneratedTopCell{},
+        \top{SortGeneratedTopCell{}}())))
+  [UNIQUE'Unds'ID{}("b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e")]
+
+// rule `project:GeneratedTopCellFragment`(inj{GeneratedTopCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarK:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCellFragment{},R} (
+      Lblproject'Coln'GeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortGeneratedTopCellFragment{}} (
+       VarK:SortGeneratedTopCellFragment{},
+        \top{SortGeneratedTopCellFragment{}}())))
+  [UNIQUE'Unds'ID{}("2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42")]
+
+// rule `project:Int`(inj{Int,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarK:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'Coln'Int{}(X0:SortK{}),
+     \and{SortInt{}} (
+       VarK:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b")]
+
+// rule `project:K`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortK{},R} (
+      Lblproject'Coln'K{}(X0:SortK{}),
+     \and{SortK{}} (
+       VarK:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a")]
+
+// rule `project:KCell`(inj{KCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(894c13c4c410f11e35bc3781505aeddde4ff400ddda1daf8b35259dbf0de9a24), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCell{}, SortKItem{}}(VarK:SortKCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCell{},R} (
+      Lblproject'Coln'KCell{}(X0:SortK{}),
+     \and{SortKCell{}} (
+       VarK:SortKCell{},
+        \top{SortKCell{}}())))
+  [UNIQUE'Unds'ID{}("894c13c4c410f11e35bc3781505aeddde4ff400ddda1daf8b35259dbf0de9a24")]
+
+// rule `project:KCellOpt`(inj{KCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f684dd78d97feadf0cbcb3cbb8892e0842f137c7b29a904cb2f3fc9755b29b30), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarK:SortKCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCellOpt{},R} (
+      Lblproject'Coln'KCellOpt{}(X0:SortK{}),
+     \and{SortKCellOpt{}} (
+       VarK:SortKCellOpt{},
+        \top{SortKCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("f684dd78d97feadf0cbcb3cbb8892e0842f137c7b29a904cb2f3fc9755b29b30")]
+
+// rule `project:KItem`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarK:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKItem{},R} (
+      Lblproject'Coln'KItem{}(X0:SortK{}),
+     \and{SortKItem{}} (
+       VarK:SortKItem{},
+        \top{SortKItem{}}())))
+  [UNIQUE'Unds'ID{}("1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29")]
+
+// rule `project:List`(inj{List,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarK:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortList{},R} (
+      Lblproject'Coln'List{}(X0:SortK{}),
+     \and{SortList{}} (
+       VarK:SortList{},
+        \top{SortList{}}())))
+  [UNIQUE'Unds'ID{}("2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5")]
+
+// rule `project:MInt{32}`(inj{MInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(542fe8154fa5338c2822d5982ca06611b86b8538d65e319e80e29737e0bdd467), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort32{}}, SortKItem{}}(VarK:SortMInt{Sort32{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMInt{Sort32{}},R} (
+      Lblproject'Coln'MInt'LBra'32'RBra'{}(X0:SortK{}),
+     \and{SortMInt{Sort32{}}} (
+       VarK:SortMInt{Sort32{}},
+        \top{SortMInt{Sort32{}}}())))
+  [UNIQUE'Unds'ID{}("542fe8154fa5338c2822d5982ca06611b86b8538d65e319e80e29737e0bdd467")]
+
+// rule `project:MInt{64}`(inj{MInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7f14eb6497f756642828728a6f83c13ac9c7e3c39e956f4ccebb2a5169359142), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort64{}}, SortKItem{}}(VarK:SortMInt{Sort64{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMInt{Sort64{}},R} (
+      Lblproject'Coln'MInt'LBra'64'RBra'{}(X0:SortK{}),
+     \and{SortMInt{Sort64{}}} (
+       VarK:SortMInt{Sort64{}},
+        \top{SortMInt{Sort64{}}}())))
+  [UNIQUE'Unds'ID{}("7f14eb6497f756642828728a6f83c13ac9c7e3c39e956f4ccebb2a5169359142")]
+
+// rule `project:Map`(inj{Map,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarK:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMap{},R} (
+      Lblproject'Coln'Map{}(X0:SortK{}),
+     \and{SortMap{}} (
+       VarK:SortMap{},
+        \top{SortMap{}}())))
+  [UNIQUE'Unds'ID{}("031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598")]
+
+// rule `project:Set`(inj{Set,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarK:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortSet{},R} (
+      Lblproject'Coln'Set{}(X0:SortK{}),
+     \and{SortSet{}} (
+       VarK:SortSet{},
+        \top{SortSet{}}())))
+  [UNIQUE'Unds'ID{}("0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0")]
+
+// rule pushList(K,L1)=>`_List_`(`ListItem`(K),L1) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f6967050cc4ec32c2d34d52f5577e09120f730420d2c5dc838cba81d04c57adf), org.kframework.attributes.Location(Location(954,8,954,54)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortKItem{}, R} (
+            X0:SortKItem{},
+            VarK:SortKItem{}
+          ),\and{R} (
+          \in{SortList{}, R} (
+            X1:SortList{},
+            VarL1:SortList{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortList{},R} (
+      LblpushList{}(X0:SortKItem{},X1:SortList{}),
+     \and{SortList{}} (
+       Lbl'Unds'List'Unds'{}(LblListItem{}(VarK:SortKItem{}),VarL1:SortList{}),
+        \top{SortList{}}())))
+  [UNIQUE'Unds'ID{}("f6967050cc4ec32c2d34d52f5577e09120f730420d2c5dc838cba81d04c57adf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(954,8,954,54)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_-Int_`(`_modInt_`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))),`_<<Int_`(#token("1","Int"),LEN)),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f), org.kframework.attributes.Location(Location(1425,8,1425,164)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds'modInt'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1425,8,1425,164)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `smaxMInt(_)_MINT_Int_Int`(N)=>`_-Int_`(`_<<Int_`(#token("1","Int"),`_-Int_`(N,#token("1","Int"))),#token("1","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(885169667c6f8fea57b7fcc52120cbef83f7a6ce4b963cfd1964a8f45e16e376), org.kframework.attributes.Location(Location(2901,8,2901,54)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarN:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblsmaxMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarN:SortInt{},\dv{SortInt{}}("1"))),\dv{SortInt{}}("1")),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("885169667c6f8fea57b7fcc52120cbef83f7a6ce4b963cfd1964a8f45e16e376"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2901,8,2901,54)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `sminMInt(_)_MINT_Int_Int`(N)=>`_-Int_`(#token("0","Int"),`_<<Int_`(#token("1","Int"),`_-Int_`(N,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(905e85b657a586ca9a0fce05831454ca4a80fc7b87b06f13eeb3d4af7821b66c), org.kframework.attributes.Location(Location(2900,8,2900,54)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarN:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblsminMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(\dv{SortInt{}}("0"),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarN:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("905e85b657a586ca9a0fce05831454ca4a80fc7b87b06f13eeb3d4af7821b66c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2900,8,2900,54)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `soverflowMInt(_,_)_MINT_Bool_Int_Int`(N,I)=>`_orBool_`(`_<Int_`(I,`sminMInt(_)_MINT_Int_Int`(N)),`_>Int_`(I,`smaxMInt(_)_MINT_Int_Int`(N))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(451ca26671f46f6bc7874beade344389ec2cd222fb83b97a9eedd324b8353629), org.kframework.attributes.Location(Location(2916,5,2918,49)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarN:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      LblsoverflowMInt'LParUndsCommUndsRParUnds'MINT'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       Lbl'Unds'orBool'Unds'{}(Lbl'Unds-LT-'Int'Unds'{}(VarI:SortInt{},LblsminMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(VarN:SortInt{})),Lbl'Unds-GT-'Int'Unds'{}(VarI:SortInt{},LblsmaxMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(VarN:SortInt{}))),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("451ca26671f46f6bc7874beade344389ec2cd222fb83b97a9eedd324b8353629"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2916,5,2918,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `umaxMInt(_)_MINT_Int_Int`(N)=>`_-Int_`(`_<<Int_`(#token("1","Int"),N),#token("1","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(112d01b7daf97f02c4b31925b2c46bfbbc1378e204996ff203543d4c44ccd5e5), org.kframework.attributes.Location(Location(2903,8,2903,45)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarN:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblumaxMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarN:SortInt{}),\dv{SortInt{}}("1")),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("112d01b7daf97f02c4b31925b2c46bfbbc1378e204996ff203543d4c44ccd5e5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2903,8,2903,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `uminMInt(_)_MINT_Int_Int`(_Gen0)=>#token("0","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(340a658083b6c1ac8b55d4c7c643de32cf560bb8b733ed8f9b139aee7c8c838b), org.kframework.attributes.Location(Location(2902,8,2902,28)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            Var'Unds'Gen0:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LbluminMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("0"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("340a658083b6c1ac8b55d4c7c643de32cf560bb8b733ed8f9b139aee7c8c838b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2902,8,2902,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `uoverflowMInt(_,_)_MINT_Bool_Int_Int`(N,I)=>`_orBool_`(`_<Int_`(I,`uminMInt(_)_MINT_Int_Int`(N)),`_>Int_`(I,`umaxMInt(_)_MINT_Int_Int`(N))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(669772aa6f72077d244868ca7dc07771189bb331b0347f2384101ba036d78ab2), org.kframework.attributes.Location(Location(2920,5,2922,49)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarN:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      LbluoverflowMInt'LParUndsCommUndsRParUnds'MINT'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       Lbl'Unds'orBool'Unds'{}(Lbl'Unds-LT-'Int'Unds'{}(VarI:SortInt{},LbluminMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(VarN:SortInt{})),Lbl'Unds-GT-'Int'Unds'{}(VarI:SortInt{},LblumaxMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(VarN:SortInt{}))),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("669772aa6f72077d244868ca7dc07771189bb331b0347f2384101ba036d78ab2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2920,5,2922,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1,1,12,10)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/test.k)")]

--- a/test/input/mint.in
+++ b/test/input/mint.in
@@ -1,0 +1,1 @@
+LblinitGeneratedTopCell{}(Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortMInt{Sort32{}}, SortKItem{}}(Lblm32'LParRParUnds'TEST'Unds'MInt{}()))))

--- a/test/output/mint.out.diff
+++ b/test/output/mint.out.diff
@@ -1,0 +1,1 @@
+Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortMInt{Sort32{}}, SortKItem{}}(\dv{SortMInt{Sort32{}}}("0p32")),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))


### PR DESCRIPTION
There existed several bugs leading to crashes when the LLVM backend compiles certain definitions containing the MInt sort. This PR contains a regression test and the fixes needed to make that test pass, namely:

* Don't emit a case for `evaluate_function_symbol` if the function has a variable return sort (only happens with functions that have a sort variable in the return sort that does not appear in the argument list)
* Fix a case where a string literal did not get its initializer set in all cases.