### PR TITLE
Drop flat namespace option

### DIFF
--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -136,7 +136,6 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   flags=(
     "-L@BREW_PREFIX@/opt/libffi/lib"
     "-L@BREW_PREFIX@/lib"
-    "-L@LLVM_LIBRARY_DIR@"
     "-Wl,-u,_table_getArgumentSortsForTag"
     "-I" "@BREW_PREFIX@/include"
   )
@@ -156,6 +155,19 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   set_visibility_hidden="$LIBDIR/libSetVisibilityHidden.dylib"
 else
   set_visibility_hidden="$LIBDIR/libSetVisibilityHidden.so"
+fi
+
+# On macOS, we get libunwind supplied as part of the developer tools in the OS,
+# and so don't need to link it directly. If we instead try to explictly link
+# against the libunwind that's part of Homebrew-supplied LLVM, it's easy to end
+# up in a situation where exceptions thrown in a shared library are not
+# compatible with the unwinding machinery in the main application binary. This
+# then manifests as BAD_ACCESS errors (or similar) when an exception is thrown,
+# _even if the exception should in principle be caught_.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  libunwind=""
+else
+  libunwind="-lunwind"
 fi
 
 # When building the Python AST module, there's no runtime and no main file, so
@@ -218,7 +230,7 @@ if [ "$main" = "static" ]; then
 elif [[ "$main" =~ "python" ]]; then
   # Don't link jemalloc when building a python library; it clashes with the
   # pymalloc implementation that Python expects you to use.
-  all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi" "-lunwind")
+  all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi" "$libunwind")
   flags+=("-fPIC" "-shared" "-I${INCDIR}" "-fvisibility=hidden")
 
   read -r -a python_include_flags <<< "$("${python_cmd}" -m pybind11 --includes)"
@@ -240,11 +252,11 @@ elif [ "$main" = "c" ]; then
 
   # Avoid jemalloc for similar reasons as Python; we don't know who is loading
   # this library so don't want to impose it.
-  all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi" "-lunwind")
+  all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi" "$libunwind")
   flags+=("-fPIC" "-shared" "$start_whole_archive" "$LIBDIR/libkllvmcruntime.a" "$end_whole_archive")
   clangpp_args+=("-o" "${output_file}")
 else
-  all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi" "-ljemalloc" "-lunwind")
+  all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi" "-ljemalloc" "$libunwind")
 fi
 
 if $link; then

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -233,6 +233,10 @@ elif [[ "$main" =~ "python" ]]; then
   all_libraries=("${libraries[@]}" "-lgmp" "-lgmpxx" "-lmpfr" "-lpthread" "-ldl" "-lffi" "$libunwind")
   flags+=("-fPIC" "-shared" "-I${INCDIR}" "-fvisibility=hidden")
 
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    flags+=("-Wl,-flat_namespace")
+  fi
+
   read -r -a python_include_flags <<< "$("${python_cmd}" -m pybind11 --includes)"
   flags+=("${python_include_flags[@]}")
 

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -207,7 +207,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   start_whole_archive="-force_load"
   end_whole_archive=""
 
-  flags+=("-Wl,-flat_namespace" "-Wl,-undefined" "-Wl,dynamic_lookup")
+  flags+=("-Wl,-undefined" "-Wl,dynamic_lookup")
 else
   start_whole_archive="-Wl,--whole-archive"
   end_whole_archive="-Wl,--no-whole-archive"

--- a/lib/codegen/ApplyPasses.cpp
+++ b/lib/codegen/ApplyPasses.cpp
@@ -123,6 +123,7 @@ void generate_object_file(llvm::Module &mod, llvm::raw_ostream &os) {
 
   auto features_string = features.getString();
   auto options = TargetOptions{};
+  options.GuaranteedTailCallOpt = true;
 
 #if LLVM_VERSION_MAJOR >= 16
   std::optional<CodeModel::Model> model = std::nullopt;

--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
       --replace '"-liconv"' '"-L${libiconv}/lib" "-liconv"' \
       --replace '"-lncurses"' '"-L${ncurses}/lib" "-lncurses"' \
       --replace '"-ltinfo"' '"-L${ncurses}/lib" "-ltinfo"' \
-      --replace '"-lunwind"' '"-L${libunwind}/lib" "-lunwind"' \
+      --replace '"$libunwind"' '"-L${libunwind}/lib" "-lunwind"' \
       --replace '"-L@BREW_PREFIX@/opt/libffi/lib"' ' ' \
       --replace '"-L@LLVM_LIBRARY_DIR@"' ' ' \
       --replace '-L@BREW_PREFIX@/lib' '-L${libcxx}/lib' \

--- a/test/c/Inputs/flat-namespace.c
+++ b/test/c/Inputs/flat-namespace.c
@@ -3,6 +3,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/**
+ * The K program corresponding to this test will evaluate the `Int2Bytes` hooked
+ * function when it is run; this hook ends up allocating and freeing a temporary
+ * MPZ integer locally. If we're in a situation where `-flat_namespace` has been
+ * enabled on macOS, it's possible for the hook to end up resolving
+ * `__gmpz_clear` to a symbol defined in the host binary (rather than libgmp's
+ * dynamic library!).
+ *
+ * This originally manifested when the HB booster loaded a C bindings library
+ * (the booster statically links libgmp and so contains a symbol with this
+ * name); this test is a minimised reproduction of that issue.
+ */
 void __gmpz_clear(void *p) {
   abort();
 }

--- a/test/c/Inputs/flat-namespace.c
+++ b/test/c/Inputs/flat-namespace.c
@@ -1,0 +1,28 @@
+#include "api.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+void __gmpz_clear(void *p) {
+  abort();
+}
+
+int main(int argc, char **argv) {
+  if (argc <= 1) {
+    return 1;
+  }
+
+  struct kllvm_c_api api = load_c_api(argv[1]);
+
+  api.kllvm_init();
+
+  kore_sort *sort_foo = api.kore_composite_sort_new("SortFoo");
+  kore_pattern *pat = api.kore_composite_pattern_new("Lblfoo");
+
+  kore_pattern *input = api.kore_pattern_make_interpreter_input(pat, sort_foo);
+
+  block *term = api.kore_pattern_construct(input);
+  block *after = api.take_steps(-1, term);
+
+  printf("%s", api.kore_block_dump(after));
+}

--- a/test/c/flat-namespace.kore
+++ b/test/c/flat-namespace.kore
@@ -1,0 +1,6525 @@
+// RUN: mkdir -p %t.dir
+// RUN: %kompile %s c -o %t.dir/libtest.so
+// RUN: %kllvm-clang Inputs/flat-namespace.c -o %t
+// RUN: %t %t.dir/libtest.so | grep -q 'Lblbar{}(\\dv{SortBytes{}}("\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\r\\xa1"))'
+
+[topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/c/k-files/flat-namespace.k)")]
+
+module BASIC-K
+    sort SortK{} []
+    sort SortKItem{} []
+endmodule
+[]
+module KSEQ
+    import BASIC-K []
+    symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol dotk{}() : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol append{}(SortK{}, SortK{}) : SortK{} [function{}(), functional{}()]
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, dotk{}()),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                TAIL:SortK{},
+                \top{SortK{}}()
+            )
+        )
+    ) []
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, kseq{}(K:SortKItem{}, KS:SortK{})),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                kseq{}(K:SortKItem{}, append{}(KS:SortK{}, TAIL:SortK{})),
+                \top{SortK{}}()
+            )
+        )
+    ) []
+endmodule
+[]
+module INJ
+    symbol inj{From, To}(From) : To [sortInjection{}()]
+    axiom {S1, S2, S3, R} \equals{S3, R}(inj{S2, S3}(inj{S1, S2}(T:S1)), inj{S1, S3}(T:S1)) [simplification{}()]
+endmodule
+[]
+module K
+    import KSEQ []
+    import INJ []
+    alias weakExistsFinally{A}(A) : A where weakExistsFinally{A}(@X:A) := @X:A []
+    alias weakAlwaysFinally{A}(A) : A where weakAlwaysFinally{A}(@X:A) := @X:A []
+    alias allPathGlobally{A}(A) : A where allPathGlobally{A}(@X:A) := @X:A []
+endmodule
+[]
+
+module FLAT-NAMESPACE
+
+// imports
+  import K []
+
+// sorts
+  sort SortKCellOpt{} []
+  sort SortIOInt{} []
+  sort SortKCell{} []
+  sort SortKConfigVar{} [hasDomainValues{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(40,3,40,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/kast.md)"), token{}()]
+  hooked-sort SortInt{} [hasDomainValues{}(), hook{}("INT.Int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1198,3,1198,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  sort SortIOError{} []
+  hooked-sort SortSet{} [concat{}(Lbl'Unds'Set'Unds'{}()), element{}(LblSetItem{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(700,3,700,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Set{}())]
+  sort SortFoo{} []
+  hooked-sort SortBytes{} [hasDomainValues{}(), hook{}("BYTES.Bytes"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1986,3,1986,35)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  sort SortEndianness{} []
+  hooked-sort SortBool{} [hasDomainValues{}(), hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1077,3,1077,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  sort SortGeneratedTopCellFragment{} []
+  sort SortIOFile{} []
+  hooked-sort SortList{} [concat{}(Lbl'Unds'List'Unds'{}()), element{}(LblListItem{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(913,3,913,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'List{}())]
+  sort SortGeneratedTopCell{} []
+  sort SortGeneratedCounterCell{} []
+  sort SortSignedness{} []
+  hooked-sort SortFloat{} [hasDomainValues{}(), hook{}("FLOAT.Float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1479,3,1479,35)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-sort SortMap{} [concat{}(Lbl'Unds'Map'Unds'{}()), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(218,3,218,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Map{}())]
+  hooked-sort SortString{} [hasDomainValues{}(), hook{}("STRING.String"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1692,3,1692,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  sort SortIOString{} []
+  sort SortId{} [hasDomainValues{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2249,3,2249,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), token{}()]
+  sort SortGeneratedCounterCellOpt{} []
+  sort SortStream{} []
+
+// symbols
+  symbol Lbl'Hash'E2BIG{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2394,22,2394,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#E2BIG")]
+  symbol Lbl'Hash'EACCES{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2395,22,2395,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EACCES")]
+  symbol Lbl'Hash'EADDRINUSE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2444,22,2444,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EADDRINUSE")]
+  symbol Lbl'Hash'EADDRNOTAVAIL{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2445,22,2445,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EADDRNOTAVAIL")]
+  symbol Lbl'Hash'EAFNOSUPPORT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2443,22,2443,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EAFNOSUPPORT")]
+  symbol Lbl'Hash'EAGAIN{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2396,22,2396,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EAGAIN")]
+  symbol Lbl'Hash'EALREADY{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2433,22,2433,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EALREADY")]
+  symbol Lbl'Hash'EBADF{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2397,22,2397,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EBADF")]
+  symbol Lbl'Hash'EBUSY{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2398,22,2398,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EBUSY")]
+  symbol Lbl'Hash'ECHILD{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2399,22,2399,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ECHILD")]
+  symbol Lbl'Hash'ECONNABORTED{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2449,22,2449,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ECONNABORTED")]
+  symbol Lbl'Hash'ECONNREFUSED{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2457,22,2457,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ECONNREFUSED")]
+  symbol Lbl'Hash'ECONNRESET{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2450,22,2450,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ECONNRESET")]
+  symbol Lbl'Hash'EDEADLK{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2400,22,2400,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EDEADLK")]
+  symbol Lbl'Hash'EDESTADDRREQ{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2435,22,2435,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EDESTADDRREQ")]
+  symbol Lbl'Hash'EDOM{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2401,22,2401,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EDOM")]
+  symbol Lbl'Hash'EEXIST{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2402,22,2402,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EEXIST")]
+  symbol Lbl'Hash'EFAULT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2403,22,2403,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EFAULT")]
+  symbol Lbl'Hash'EFBIG{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2404,22,2404,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EFBIG")]
+  symbol Lbl'Hash'EHOSTDOWN{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2458,22,2458,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EHOSTDOWN")]
+  symbol Lbl'Hash'EHOSTUNREACH{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2459,22,2459,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EHOSTUNREACH")]
+  symbol Lbl'Hash'EINPROGRESS{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2432,22,2432,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EINPROGRESS")]
+  symbol Lbl'Hash'EINTR{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2405,22,2405,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EINTR")]
+  symbol Lbl'Hash'EINVAL{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2406,22,2406,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EINVAL")]
+  symbol Lbl'Hash'EIO{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2407,22,2407,43)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EIO")]
+  symbol Lbl'Hash'EISCONN{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2452,22,2452,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EISCONN")]
+  symbol Lbl'Hash'EISDIR{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2408,22,2408,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EISDIR")]
+  symbol Lbl'Hash'ELOOP{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2460,22,2460,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ELOOP")]
+  symbol Lbl'Hash'EMFILE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2409,22,2409,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EMFILE")]
+  symbol Lbl'Hash'EMLINK{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2410,22,2410,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EMLINK")]
+  symbol Lbl'Hash'EMSGSIZE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2436,22,2436,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EMSGSIZE")]
+  symbol Lbl'Hash'ENAMETOOLONG{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2411,22,2411,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENAMETOOLONG")]
+  symbol Lbl'Hash'ENETDOWN{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2446,22,2446,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENETDOWN")]
+  symbol Lbl'Hash'ENETRESET{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2448,22,2448,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENETRESET")]
+  symbol Lbl'Hash'ENETUNREACH{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2447,22,2447,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENETUNREACH")]
+  symbol Lbl'Hash'ENFILE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2412,22,2412,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENFILE")]
+  symbol Lbl'Hash'ENOBUFS{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2451,22,2451,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOBUFS")]
+  symbol Lbl'Hash'ENODEV{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2413,22,2413,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENODEV")]
+  symbol Lbl'Hash'ENOENT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2414,22,2414,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOENT")]
+  symbol Lbl'Hash'ENOEXEC{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2415,22,2415,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOEXEC")]
+  symbol Lbl'Hash'ENOLCK{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2416,22,2416,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOLCK")]
+  symbol Lbl'Hash'ENOMEM{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2417,22,2417,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOMEM")]
+  symbol Lbl'Hash'ENOPROTOOPT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2438,22,2438,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOPROTOOPT")]
+  symbol Lbl'Hash'ENOSPC{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2418,22,2418,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOSPC")]
+  symbol Lbl'Hash'ENOSYS{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2419,22,2419,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOSYS")]
+  symbol Lbl'Hash'ENOTCONN{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2453,22,2453,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOTCONN")]
+  symbol Lbl'Hash'ENOTDIR{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2420,22,2420,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOTDIR")]
+  symbol Lbl'Hash'ENOTEMPTY{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2421,22,2421,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOTEMPTY")]
+  symbol Lbl'Hash'ENOTSOCK{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2434,22,2434,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOTSOCK")]
+  symbol Lbl'Hash'ENOTTY{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2422,22,2422,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOTTY")]
+  symbol Lbl'Hash'ENXIO{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2423,22,2423,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENXIO")]
+  symbol Lbl'Hash'EOF{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2392,22,2392,43)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EOF")]
+  symbol Lbl'Hash'EOPNOTSUPP{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2441,22,2441,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EOPNOTSUPP")]
+  symbol Lbl'Hash'EOVERFLOW{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2461,22,2461,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EOVERFLOW")]
+  symbol Lbl'Hash'EPERM{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2424,22,2424,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EPERM")]
+  symbol Lbl'Hash'EPFNOSUPPORT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2442,22,2442,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EPFNOSUPPORT")]
+  symbol Lbl'Hash'EPIPE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2425,22,2425,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EPIPE")]
+  symbol Lbl'Hash'EPROTONOSUPPORT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2439,22,2439,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EPROTONOSUPPORT")]
+  symbol Lbl'Hash'EPROTOTYPE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2437,22,2437,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EPROTOTYPE")]
+  symbol Lbl'Hash'ERANGE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2426,22,2426,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ERANGE")]
+  symbol Lbl'Hash'EROFS{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2427,22,2427,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EROFS")]
+  symbol Lbl'Hash'ESHUTDOWN{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2454,22,2454,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ESHUTDOWN")]
+  symbol Lbl'Hash'ESOCKTNOSUPPORT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2440,22,2440,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ESOCKTNOSUPPORT")]
+  symbol Lbl'Hash'ESPIPE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2428,22,2428,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ESPIPE")]
+  symbol Lbl'Hash'ESRCH{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2429,22,2429,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ESRCH")]
+  symbol Lbl'Hash'ETIMEDOUT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2456,22,2456,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ETIMEDOUT")]
+  symbol Lbl'Hash'ETOOMANYREFS{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2455,22,2455,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ETOOMANYREFS")]
+  symbol Lbl'Hash'EWOULDBLOCK{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2431,22,2431,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EWOULDBLOCK")]
+  symbol Lbl'Hash'EXDEV{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2430,22,2430,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EXDEV")]
+  hooked-symbol Lbl'Hash'accept'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [function{}(), hook{}("IO.accept"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2559,20,2559,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(SortK{}) : SortStream{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2663,21,2663,31)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'close'LParUndsRParUnds'K-IO'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [function{}(), hook{}("IO.close"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2533,16,2533,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'getc'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [function{}(), hook{}("IO.getc"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2514,20,2514,89)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(SortInt{}) : SortStream{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2664,21,2664,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'lock'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [function{}(), hook{}("IO.lock"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2545,16,2545,91)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'log{}(SortString{}) : SortK{} [function{}(), functional{}(), hook{}("IO.logString"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2639,16,2639,108)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#log"), total{}()]
+  hooked-symbol Lbl'Hash'logToFile{}(SortString{}, SortString{}) : SortK{} [function{}(), functional{}(), hook{}("IO.log"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2630,16,2630,128)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#logToFile"), total{}()]
+  hooked-symbol Lbl'Hash'mkstemp'LParUndsRParUnds'K-IO'Unds'IOFile'Unds'String{}(SortString{}) : SortIOFile{} [function{}(), hook{}("IO.mkstemp"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2607,21,2607,84)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'open'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'String{}(SortString{}) : SortIOInt{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2484,20,2484,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'Unds'IOInt'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortIOInt{} [function{}(), hook{}("IO.open"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2485,18,2485,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(SortInt{}) : SortStream{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2666,21,2666,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortStream{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2665,21,2665,48)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'putc'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [function{}(), hook{}("IO.putc"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2524,16,2524,93)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'read'LParUndsCommUndsRParUnds'K-IO'Unds'IOString'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortIOString{} [function{}(), hook{}("IO.read"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2515,23,2515,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'remove'LParUndsRParUnds'K-IO'Unds'K'Unds'String{}(SortString{}) : SortK{} [function{}(), functional{}(), hook{}("IO.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2618,16,2618,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Hash'seek'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [function{}(), hook{}("IO.seek"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2500,16,2500,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'seekEnd'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [function{}(), hook{}("IO.seekEnd"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2501,16,2501,96)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'shutdownWrite'LParUndsRParUnds'K-IO'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [function{}(), hook{}("IO.shutdownWrite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2560,16,2560,91)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}() : SortInt{} [function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2580,19,2580,46)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}() : SortInt{} [function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2578,18,2578,46)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}() : SortInt{} [function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2579,19,2579,46)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Hash'system'LParUndsRParUnds'K-IO'Unds'KItem'Unds'String{}(SortString{}) : SortKItem{} [function{}(), hook{}("IO.system"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2596,20,2596,74)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'systemResult{}(SortInt{}, SortString{}, SortString{}) : SortKItem{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2597,20,2597,135)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#systemResult")]
+  hooked-symbol Lbl'Hash'tell'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [function{}(), hook{}("IO.tell"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2499,20,2499,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'tempFile{}(SortString{}, SortInt{}) : SortIOFile{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2609,21,2609,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#tempFile")]
+  hooked-symbol Lbl'Hash'time'LParRParUnds'K-IO'Unds'Int{}() : SortInt{} [function{}(), hook{}("IO.time"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2569,18,2569,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'trace{}(SortKItem{}) : SortK{} [function{}(), functional{}(), hook{}("IO.traceTerm"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2650,16,2650,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#trace"), total{}()]
+  hooked-symbol Lbl'Hash'traceK{}(SortK{}) : SortK{} [function{}(), functional{}(), hook{}("IO.traceTerm"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2651,16,2651,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#traceK"), total{}()]
+  symbol Lbl'Hash'unknownIOError{}(SortInt{}) : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2393,22,2393,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#unknownIOError")]
+  hooked-symbol Lbl'Hash'unlock'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [function{}(), hook{}("IO.unlock"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2546,16,2546,95)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'write'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'String{}(SortInt{}, SortString{}) : SortK{} [function{}(), hook{}("IO.write"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2525,16,2525,93)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Stop'Bytes'Unds'BYTES-HOOKED'Unds'Bytes{}() : SortBytes{} [function{}(), functional{}(), hook{}("BYTES.empty"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2017,20,2017,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [function{}(), functional{}(), hook{}("LIST.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(937,19,937,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("smt_seq_nil"), symbol'Kywd'{}(".List"), total{}()]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [function{}(), functional{}(), hook{}("MAP.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(248,18,248,96)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(".Map"), total{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [function{}(), functional{}(), hook{}("SET.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(729,18,729,90)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(".Set"), total{}()]
+  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [cell{}(), constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortKCell{}, SortGeneratedCounterCell{}) : SortGeneratedTopCell{} [cell{}(), constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortKCellOpt{}, SortGeneratedCounterCellOpt{}) : SortGeneratedTopCellFragment{} [constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [cell{}(), constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(527,17,527,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/kast.md)")]
+  hooked-symbol LblBase2String'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortString{} [function{}(), hook{}("STRING.base2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1821,21,1821,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(SortBool{}) : SortString{} [function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1771,21,1771,56)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblBytes2Int'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Int'Unds'Bytes'Unds'Endianness'Unds'Signedness{}(SortBytes{}, SortEndianness{}, SortSignedness{}) : SortInt{} [function{}(), functional{}(), hook{}("BYTES.bytes2int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2066,18,2066,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblBytes2String'LParUndsRParUnds'BYTES-HOOKED'Unds'String'Unds'Bytes{}(SortBytes{}) : SortString{} [function{}(), functional{}(), hook{}("BYTES.bytes2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2078,21,2078,84)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblFloat2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float{}(SortFloat{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.float2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1798,21,1798,101)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblFloatFormat{}(SortFloat{}, SortString{}) : SortString{} [function{}(), hook{}("STRING.floatFormat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1799,21,1799,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("FloatFormat")]
+  hooked-symbol LblId2String'LParUndsRParUnds'ID-COMMON'Unds'String'Unds'Id{}(SortId{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.token2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2256,21,2256,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblInt2Bytes'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Int'Unds'Int'Unds'Endianness{}(SortInt{}, SortInt{}, SortEndianness{}) : SortBytes{} [function{}(), functional{}(), hook{}("BYTES.int2bytes"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2067,20,2067,100)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol LblInt2BytesNoLen{}(SortInt{}, SortEndianness{}, SortSignedness{}) : SortBytes{} [function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2068,20,2068,100)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Int2BytesNoLen"), total{}()]
+  hooked-symbol LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(SortInt{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.int2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1820,21,1820,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [function{}(), hook{}("LIST.get"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(965,20,965,91)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("List:get")]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [function{}(), hook{}("LIST.range"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1012,19,1012,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("List:range")]
+  hooked-symbol LblList'Coln'set{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [function{}(), hook{}("LIST.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(974,19,974,108)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("List:set")]
+  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [function{}(), functional{}(), hook{}("LIST.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(945,19,945,124)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("smt_seq_elem"), symbol'Kywd'{}("ListItem"), total{}()]
+  hooked-symbol LblMap'Coln'choice{}(SortMap{}) : SortKItem{} [function{}(), hook{}("MAP.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,20,393,101)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Map:choice")]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [function{}(), hook{}("MAP.lookup"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(271,20,271,105)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Map:lookup")]
+  hooked-symbol LblMap'Coln'lookupOrDefault{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [function{}(), functional{}(), hook{}("MAP.lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(281,20,281,134)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Map:lookupOrDefault"), total{}()]
+  hooked-symbol LblMap'Coln'update{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,18,290,132)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Map:update"), total{}()]
+  hooked-symbol LblSet'Coln'choice{}(SortSet{}) : SortKItem{} [function{}(), hook{}("SET.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(804,20,804,95)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Set:choice")]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [function{}(), functional{}(), hook{}("SET.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(769,18,769,106)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Set:difference"), total{}()]
+  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [function{}(), functional{}(), hook{}("SET.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(777,19,777,94)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Set:in"), total{}()]
+  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [function{}(), functional{}(), hook{}("SET.element"), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(737,18,737,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("SetItem"), total{}()]
+  hooked-symbol LblString2Base'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'Int{}(SortString{}, SortInt{}) : SortInt{} [function{}(), hook{}("STRING.string2base"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1822,21,1822,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(SortString{}) : SortBool{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1777,19,1777,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblString2Bytes'LParUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'String{}(SortString{}) : SortBytes{} [function{}(), functional{}(), hook{}("BYTES.string2bytes"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2079,20,2079,84)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblString2Float'LParUndsRParUnds'STRING-COMMON'Unds'Float'Unds'String{}(SortString{}) : SortFloat{} [function{}(), hook{}("STRING.string2float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1800,21,1800,94)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(SortString{}) : SortId{} [function{}(), functional{}(), hook{}("STRING.string2token"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2257,17,2257,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblString2Int'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [function{}(), hook{}("STRING.string2int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1819,21,1819,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'UndsPerc'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.tmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1246,18,1246,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("mod"), symbol'Kywd'{}("_%Int_")]
+  hooked-symbol Lbl'UndsAnd-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1257,18,1257,125)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("andInt"), symbol'Kywd'{}("_&Int_"), total{}()]
+  hooked-symbol Lbl'UndsStar'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.mul"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1242,18,1242,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("*"), symbol'Kywd'{}("_*Int_"), total{}()]
+  hooked-symbol Lbl'UndsPlus'Bytes'UndsUnds'BYTES-HOOKED'Unds'Bytes'Unds'Bytes'Unds'Bytes{}(SortBytes{}, SortBytes{}) : SortBytes{} [function{}(), functional{}(), hook{}("BYTES.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2179,20,2179,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.add"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1251,18,1251,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("+"), symbol'Kywd'{}("_+Int_"), total{}()]
+  hooked-symbol Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1710,21,1710,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds'-Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.sub"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1252,18,1252,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("-"), symbol'Kywd'{}("_-Int_"), total{}()]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,18,311,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'UndsSlsh'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.tdiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1245,18,1245,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("div"), symbol'Kywd'{}("_/Int_")]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.shl"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1255,18,1255,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("shlInt"), symbol'Kywd'{}("_<<Int_")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1313,19,1313,105)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("<="), symbol'Kywd'{}("_<=Int_"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [function{}(), functional{}(), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,19,383,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [function{}(), functional{}(), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(786,19,786,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [function{}(), functional{}(), hook{}("STRING.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1855,19,1855,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1314,19,1314,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("<"), symbol'Kywd'{}("_<Int_"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [function{}(), functional{}(), hook{}("STRING.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1854,19,1854,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1118,19,1118,126)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("distinct"), symbol'Kywd'{}("_=/=Bool_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1318,19,1318,118)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("distinct"), symbol'Kywd'{}("_=/=Int_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [function{}(), functional{}(), hook{}("KEQUAL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2287,19,2287,138)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("distinct"), symbol'Kywd'{}("_=/=K_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [function{}(), functional{}(), hook{}("STRING.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1851,19,1851,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1117,19,1117,118)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("="), symbol'Kywd'{}("_==Bool_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1317,19,1317,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("="), symbol'Kywd'{}("_==Int_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [function{}(), functional{}(), hook{}("KEQUAL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2286,19,2286,127)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("="), symbol'Kywd'{}("_==K_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [function{}(), functional{}(), hook{}("STRING.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1850,19,1850,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1315,19,1315,105)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}(">="), symbol'Kywd'{}("_>=Int_"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [function{}(), functional{}(), hook{}("STRING.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1857,19,1857,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.shr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1254,18,1254,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("shrInt"), symbol'Kywd'{}("_>>Int_")]
+  hooked-symbol Lbl'Unds-GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1316,19,1316,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}(">"), symbol'Kywd'{}("_>Int_"), total{}()]
+  hooked-symbol Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [function{}(), functional{}(), hook{}("STRING.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1856,19,1856,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [element{}(LblListItem{}()), function{}(), functional{}(), hook{}("LIST.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(929,19,929,180)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("smt_seq_concat"), symbol'Kywd'{}("_List_"), total{}(), unit{}(Lbl'Stop'List{}())]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), function{}(), hook{}("MAP.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,18,240,165)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_Map_"), unit{}(Lbl'Stop'Map{}())]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [element{}(LblSetItem{}()), function{}(), hook{}("SET.concat"), idem{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(721,18,721,157)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_Set_"), unit{}(Lbl'Stop'Set{}())]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'BYTES-HOOKED'Unds'Bytes'Unds'Bytes'Unds'Int'Unds'Int{}(SortBytes{}, SortInt{}, SortInt{}) : SortBytes{} [function{}(), hook{}("BYTES.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2090,20,2090,91)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(299,18,299,109)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_[_<-undef]"), total{}()]
+  hooked-symbol Lbl'UndsLSqBUndsRSqBUnds'BYTES-HOOKED'Unds'Int'Unds'Bytes'Unds'Int{}(SortBytes{}, SortInt{}) : SortInt{} [function{}(), hook{}("BYTES.get"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2099,18,2099,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUnds'{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.powmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1240,18,1240,131)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(mod (^ #1 #2) #3)"), symbol'Kywd'{}("_^%Int__")]
+  hooked-symbol Lbl'UndsXor-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.pow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1239,18,1239,109)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("^"), symbol'Kywd'{}("_^Int_")]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1110,19,1110,138)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("and"), symbol'Kywd'{}("_andBool_"), total{}()]
+  hooked-symbol Lbl'Unds'andThenBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.andThen"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1111,19,1111,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("and"), symbol'Kywd'{}("_andThenBool_"), total{}()]
+  hooked-symbol Lbl'Unds'divInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.ediv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1248,18,1248,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("div"), symbol'Kywd'{}("_divInt_")]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1327,19,1327,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Unds'impliesBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.implies"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1115,19,1115,145)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("=>"), symbol'Kywd'{}("_impliesBool_"), total{}()]
+  hooked-symbol Lbl'Unds'inList'Unds'{}(SortKItem{}, SortList{}) : SortBool{} [function{}(), functional{}(), hook{}("LIST.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1021,19,1021,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_inList_"), total{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [function{}(), functional{}(), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(357,19,357,89)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds'modInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.emod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1249,18,1249,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("mod"), symbol'Kywd'{}("_modInt_")]
+  hooked-symbol Lbl'Unds'orBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1113,19,1113,135)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("or"), symbol'Kywd'{}("_orBool_"), total{}()]
+  hooked-symbol Lbl'Unds'orElseBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.orElse"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1114,19,1114,143)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("or"), symbol'Kywd'{}("_orElseBool_"), total{}()]
+  hooked-symbol Lbl'Unds'xorBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1112,19,1112,138)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("xor"), symbol'Kywd'{}("_xorBool_"), total{}()]
+  hooked-symbol Lbl'Unds'xorInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1259,18,1259,127)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("xorInt"), symbol'Kywd'{}("_xorInt_"), total{}()]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.element"), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(257,18,257,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_|->_"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1261,18,1261,123)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("orInt"), symbol'Kywd'{}("_|Int_"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [function{}(), functional{}(), hook{}("SET.union"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(748,18,748,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.abs"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1278,18,1278,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (< #1 0) (- 0 #1) #1)"), total{}()]
+  symbol Lblbar{}(SortBytes{}) : SortFoo{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,18,5,42)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/c/k-files/flat-namespace.k)"), symbol'Kywd'{}("bar")]
+  symbol LblbigEndianBytes{}() : SortEndianness{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2028,25,2028,54)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("bigEndianBytes")]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.bitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1303,18,1303,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblcategoryChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'String{}(SortString{}) : SortString{} [function{}(), hook{}("STRING.category"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1867,21,1867,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblchrChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(SortInt{}) : SortString{} [function{}(), hook{}("STRING.chr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1727,21,1727,70)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortInt{} [function{}(), functional{}(), hook{}("STRING.countAllOccurrences"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1840,18,1840,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LbldirectionalityChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'String{}(SortString{}) : SortString{} [function{}(), hook{}("STRING.directionality"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1868,21,1868,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [function{}(), hook{}("LIST.fill"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1002,19,1002,100)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [function{}(), hook{}("STRING.findChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1764,18,1764,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [function{}(), hook{}("STRING.find"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1753,18,1753,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lblfoo{}() : SortFoo{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(4,18,4,42)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/c/k-files/flat-namespace.k)"), symbol'Kywd'{}("foo")]
+  symbol LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(SortInt{}) : SortId{} [freshGenerator{}(), function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2258,17,2258,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [freshGenerator{}(), function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1441,18,1441,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol LblgetGeneratedCounterCell{}(SortGeneratedTopCell{}) : SortGeneratedCounterCell{} [function{}()]
+  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [function{}(), functional{}(), total{}()]
+  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [function{}()]
+  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [function{}()]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [function{}(), functional{}(), hook{}("SET.intersection"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(759,18,759,90)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol LblisBool{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisBytes{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisEndianness{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisFloat{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisFoo{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisIOError{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisIOFile{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisIOInt{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisIOString{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisId{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisInt{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisK{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisList{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisMap{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisSignedness{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisStream{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisString{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  hooked-symbol Lblite{SortSort}(SortBool{}, SortSort, SortSort) : SortSort [function{}(), functional{}(), hook{}("KEQUAL.ite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2291,26,2291,132)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("ite"), symbol'Kywd'{}("ite"), total{}()]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(SortMap{}) : SortSet{} [function{}(), functional{}(), hook{}("MAP.keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,18,341,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [function{}(), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,19,349,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LbllengthBytes'LParUndsRParUnds'BYTES-HOOKED'Unds'Int'Unds'Bytes{}(SortBytes{}) : SortInt{} [function{}(), functional{}(), hook{}("BYTES.length"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2169,18,2169,95)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("lengthBytes"), total{}()]
+  hooked-symbol LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [function{}(), functional{}(), hook{}("STRING.length"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1718,18,1718,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol LbllittleEndianBytes{}() : SortEndianness{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2027,25,2027,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("littleEndianBytes")]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), hook{}("INT.log2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1289,18,1289,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'Unds'List'Unds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [function{}(), hook{}("LIST.make"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(983,19,983,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.max"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1270,18,1270,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (< #1 #2) #2 #1)"), total{}()]
+  hooked-symbol LblmemsetBytes'LParUndsCommUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Bytes'Unds'Int'Unds'Int'Unds'Int{}(SortBytes{}, SortInt{}, SortInt{}, SortInt{}) : SortBytes{} [function{}(), hook{}("BYTES.memset"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2137,20,2137,107)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.min"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1269,18,1269,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (< #1 #2) #1 #2)"), total{}()]
+  hooked-symbol LblnewUUID'Unds'STRING-COMMON'Unds'String{}() : SortString{} [function{}(), hook{}("STRING.uuid"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1870,21,1870,68)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblnoGeneratedCounterCell{}() : SortGeneratedCounterCellOpt{} [constructor{}(), functional{}(), injective{}()]
+  symbol LblnoKCell{}() : SortKCellOpt{} [constructor{}(), functional{}(), injective{}()]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1109,19,1109,131)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("not"), symbol'Kywd'{}("notBool_"), total{}()]
+  hooked-symbol LblordChar'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [function{}(), hook{}("STRING.ord"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1728,18,1728,70)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblpadLeftBytes'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Bytes'Unds'Int'Unds'Int{}(SortBytes{}, SortInt{}, SortInt{}) : SortBytes{} [function{}(), hook{}("BYTES.padLeft"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2151,20,2151,96)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblpadRightBytes'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Bytes'Unds'Int'Unds'Int{}(SortBytes{}, SortInt{}, SortInt{}) : SortBytes{} [function{}(), hook{}("BYTES.padRight"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2150,20,2150,98)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lblproject'ColnHash'tempFile'Coln'fd{}(SortIOFile{}) : SortInt{} [function{}()]
+  symbol Lblproject'ColnHash'tempFile'Coln'path{}(SortIOFile{}) : SortString{} [function{}()]
+  symbol Lblproject'ColnHash'unknownIOError'Coln'errno{}(SortIOError{}) : SortInt{} [function{}()]
+  symbol Lblproject'Coln'Bool{}(SortK{}) : SortBool{} [function{}()]
+  symbol Lblproject'Coln'Bytes{}(SortK{}) : SortBytes{} [function{}()]
+  symbol Lblproject'Coln'Endianness{}(SortK{}) : SortEndianness{} [function{}()]
+  symbol Lblproject'Coln'Float{}(SortK{}) : SortFloat{} [function{}()]
+  symbol Lblproject'Coln'Foo{}(SortK{}) : SortFoo{} [function{}()]
+  symbol Lblproject'Coln'GeneratedCounterCell{}(SortK{}) : SortGeneratedCounterCell{} [function{}()]
+  symbol Lblproject'Coln'GeneratedCounterCellOpt{}(SortK{}) : SortGeneratedCounterCellOpt{} [function{}()]
+  symbol Lblproject'Coln'GeneratedTopCell{}(SortK{}) : SortGeneratedTopCell{} [function{}()]
+  symbol Lblproject'Coln'GeneratedTopCellFragment{}(SortK{}) : SortGeneratedTopCellFragment{} [function{}()]
+  symbol Lblproject'Coln'IOError{}(SortK{}) : SortIOError{} [function{}()]
+  symbol Lblproject'Coln'IOFile{}(SortK{}) : SortIOFile{} [function{}()]
+  symbol Lblproject'Coln'IOInt{}(SortK{}) : SortIOInt{} [function{}()]
+  symbol Lblproject'Coln'IOString{}(SortK{}) : SortIOString{} [function{}()]
+  symbol Lblproject'Coln'Id{}(SortK{}) : SortId{} [function{}()]
+  symbol Lblproject'Coln'Int{}(SortK{}) : SortInt{} [function{}()]
+  symbol Lblproject'Coln'K{}(SortK{}) : SortK{} [function{}()]
+  symbol Lblproject'Coln'KCell{}(SortK{}) : SortKCell{} [function{}()]
+  symbol Lblproject'Coln'KCellOpt{}(SortK{}) : SortKCellOpt{} [function{}()]
+  symbol Lblproject'Coln'KItem{}(SortK{}) : SortKItem{} [function{}()]
+  symbol Lblproject'Coln'List{}(SortK{}) : SortList{} [function{}()]
+  symbol Lblproject'Coln'Map{}(SortK{}) : SortMap{} [function{}()]
+  symbol Lblproject'Coln'Set{}(SortK{}) : SortSet{} [function{}()]
+  symbol Lblproject'Coln'Signedness{}(SortK{}) : SortSignedness{} [function{}()]
+  symbol Lblproject'Coln'Stream{}(SortK{}) : SortStream{} [function{}()]
+  symbol Lblproject'Coln'String{}(SortK{}) : SortString{} [function{}()]
+  hooked-symbol LblpushList{}(SortKItem{}, SortList{}) : SortList{} [function{}(), functional{}(), hook{}("LIST.push"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(953,19,953,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("pushList"), total{}()]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), hook{}("INT.rand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1337,18,1337,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.removeAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,18,333,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortString{}, SortInt{}) : SortString{} [function{}(), hook{}("STRING.replace"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1838,21,1838,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.replaceAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1837,21,1837,149)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblreplaceAtBytes'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Bytes'Unds'Int'Unds'Bytes{}(SortBytes{}, SortInt{}, SortBytes{}) : SortBytes{} [function{}(), hook{}("BYTES.replaceAt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2123,20,2123,105)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.replaceFirst"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1839,21,1839,151)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblreverseBytes'LParUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Bytes{}(SortBytes{}) : SortBytes{} [function{}(), functional{}(), hook{}("BYTES.reverse"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2161,20,2161,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [function{}(), hook{}("STRING.rfindChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1765,18,1765,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [function{}(), hook{}("STRING.rfind"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1754,18,1754,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.signExtendBitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1304,18,1304,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblsignedBytes{}() : SortSignedness{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2037,25,2037,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("signedBytes")]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(SortSet{}) : SortInt{} [function{}(), functional{}(), hook{}("SET.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(794,18,794,76)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblsizeList{}(SortList{}) : SortInt{} [function{}(), functional{}(), hook{}("LIST.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1029,18,1029,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("smt_seq_len"), symbol'Kywd'{}("sizeList"), total{}()]
+  hooked-symbol LblsizeMap{}(SortMap{}) : SortInt{} [function{}(), functional{}(), hook{}("MAP.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(373,18,373,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("sizeMap"), total{}()]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT-COMMON'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [function{}(), hook{}("INT.srand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1338,16,1338,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblsubstrBytes'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Bytes'Unds'Int'Unds'Int{}(SortBytes{}, SortInt{}, SortInt{}) : SortBytes{} [function{}(), hook{}("BYTES.substr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2111,20,2111,101)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(SortString{}, SortInt{}, SortInt{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.substr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1743,21,1743,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol LblunsignedBytes{}() : SortSignedness{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2038,25,2038,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("unsignedBytes")]
+  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [function{}(), hook{}("LIST.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(993,19,993,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(324,18,324,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [function{}(), hook{}("MAP.values"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(365,19,365,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Tild'Int'Unds'{}(SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1237,18,1237,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("notInt"), symbol'Kywd'{}("~Int_"), total{}()]
+
+// generated axioms
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortEndianness{}, SortKItem{}} (From:SortEndianness{}))) [subsort{SortEndianness{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, inj{SortKCell{}, SortKCellOpt{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCellOpt{}, SortKItem{}} (From:SortKCellOpt{}))) [subsort{SortKCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMap{}, SortKItem{}} (From:SortMap{}))) [subsort{SortMap{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBytes{}, SortKItem{}} (From:SortBytes{}))) [subsort{SortBytes{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCell{}, SortKItem{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSet{}, SortKItem{}} (From:SortSet{}))) [subsort{SortSet{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOError{}, SortKItem{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortId{}, SortKItem{}} (From:SortId{}))) [subsort{SortId{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortFoo{}, SortKItem{}} (From:SortFoo{}))) [subsort{SortFoo{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (From:SortGeneratedCounterCellOpt{}))) [subsort{SortGeneratedCounterCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortList{}, SortKItem{}} (From:SortList{}))) [subsort{SortList{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCell{}, SortKItem{}} (From:SortGeneratedTopCell{}))) [subsort{SortGeneratedTopCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStream{}, SortKItem{}} (From:SortStream{}))) [subsort{SortStream{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBool{}, SortKItem{}} (From:SortBool{}))) [subsort{SortBool{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOString{}, SortKItem{}} (From:SortIOString{}))) [subsort{SortIOString{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOFile{}, SortKItem{}} (From:SortIOFile{}))) [subsort{SortIOFile{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSignedness{}, SortKItem{}} (From:SortSignedness{}))) [subsort{SortSignedness{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortFloat{}, SortKItem{}} (From:SortFloat{}))) [subsort{SortFloat{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortString{}, SortKItem{}} (From:SortString{}))) [subsort{SortString{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOInt{}, SortKItem{}} (From:SortIOInt{}))) [subsort{SortIOInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (From:SortGeneratedTopCellFragment{}))) [subsort{SortGeneratedTopCellFragment{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOInt{}, \equals{SortIOInt{}, R} (Val:SortIOInt{}, inj{SortInt{}, SortIOInt{}} (From:SortInt{}))) [subsort{SortInt{}, SortIOInt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOInt{}, \equals{SortIOInt{}, R} (Val:SortIOInt{}, inj{SortIOError{}, SortIOInt{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOInt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOString{}, \equals{SortIOString{}, R} (Val:SortIOString{}, inj{SortString{}, SortIOString{}} (From:SortString{}))) [subsort{SortString{}, SortIOString{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOString{}, \equals{SortIOString{}, R} (Val:SortIOString{}, inj{SortIOError{}, SortIOString{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOString{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOFile{}, \equals{SortIOFile{}, R} (Val:SortIOFile{}, inj{SortIOError{}, SortIOFile{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOFile{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKConfigVar{}, SortKItem{}} (From:SortKConfigVar{}))) [subsort{SortKConfigVar{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'E2BIG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EACCES{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EADDRINUSE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EADDRNOTAVAIL{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EAFNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EAGAIN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EALREADY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EBADF{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EBUSY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECHILD{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNABORTED{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNREFUSED{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNRESET{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDEADLK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDESTADDRREQ{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDOM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EEXIST{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EFAULT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EFBIG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EHOSTDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EHOSTUNREACH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINPROGRESS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINTR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINVAL{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EIO{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EISCONN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EISDIR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ELOOP{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMFILE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMLINK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMSGSIZE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENAMETOOLONG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETRESET{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETUNREACH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENFILE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOBUFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENODEV{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOENT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOEXEC{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOLCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOMEM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOPROTOOPT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOSPC{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOSYS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTCONN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTDIR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTEMPTY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTSOCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTTY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENXIO{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOF{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOPNOTSUPP{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOVERFLOW{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPERM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPFNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPIPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPROTONOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPROTOTYPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ERANGE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EROFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESHUTDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESOCKTNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESPIPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESRCH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ETIMEDOUT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ETOOMANYREFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EWOULDBLOCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EXDEV{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(Y0:SortK{})), Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{})), Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'log{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'logToFile{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{})), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(X0:SortString{}, X1:SortString{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{})), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(\and{SortString{}} (X0:SortString{}, Y0:SortString{}), \and{SortString{}} (X1:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'remove'LParUndsRParUnds'K-IO'Unds'K'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'systemResult{}(K0:SortInt{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'systemResult{}(X0:SortInt{}, X1:SortString{}, X2:SortString{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{})), Lbl'Hash'systemResult{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}), \and{SortString{}} (X1:SortString{}, Y1:SortString{}), \and{SortString{}} (X2:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortIOFile{}, \equals{SortIOFile{}, R} (Val:SortIOFile{}, Lbl'Hash'tempFile{}(K0:SortString{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortIOFile{}} (\and{SortIOFile{}} (Lbl'Hash'tempFile{}(X0:SortString{}, X1:SortInt{}), Lbl'Hash'tempFile{}(Y0:SortString{}, Y1:SortInt{})), Lbl'Hash'tempFile{}(\and{SortString{}} (X0:SortString{}, Y0:SortString{}), \and{SortInt{}} (X1:SortInt{}, Y1:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'trace{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'traceK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'unknownIOError{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'unknownIOError{}(Y0:SortInt{})), Lbl'Hash'unknownIOError{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBytes{}, \equals{SortBytes{}, R} (Val:SortBytes{}, Lbl'Stop'Bytes'Unds'BYTES-HOOKED'Unds'Bytes{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Stop'Set{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, Lbl'-LT-'generatedCounter'-GT-'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedCounterCell{}} (\and{SortGeneratedCounterCell{}} (Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{}), Lbl'-LT-'generatedCounter'-GT-'{}(Y0:SortInt{})), Lbl'-LT-'generatedCounter'-GT-'{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCell{}, \equals{SortGeneratedTopCell{}, R} (Val:SortGeneratedTopCell{}, Lbl'-LT-'generatedTop'-GT-'{}(K0:SortKCell{}, K1:SortGeneratedCounterCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCell{}} (\and{SortGeneratedTopCell{}} (Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}), Lbl'-LT-'generatedTop'-GT-'{}(Y0:SortKCell{}, Y1:SortGeneratedCounterCell{})), Lbl'-LT-'generatedTop'-GT-'{}(\and{SortKCell{}} (X0:SortKCell{}, Y0:SortKCell{}), \and{SortGeneratedCounterCell{}} (X1:SortGeneratedCounterCell{}, Y1:SortGeneratedCounterCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCellFragment{}, \equals{SortGeneratedTopCellFragment{}, R} (Val:SortGeneratedTopCellFragment{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(K0:SortKCellOpt{}, K1:SortGeneratedCounterCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCellFragment{}} (\and{SortGeneratedTopCellFragment{}} (Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}), Lbl'-LT-'generatedTop'-GT-'-fragment{}(Y0:SortKCellOpt{}, Y1:SortGeneratedCounterCellOpt{})), Lbl'-LT-'generatedTop'-GT-'-fragment{}(\and{SortKCellOpt{}} (X0:SortKCellOpt{}, Y0:SortKCellOpt{}), \and{SortGeneratedCounterCellOpt{}} (X1:SortGeneratedCounterCellOpt{}, Y1:SortGeneratedCounterCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, Lbl'-LT-'k'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblBytes2Int'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Int'Unds'Bytes'Unds'Endianness'Unds'Signedness{}(K0:SortBytes{}, K1:SortEndianness{}, K2:SortSignedness{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblBytes2String'LParUndsRParUnds'BYTES-HOOKED'Unds'String'Unds'Bytes{}(K0:SortBytes{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblFloat2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float{}(K0:SortFloat{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblId2String'LParUndsRParUnds'ID-COMMON'Unds'String'Unds'Id{}(K0:SortId{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBytes{}, \equals{SortBytes{}, R} (Val:SortBytes{}, LblInt2Bytes'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Int'Unds'Int'Unds'Endianness{}(K0:SortInt{}, K1:SortInt{}, K2:SortEndianness{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBytes{}, \equals{SortBytes{}, R} (Val:SortBytes{}, LblInt2BytesNoLen{}(K0:SortInt{}, K1:SortEndianness{}, K2:SortSignedness{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, LblMap'Coln'lookupOrDefault{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblMap'Coln'update{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortKItem{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBytes{}, \equals{SortBytes{}, R} (Val:SortBytes{}, LblString2Bytes'LParUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBytes{}, \equals{SortBytes{}, R} (Val:SortBytes{}, Lbl'UndsPlus'Bytes'UndsUnds'BYTES-HOOKED'Unds'Bytes'Unds'Bytes'Unds'Bytes{}(K0:SortBytes{}, K1:SortBytes{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:SortList{},K2:SortList{}),K3:SortList{}),Lbl'Unds'List'Unds'{}(K1:SortList{},Lbl'Unds'List'Unds'{}(K2:SortList{},K3:SortList{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(K:SortList{},Lbl'Stop'List{}()),K:SortList{}) [unit{}()] // right unit
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Stop'List{}(),K:SortList{}),K:SortList{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K:SortMap{},Lbl'Stop'Map{}()),K:SortMap{}) [unit{}()] // right unit
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),K:SortMap{}),K:SortMap{}) [unit{}()] // left unit
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},Lbl'Stop'Set{}()),K:SortSet{}) [unit{}()] // right unit
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Stop'Set{}(),K:SortSet{}),K:SortSet{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'inList'Unds'{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(K0:SortKItem{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortKItem{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortFoo{}, \equals{SortFoo{}, R} (Val:SortFoo{}, Lblbar{}(K0:SortBytes{}))) [functional{}()] // functional
+  axiom{}\implies{SortFoo{}} (\and{SortFoo{}} (Lblbar{}(X0:SortBytes{}), Lblbar{}(Y0:SortBytes{})), Lblbar{}(\and{SortBytes{}} (X0:SortBytes{}, Y0:SortBytes{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lblbar{}(X0:SortBytes{}), Lblfoo{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortEndianness{}, \equals{SortEndianness{}, R} (Val:SortEndianness{}, LblbigEndianBytes{}())) [functional{}()] // functional
+  axiom{}\not{SortEndianness{}} (\and{SortEndianness{}} (LblbigEndianBytes{}(), LbllittleEndianBytes{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortFoo{}, \equals{SortFoo{}, R} (Val:SortFoo{}, Lblfoo{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, LblinitGeneratedCounterCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBool{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBytes{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisEndianness{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisFloat{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisFoo{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCellFragment{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOError{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOFile{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOString{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisId{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKConfigVar{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisList{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMap{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisSet{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisSignedness{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisStream{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisString{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R, SortSort} \exists{R} (Val:SortSort, \equals{SortSort, R} (Val:SortSort, Lblite{SortSort}(K0:SortBool{}, K1:SortSort, K2:SortSort))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LbllengthBytes'LParUndsRParUnds'BYTES-HOOKED'Unds'Int'Unds'Bytes{}(K0:SortBytes{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortEndianness{}, \equals{SortEndianness{}, R} (Val:SortEndianness{}, LbllittleEndianBytes{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, LblnoGeneratedCounterCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, LblnoKCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblpushList{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBytes{}, \equals{SortBytes{}, R} (Val:SortBytes{}, LblreverseBytes'LParUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Bytes{}(K0:SortBytes{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSignedness{}, \equals{SortSignedness{}, R} (Val:SortSignedness{}, LblsignedBytes{}())) [functional{}()] // functional
+  axiom{}\not{SortSignedness{}} (\and{SortSignedness{}} (LblsignedBytes{}(), LblunsignedBytes{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblsizeList{}(K0:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblsizeMap{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(K0:SortString{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSignedness{}, \equals{SortSignedness{}, R} (Val:SortSignedness{}, LblunsignedBytes{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'Unds'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortBytes{}} (\top{SortBytes{}}(), \bottom{SortBytes{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortEndianness{}} (LblbigEndianBytes{}(), LbllittleEndianBytes{}(), \bottom{SortEndianness{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortFloat{}} (\top{SortFloat{}}(), \bottom{SortFloat{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortFoo{}} (\exists{SortFoo{}} (X0:SortBytes{}, Lblbar{}(X0:SortBytes{})), Lblfoo{}(), \bottom{SortFoo{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCellOpt{}} (LblnoGeneratedCounterCell{}(), \exists{SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{})), \bottom{SortGeneratedCounterCellOpt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCell{}} (\exists{SortGeneratedTopCell{}} (X0:SortKCell{}, \exists{SortGeneratedTopCell{}} (X1:SortGeneratedCounterCell{}, Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}))), \bottom{SortGeneratedTopCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCellFragment{}} (\exists{SortGeneratedTopCellFragment{}} (X0:SortKCellOpt{}, \exists{SortGeneratedTopCellFragment{}} (X1:SortGeneratedCounterCellOpt{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}))), \bottom{SortGeneratedTopCellFragment{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EACCES{}(), Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EAGAIN{}(), Lbl'Hash'EALREADY{}(), Lbl'Hash'EBADF{}(), Lbl'Hash'EBUSY{}(), Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDEADLK{}(), Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EDOM{}(), Lbl'Hash'EEXIST{}(), Lbl'Hash'EFAULT{}(), Lbl'Hash'EFBIG{}(), Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EINTR{}(), Lbl'Hash'EINVAL{}(), Lbl'Hash'EIO{}(), Lbl'Hash'EISCONN{}(), Lbl'Hash'EISDIR{}(), Lbl'Hash'ELOOP{}(), Lbl'Hash'EMFILE{}(), Lbl'Hash'EMLINK{}(), Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOTTY{}(), Lbl'Hash'ENXIO{}(), Lbl'Hash'EOF{}(), Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPERM{}(), Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPIPE{}(), Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ERANGE{}(), Lbl'Hash'EROFS{}(), Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESPIPE{}(), Lbl'Hash'ESRCH{}(), Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EXDEV{}(), \exists{SortIOError{}} (X0:SortInt{}, Lbl'Hash'unknownIOError{}(X0:SortInt{})), \bottom{SortIOError{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOFile{}} (\exists{SortIOFile{}} (X0:SortString{}, \exists{SortIOFile{}} (X1:SortInt{}, Lbl'Hash'tempFile{}(X0:SortString{}, X1:SortInt{}))), \exists{SortIOFile{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOFile{}} (Val:SortIOError{})), \bottom{SortIOFile{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOInt{}} (\exists{SortIOInt{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOInt{}} (Val:SortIOError{})), \exists{SortIOInt{}} (Val:SortInt{}, inj{SortInt{}, SortIOInt{}} (Val:SortInt{})), \bottom{SortIOInt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOString{}} (\exists{SortIOString{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOString{}} (Val:SortIOError{})), \exists{SortIOString{}} (Val:SortString{}, inj{SortString{}, SortIOString{}} (Val:SortString{})), \bottom{SortIOString{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortId{}} (\top{SortId{}}(), \bottom{SortId{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKCellOpt{}} (LblnoKCell{}(), \exists{SortKCellOpt{}} (Val:SortKCell{}, inj{SortKCell{}, SortKCellOpt{}} (Val:SortKCell{})), \bottom{SortKCellOpt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortInt{}, \exists{SortKItem{}} (X1:SortString{}, \exists{SortKItem{}} (X2:SortString{}, Lbl'Hash'systemResult{}(X0:SortInt{}, X1:SortString{}, X2:SortString{})))), \exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \exists{SortKItem{}} (Val:SortBytes{}, inj{SortBytes{}, SortKItem{}} (Val:SortBytes{})), \exists{SortKItem{}} (Val:SortEndianness{}, inj{SortEndianness{}, SortKItem{}} (Val:SortEndianness{})), \exists{SortKItem{}} (Val:SortFloat{}, inj{SortFloat{}, SortKItem{}} (Val:SortFloat{})), \exists{SortKItem{}} (Val:SortFoo{}, inj{SortFoo{}, SortKItem{}} (Val:SortFoo{})), \exists{SortKItem{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (Val:SortGeneratedCounterCell{})), \exists{SortKItem{}} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (Val:SortGeneratedCounterCellOpt{})), \exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \exists{SortKItem{}} (Val:SortIOError{}, inj{SortIOError{}, SortKItem{}} (Val:SortIOError{})), \exists{SortKItem{}} (Val:SortIOFile{}, inj{SortIOFile{}, SortKItem{}} (Val:SortIOFile{})), \exists{SortKItem{}} (Val:SortIOInt{}, inj{SortIOInt{}, SortKItem{}} (Val:SortIOInt{})), \exists{SortKItem{}} (Val:SortIOString{}, inj{SortIOString{}, SortKItem{}} (Val:SortIOString{})), \exists{SortKItem{}} (Val:SortId{}, inj{SortId{}, SortKItem{}} (Val:SortId{})), \exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \exists{SortKItem{}} (Val:SortKConfigVar{}, inj{SortKConfigVar{}, SortKItem{}} (Val:SortKConfigVar{})), \exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \exists{SortKItem{}} (Val:SortSignedness{}, inj{SortSignedness{}, SortKItem{}} (Val:SortSignedness{})), \exists{SortKItem{}} (Val:SortStream{}, inj{SortStream{}, SortKItem{}} (Val:SortStream{})), \exists{SortKItem{}} (Val:SortString{}, inj{SortString{}, SortKItem{}} (Val:SortString{})), \bottom{SortKItem{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortSignedness{}} (LblsignedBytes{}(), LblunsignedBytes{}(), \bottom{SortSignedness{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortStream{}} (\exists{SortStream{}} (X0:SortK{}, Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{})), \exists{SortStream{}} (X0:SortInt{}, Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{})), \exists{SortStream{}} (X0:SortInt{}, Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{})), \exists{SortStream{}} (X0:SortString{}, \exists{SortStream{}} (X1:SortString{}, Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(X0:SortString{}, X1:SortString{}))), \bottom{SortStream{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortString{}} (\top{SortString{}}(), \bottom{SortString{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+
+// rules
+// rule `#open(_)_K-IO_IOInt_String`(S)=>`#open(_,_)_K-IO_IOInt_String_String`(S,#token("\"r+\"","String")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7ad2779cd54b9009119458217cae5138026cc4ff244e54c28e64db21100f63d9), org.kframework.attributes.Location(Location(2487,8,2487,48)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS:SortString{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOInt{},R} (
+      Lbl'Hash'open'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'String{}(X0:SortString{}),
+     \and{SortIOInt{}} (
+       Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'Unds'IOInt'Unds'String'Unds'String{}(VarS:SortString{},\dv{SortString{}}("r+")),
+        \top{SortIOInt{}}())))
+  [UNIQUE'Unds'ID{}("7ad2779cd54b9009119458217cae5138026cc4ff244e54c28e64db21100f63d9"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2487,8,2487,48)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `#stderr_K-IO_Int`(.KList)=>#token("2","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(75e0a8082acda4cf1e29caa6aaafb7f9a421e16421a41f2006943d6fab17a162), org.kframework.attributes.Location(Location(2584,8,2584,20)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortInt{},R} (
+      Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}(),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("2"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("75e0a8082acda4cf1e29caa6aaafb7f9a421e16421a41f2006943d6fab17a162"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2584,8,2584,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `#stdin_K-IO_Int`(.KList)=>#token("0","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c7ffdc9908c28a954521816d680f4e5ec44a679c7231a8dd09d4700f50b6d8c3), org.kframework.attributes.Location(Location(2582,8,2582,19)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortInt{},R} (
+      Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}(),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("0"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("c7ffdc9908c28a954521816d680f4e5ec44a679c7231a8dd09d4700f50b6d8c3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2582,8,2582,19)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `#stdout_K-IO_Int`(.KList)=>#token("1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4ad4f379ff9db687ff9dfd1b15052edbcd3342a2ed262ecdd38c769e177a592c), org.kframework.attributes.Location(Location(2583,8,2583,20)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortInt{},R} (
+      Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}(),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("1"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("4ad4f379ff9db687ff9dfd1b15052edbcd3342a2ed262ecdd38c769e177a592c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2583,8,2583,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Foo,KItem}(foo(.KList))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Foo,KItem}(bar(`Int2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Int_Endianness`(#token("10","Int"),#token("3489","Int"),bigEndianBytes(.KList))))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(6d218eb16d2e2cd368edcfeaf1124f3b7a80c625a70bac2b57a423993539d244), org.kframework.attributes.Location(Location(13,8,13,45)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/llvm-backend/test/c/k-files/flat-namespace.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblfoo{}()),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblbar{}(LblInt2Bytes'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Int'Unds'Int'Unds'Endianness{}(\dv{SortInt{}}("10"),\dv{SortInt{}}("3489"),LblbigEndianBytes{}()))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("6d218eb16d2e2cd368edcfeaf1124f3b7a80c625a70bac2b57a423993539d244"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(13,8,13,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/c/k-files/flat-namespace.k)")]
+
+// rule `Bool2String(_)_STRING-COMMON_String_Bool`(#token("false","Bool"))=>#token("\"false\"","String") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cca4780e4e7660055f781b9643f3125234a0f4f08ba76cacf8e5a18fe7fc999f), org.kframework.attributes.Location(Location(1773,8,1773,37)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(X0:SortBool{}),
+     \and{SortString{}} (
+       \dv{SortString{}}("false"),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("cca4780e4e7660055f781b9643f3125234a0f4f08ba76cacf8e5a18fe7fc999f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1773,8,1773,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `Bool2String(_)_STRING-COMMON_String_Bool`(#token("true","Bool"))=>#token("\"true\"","String") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(365df37345a5a44ac061f8741369c7bd74a49f0f6e7b716be0374806dd1add3d), org.kframework.attributes.Location(Location(1772,8,1772,36)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(X0:SortBool{}),
+     \and{SortString{}} (
+       \dv{SortString{}}("true"),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("365df37345a5a44ac061f8741369c7bd74a49f0f6e7b716be0374806dd1add3d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1772,8,1772,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `Int2BytesNoLen`(#token("-1","Int") #as _Gen0,E,signedBytes(.KList))=>`Int2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Int_Endianness`(#token("1","Int"),_Gen0,E) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2464f112da5a6bd317bd14b09af4083db0abae2d0c13691682efaac88629ab4b), org.kframework.attributes.Location(Location(2220,8,2220,67)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            \and{SortInt{}}(\dv{SortInt{}}("-1"),Var'Unds'Gen0:SortInt{})
+          ),\and{R} (
+          \in{SortEndianness{}, R} (
+            X1:SortEndianness{},
+            VarE:SortEndianness{}
+          ),\and{R} (
+          \in{SortSignedness{}, R} (
+            X2:SortSignedness{},
+            LblsignedBytes{}()
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortBytes{},R} (
+      LblInt2BytesNoLen{}(X0:SortInt{},X1:SortEndianness{},X2:SortSignedness{}),
+     \and{SortBytes{}} (
+       LblInt2Bytes'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Int'Unds'Int'Unds'Endianness{}(\dv{SortInt{}}("1"),Var'Unds'Gen0:SortInt{},VarE:SortEndianness{}),
+        \top{SortBytes{}}())))
+  [UNIQUE'Unds'ID{}("2464f112da5a6bd317bd14b09af4083db0abae2d0c13691682efaac88629ab4b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2220,8,2220,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `Int2BytesNoLen`(I,E,signedBytes(.KList))=>`Int2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Int_Endianness`(`_/Int_`(`_+Int_`(`log2Int(_)_INT-COMMON_Int_Int`(I),#token("9","Int")),#token("8","Int")),I,E) requires `_>Int_`(I,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(20f05d9e70a7a8f574addbed279025551280428855c7413d70440622e944ceed), org.kframework.attributes.Location(Location(2216,8,2217,22)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)]), preserves-definedness]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-'Int'Unds'{}(VarI:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortEndianness{}, R} (
+            X1:SortEndianness{},
+            VarE:SortEndianness{}
+          ),\and{R} (
+          \in{SortSignedness{}, R} (
+            X2:SortSignedness{},
+            LblsignedBytes{}()
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortBytes{},R} (
+      LblInt2BytesNoLen{}(X0:SortInt{},X1:SortEndianness{},X2:SortSignedness{}),
+     \and{SortBytes{}} (
+       LblInt2Bytes'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Int'Unds'Int'Unds'Endianness{}(Lbl'UndsSlsh'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI:SortInt{}),\dv{SortInt{}}("9")),\dv{SortInt{}}("8")),VarI:SortInt{},VarE:SortEndianness{}),
+        \top{SortBytes{}}())))
+  [UNIQUE'Unds'ID{}("20f05d9e70a7a8f574addbed279025551280428855c7413d70440622e944ceed"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2216,8,2217,22)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), preserves-definedness{}()]
+
+// rule `Int2BytesNoLen`(I,E,signedBytes(.KList))=>`Int2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Int_Endianness`(`_/Int_`(`_+Int_`(`log2Int(_)_INT-COMMON_Int_Int`(`~Int_`(I)),#token("9","Int")),#token("8","Int")),I,E) requires `_<Int_`(I,#token("-1","Int")) ensures #token("true","Bool") [UNIQUE_ID(43f856e27d1ef303c7d702358487c01fc438c8c901cf7be61d5c10ca384b64d9), org.kframework.attributes.Location(Location(2218,8,2219,23)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)]), preserves-definedness]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'Unds'{}(VarI:SortInt{},\dv{SortInt{}}("-1")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortEndianness{}, R} (
+            X1:SortEndianness{},
+            VarE:SortEndianness{}
+          ),\and{R} (
+          \in{SortSignedness{}, R} (
+            X2:SortSignedness{},
+            LblsignedBytes{}()
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortBytes{},R} (
+      LblInt2BytesNoLen{}(X0:SortInt{},X1:SortEndianness{},X2:SortSignedness{}),
+     \and{SortBytes{}} (
+       LblInt2Bytes'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Int'Unds'Int'Unds'Endianness{}(Lbl'UndsSlsh'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(Lbl'Tild'Int'Unds'{}(VarI:SortInt{})),\dv{SortInt{}}("9")),\dv{SortInt{}}("8")),VarI:SortInt{},VarE:SortEndianness{}),
+        \top{SortBytes{}}())))
+  [UNIQUE'Unds'ID{}("43f856e27d1ef303c7d702358487c01fc438c8c901cf7be61d5c10ca384b64d9"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2218,8,2219,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), preserves-definedness{}()]
+
+// rule `Int2BytesNoLen`(I,E,unsignedBytes(.KList))=>`Int2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Int_Endianness`(`_/Int_`(`_+Int_`(`log2Int(_)_INT-COMMON_Int_Int`(I),#token("8","Int")),#token("8","Int")),I,E) requires `_>Int_`(I,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(e9743d519935dba707873fc47cbb21aec1128cd8f420f3b8ac5987f134fa4af0), org.kframework.attributes.Location(Location(2213,8,2214,22)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)]), preserves-definedness]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-'Int'Unds'{}(VarI:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortEndianness{}, R} (
+            X1:SortEndianness{},
+            VarE:SortEndianness{}
+          ),\and{R} (
+          \in{SortSignedness{}, R} (
+            X2:SortSignedness{},
+            LblunsignedBytes{}()
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortBytes{},R} (
+      LblInt2BytesNoLen{}(X0:SortInt{},X1:SortEndianness{},X2:SortSignedness{}),
+     \and{SortBytes{}} (
+       LblInt2Bytes'LParUndsCommUndsCommUndsRParUnds'BYTES-HOOKED'Unds'Bytes'Unds'Int'Unds'Int'Unds'Endianness{}(Lbl'UndsSlsh'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI:SortInt{}),\dv{SortInt{}}("8")),\dv{SortInt{}}("8")),VarI:SortInt{},VarE:SortEndianness{}),
+        \top{SortBytes{}}())))
+  [UNIQUE'Unds'ID{}("e9743d519935dba707873fc47cbb21aec1128cd8f420f3b8ac5987f134fa4af0"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2213,8,2214,22)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), preserves-definedness{}()]
+
+// rule `Int2BytesNoLen`(#token("0","Int"),_Gen0,_Gen1)=>`.Bytes_BYTES-HOOKED_Bytes`(.KList) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5103ec44e9087400a3f53b6de7facac69488940261ed78d881e17005fe732e24), org.kframework.attributes.Location(Location(2215,8,2215,48)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            \dv{SortInt{}}("0")
+          ),\and{R} (
+          \in{SortEndianness{}, R} (
+            X1:SortEndianness{},
+            Var'Unds'Gen0:SortEndianness{}
+          ),\and{R} (
+          \in{SortSignedness{}, R} (
+            X2:SortSignedness{},
+            Var'Unds'Gen1:SortSignedness{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortBytes{},R} (
+      LblInt2BytesNoLen{}(X0:SortInt{},X1:SortEndianness{},X2:SortSignedness{}),
+     \and{SortBytes{}} (
+       Lbl'Stop'Bytes'Unds'BYTES-HOOKED'Unds'Bytes{}(),
+        \top{SortBytes{}}())))
+  [UNIQUE'Unds'ID{}("5103ec44e9087400a3f53b6de7facac69488940261ed78d881e17005fe732e24"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2215,8,2215,48)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `String2Bool(_)_STRING-COMMON_Bool_String`(#token("\"false\"","String"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b73b5c8e0ae45020f2b9b8170d366691fee01a63763b79653a2075703ec4e835), org.kframework.attributes.Location(Location(1779,8,1779,37)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            \dv{SortString{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(X0:SortString{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b73b5c8e0ae45020f2b9b8170d366691fee01a63763b79653a2075703ec4e835"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1779,8,1779,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `String2Bool(_)_STRING-COMMON_Bool_String`(#token("\"true\"","String"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(27a5d1d7872d61f82556a4e44bda13846dde7dc2d9c54304d7858de9a8b9d6b8), org.kframework.attributes.Location(Location(1778,8,1778,36)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            \dv{SortString{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(X0:SortString{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("27a5d1d7872d61f82556a4e44bda13846dde7dc2d9c54304d7858de9a8b9d6b8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1778,8,1778,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_<=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_<String__STRING-COMMON_Bool_String_String`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9e50fb4dcba1212ee863c170298cb8b555f39fb3b4bcb649f3d1d8e321accc80), org.kframework.attributes.Location(Location(1872,8,1872,63)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9e50fb4dcba1212ee863c170298cb8b555f39fb3b4bcb649f3d1d8e321accc80"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1872,8,1872,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_=/=Bool_`(B1,B2)=>`notBool_`(`_==Bool_`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f), org.kframework.attributes.Location(Location(1159,8,1159,57)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB1:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB2:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(VarB1:SortBool{},VarB2:SortBool{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1159,8,1159,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_=/=Int_`(I1,I2)=>`notBool_`(`_==Int_`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3), org.kframework.attributes.Location(Location(1438,8,1438,53)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Int'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1438,8,1438,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c), org.kframework.attributes.Location(Location(2316,8,2316,45)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarK2:SortK{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2316,8,2316,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_=/=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_==String__STRING-COMMON_Bool_String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f390a9b650f3de0e3a93773a46e65aae3decdeb2a10906058f204f031681c9b7), org.kframework.attributes.Location(Location(1852,8,1852,65)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f390a9b650f3de0e3a93773a46e65aae3decdeb2a10906058f204f031681c9b7"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1852,8,1852,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_>=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_<String__STRING-COMMON_Bool_String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b376ffb0925555ed27696d73fc8fe43306e2005e4cf6ad819e860958992f9f17), org.kframework.attributes.Location(Location(1874,8,1874,63)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b376ffb0925555ed27696d73fc8fe43306e2005e4cf6ad819e860958992f9f17"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1874,8,1874,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_>String__STRING-COMMON_Bool_String_String`(S1,S2)=>`_<String__STRING-COMMON_Bool_String_String`(S2,S1) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8e5353c0a58491f8613ad7a35d0833206c342df0c91773e42485e52f4dad0cd0), org.kframework.attributes.Location(Location(1873,8,1873,52)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{}),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("8e5353c0a58491f8613ad7a35d0833206c342df0c91773e42485e52f4dad0cd0"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1873,8,1873,52)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_andBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497), org.kframework.attributes.Location(Location(1132,8,1132,37)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1132,8,1132,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(72139ee1f2b9362a47514de6503329ccf3c27e74e3ebfa0c0fe26321ec13f281), org.kframework.attributes.Location(Location(1131,8,1131,37)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("72139ee1f2b9362a47514de6503329ccf3c27e74e3ebfa0c0fe26321ec13f281"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1131,8,1131,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_andBool_`(_Gen0,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd61c826168aab115cd7f528702e8187ca16195bdcf29f42f33a32c83afebb12), org.kframework.attributes.Location(Location(1133,8,1133,37)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fd61c826168aab115cd7f528702e8187ca16195bdcf29f42f33a32c83afebb12"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1133,8,1133,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f), org.kframework.attributes.Location(Location(1130,8,1130,37)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1130,8,1130,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_andThenBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d), org.kframework.attributes.Location(Location(1137,8,1137,36)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1137,8,1137,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_andThenBool_`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2cfb33affb9c668d39a4a7267156085e1dbd3584fc7925b1aa9a1672bb9eab9f), org.kframework.attributes.Location(Location(1136,8,1136,37)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(VarK:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2cfb33affb9c668d39a4a7267156085e1dbd3584fc7925b1aa9a1672bb9eab9f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1136,8,1136,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_andThenBool_`(_Gen0,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(198861009d03d8f5220000f16342962720be289ca0d49b12953fb2693e2fea01), org.kframework.attributes.Location(Location(1138,8,1138,36)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("198861009d03d8f5220000f16342962720be289ca0d49b12953fb2693e2fea01"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1138,8,1138,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_andThenBool_`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689), org.kframework.attributes.Location(Location(1135,8,1135,37)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1135,8,1135,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_divInt_`(I1,I2)=>`_/Int_`(`_-Int_`(I1,`_modInt_`(I1,I2)),I2) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4), org.kframework.attributes.Location(Location(1427,8,1428,23)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      Lbl'Unds'divInt'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsSlsh'Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1427,8,1428,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_dividesInt__INT-COMMON_Bool_Int_Int`(I1,I2)=>`_==Int_`(`_%Int_`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5), org.kframework.attributes.Location(Location(1439,8,1439,58)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       Lbl'UndsEqlsEqls'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0")),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1439,8,1439,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_impliesBool_`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(93b8d798abd6d9999e0e733384ad161e9a0bd2f074623a742afdc63964380aba), org.kframework.attributes.Location(Location(1157,8,1157,45)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(VarB:SortBool{}),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("93b8d798abd6d9999e0e733384ad161e9a0bd2f074623a742afdc63964380aba"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1157,8,1157,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_impliesBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b4994db7b40b72dc09ac8d5d036263b215c37d45f45d764251d8b607a7592ba), org.kframework.attributes.Location(Location(1156,8,1156,39)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2b4994db7b40b72dc09ac8d5d036263b215c37d45f45d764251d8b607a7592ba"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1156,8,1156,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_impliesBool_`(#token("false","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e), org.kframework.attributes.Location(Location(1155,8,1155,40)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1155,8,1155,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_impliesBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d), org.kframework.attributes.Location(Location(1154,8,1154,36)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1154,8,1154,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_modInt_`(I1,I2)=>`_%Int_`(`_+Int_`(`_%Int_`(I1,`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(44257f63a99a0583c2d10058edbff90118966e30914b3a637b8315212c681bc4), concrete, org.kframework.attributes.Location(Location(1430,5,1433,23)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)]), simplification]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \equals{SortInt{},R} (
+      Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsPerc'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("44257f63a99a0583c2d10058edbff90118966e30914b3a637b8315212c681bc4"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1430,5,1433,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a5bb27ab54700cb845d17b12e0b0a4cbd5c8944272bcbe0d15ccc0b44d0049ff), org.kframework.attributes.Location(Location(1147,8,1147,32)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a5bb27ab54700cb845d17b12e0b0a4cbd5c8944272bcbe0d15ccc0b44d0049ff"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1147,8,1147,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(942af273100b5a3c1fb3d0c8cc92b0bf845a7b34444c5a6c35b7d3fe72bef48e), org.kframework.attributes.Location(Location(1145,8,1145,34)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("942af273100b5a3c1fb3d0c8cc92b0bf845a7b34444c5a6c35b7d3fe72bef48e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1145,8,1145,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b), org.kframework.attributes.Location(Location(1146,8,1146,32)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1146,8,1146,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_orBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2), org.kframework.attributes.Location(Location(1144,8,1144,34)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1144,8,1144,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_orElseBool_`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(13cf42d440f9a7a360a8136ee4b35ae7b99501f515322d214c3b866691f4713b), org.kframework.attributes.Location(Location(1152,8,1152,37)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(VarK:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("13cf42d440f9a7a360a8136ee4b35ae7b99501f515322d214c3b866691f4713b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1152,8,1152,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orElseBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2459cad4fbb946a5c7f71565601afeeec79f05f41497b1f7ef547578c88f3158), org.kframework.attributes.Location(Location(1150,8,1150,33)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2459cad4fbb946a5c7f71565601afeeec79f05f41497b1f7ef547578c88f3158"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1150,8,1150,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orElseBool_`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf), org.kframework.attributes.Location(Location(1151,8,1151,37)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1151,8,1151,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_orElseBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6), org.kframework.attributes.Location(Location(1149,8,1149,33)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1149,8,1149,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_xorBool_`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f), org.kframework.attributes.Location(Location(1142,8,1142,38)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1142,8,1142,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_xorBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(69f518203376930fb76ce51df5dd0c6c81d19f71eba3a1852afa5301d02eb4fa), org.kframework.attributes.Location(Location(1141,8,1141,38)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("69f518203376930fb76ce51df5dd0c6c81d19f71eba3a1852afa5301d02eb4fa"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1141,8,1141,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_xorBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf), org.kframework.attributes.Location(Location(1140,8,1140,38)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1140,8,1140,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_|Set__SET_Set_Set_Set`(S1,S2)=>`_Set_`(S1,`Set:difference`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c384edb8f3875244a593dda6163c3dee1bce5485e4e1848892aebc2bab67d2e9), concrete, org.kframework.attributes.Location(Location(749,8,749,45)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortSet{}, R} (
+            X0:SortSet{},
+            VarS1:SortSet{}
+          ),\and{R} (
+          \in{SortSet{}, R} (
+            X1:SortSet{},
+            VarS2:SortSet{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortSet{},R} (
+      Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(X0:SortSet{},X1:SortSet{}),
+     \and{SortSet{}} (
+       Lbl'Unds'Set'Unds'{}(VarS1:SortSet{},LblSet'Coln'difference{}(VarS2:SortSet{},VarS1:SortSet{})),
+        \top{SortSet{}}())))
+  [UNIQUE'Unds'ID{}("c384edb8f3875244a593dda6163c3dee1bce5485e4e1848892aebc2bab67d2e9"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(749,8,749,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_modInt_`(`_>>Int_`(I,IDX),`_<<Int_`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119), org.kframework.attributes.Location(Location(1423,8,1423,85)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'modInt'Unds'{}(Lbl'Unds-GT--GT-'Int'Unds'{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1423,8,1423,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToCount)=>`_+Int_`(#token("1","Int"),`countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToCount)),`lengthString(_)_STRING-COMMON_Int_String`(Source)),ToCount)) requires `_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(628cff029a6d79e4c99999c0309f91ab8cb12f0ba549bb3faa850f96304c970e), org.kframework.attributes.Location(Location(1883,8,1884,60)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToCount:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortInt{}} (
+       Lbl'UndsPlus'Int'Unds'{}(\dv{SortInt{}}("1"),LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToCount:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})),VarToCount:SortString{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("628cff029a6d79e4c99999c0309f91ab8cb12f0ba549bb3faa850f96304c970e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1883,8,1884,60)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToCount)=>#token("0","Int") requires `_<Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(1c726cd81629c2e5f411539a7f9b4d297e8600e5d71a5d235d287e3001f3ec84), org.kframework.attributes.Location(Location(1881,8,1882,59)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToCount:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("0"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("1c726cd81629c2e5f411539a7f9b4d297e8600e5d71a5d235d287e3001f3ec84"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1881,8,1882,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,S2,I)=>ite{Int}(`_==Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),#token("-1","Int")),`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I),ite{Int}(`_==Int_`(`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I),#token("-1","Int")),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`minInt(_,_)_INT-COMMON_Int_Int_Int`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I)))) requires `_=/=String__STRING-COMMON_Bool_String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [UNIQUE_ID(5b5d41706ad496a8165f1ea9c2109ce502796cbe90047732b173b3ad015058e3), org.kframework.attributes.Location(Location(1876,8,1876,431)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lblite{SortInt{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}),Lblite{SortInt{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{})))),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("5b5d41706ad496a8165f1ea9c2109ce502796cbe90047732b173b3ad015058e3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1876,8,1876,431)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(_Gen0,#token("\"\"","String"),_Gen1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5a6cf981f0ec2494854cd3e517b0cf645a1c9762c92a14849adfca9a6a553117), org.kframework.attributes.Location(Location(1877,8,1877,32)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            \dv{SortString{}}("")
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            Var'Unds'Gen1:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("-1"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("5a6cf981f0ec2494854cd3e517b0cf645a1c9762c92a14849adfca9a6a553117"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1877,8,1877,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `freshId(_)_ID-COMMON_Id_Int`(I)=>`String2Id(_)_ID-COMMON_Id_String`(`_+String__STRING-COMMON_String_String_String`(#token("\"_\"","String"),`Int2String(_)_STRING-COMMON_String_Int`(I))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3965c8e65257ebae926d601fa8ac672d34e4c211d73ba594c571c6bc5960f3de), org.kframework.attributes.Location(Location(2260,8,2260,62)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortId{},R} (
+      LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(X0:SortInt{}),
+     \and{SortId{}} (
+       LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(\dv{SortString{}}("_"),LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(VarI:SortInt{}))),
+        \top{SortId{}}())))
+  [UNIQUE'Unds'ID{}("3965c8e65257ebae926d601fa8ac672d34e4c211d73ba594c571c6bc5960f3de"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2260,8,2260,62)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `freshInt(_)_INT_Int_Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b), org.kframework.attributes.Location(Location(1442,8,1442,28)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       VarI:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1442,8,1442,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule getGeneratedCounterCell(`<generatedTop>`(_DotVar0,Cell))=>Cell requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortGeneratedTopCell{}, R} (
+            X0:SortGeneratedTopCell{},
+            Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'DotVar0:SortKCell{},VarCell:SortGeneratedCounterCell{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblgetGeneratedCounterCell{}(X0:SortGeneratedTopCell{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarCell:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3")]
+
+// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblinitGeneratedCounterCell{}(),
+     \and{SortGeneratedCounterCell{}} (
+       Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")),
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553")]
+
+// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initKCell(Init),initGeneratedCounterCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4cbc9d1da6e6bfe3605113d64379a38394b46b474e41d7bf884f8912546543b1), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      LblinitGeneratedTopCell{}(X0:SortMap{}),
+     \and{SortGeneratedTopCell{}} (
+       Lbl'-LT-'generatedTop'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}()),
+        \top{SortGeneratedTopCell{}}())))
+  [UNIQUE'Unds'ID{}("4cbc9d1da6e6bfe3605113d64379a38394b46b474e41d7bf884f8912546543b1")]
+
+// rule initKCell(Init)=>`<k>`(`project:KItem`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar"))))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(888ac40929773fd17d5b9fd1e9d0be94791665a663f07907d894c31dccc871a5), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCell{},R} (
+      LblinitKCell{}(X0:SortMap{}),
+     \and{SortKCell{}} (
+       Lbl'-LT-'k'-GT-'{}(kseq{}(Lblproject'Coln'KItem{}(kseq{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))),dotk{}())),dotk{}())),
+        \top{SortKCell{}}())))
+  [UNIQUE'Unds'ID{}("888ac40929773fd17d5b9fd1e9d0be94791665a663f07907d894c31dccc871a5")]
+
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(495da551d13b205c8648618471ccfca028707f98eff21e6b11d591515ed6f29a), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortBool{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'Gen1:SortBool{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("495da551d13b205c8648618471ccfca028707f98eff21e6b11d591515ed6f29a"), owise{}()]
+
+// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarBool:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77")]
+
+// rule isBytes(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7b64e4dd7c4feb3f2de6be193043beffb53ede0465701be9cadd48a9abe0e27f), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortBytes{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortBytes{}, SortKItem{}}(Var'Unds'Gen1:SortBytes{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisBytes{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7b64e4dd7c4feb3f2de6be193043beffb53ede0465701be9cadd48a9abe0e27f"), owise{}()]
+
+// rule isBytes(inj{Bytes,KItem}(Bytes))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cf9557048af554522e5d8df98ce08e94bee4e83a204d7d8282e6546ab477e7af)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBytes{}, SortKItem{}}(VarBytes:SortBytes{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisBytes{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("cf9557048af554522e5d8df98ce08e94bee4e83a204d7d8282e6546ab477e7af")]
+
+// rule isEndianness(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1e0c7b51dfff4f4f81e007d23b825ea5a0aac1580bcc8afdf28a2ab4b982dbe7), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortEndianness{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortEndianness{}, SortKItem{}}(Var'Unds'Gen1:SortEndianness{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisEndianness{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("1e0c7b51dfff4f4f81e007d23b825ea5a0aac1580bcc8afdf28a2ab4b982dbe7"), owise{}()]
+
+// rule isEndianness(inj{Endianness,KItem}(Endianness))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(046f538ac22bdf3ccf0a2eb4a68371a574a4365990ffba4473d6583c31396757)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortEndianness{}, SortKItem{}}(VarEndianness:SortEndianness{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisEndianness{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("046f538ac22bdf3ccf0a2eb4a68371a574a4365990ffba4473d6583c31396757")]
+
+// rule isFloat(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(613283edb3d0af0dfe3d5c3626073b1904f0e254fc0797cd7a4f620cfeb7de62), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortFloat{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortFloat{}, SortKItem{}}(Var'Unds'Gen1:SortFloat{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisFloat{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("613283edb3d0af0dfe3d5c3626073b1904f0e254fc0797cd7a4f620cfeb7de62"), owise{}()]
+
+// rule isFloat(inj{Float,KItem}(Float))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d74a36c34f45e0bf74d89fdd362f124478ab18934b5786ff4aabfe527643c5f0)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortFloat{}, SortKItem{}}(VarFloat:SortFloat{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisFloat{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d74a36c34f45e0bf74d89fdd362f124478ab18934b5786ff4aabfe527643c5f0")]
+
+// rule isFoo(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c5e5a18050d91bc4227d83021a7a713cc516bc772655df66f5d59eda9180aecf), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortFoo{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortFoo{}, SortKItem{}}(Var'Unds'Gen1:SortFoo{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisFoo{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("c5e5a18050d91bc4227d83021a7a713cc516bc772655df66f5d59eda9180aecf"), owise{}()]
+
+// rule isFoo(inj{Foo,KItem}(Foo))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1730b15b3df8c1ba505d757a95d3378b37691d6307ab5e39247f96643b5e212c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortFoo{}, SortKItem{}}(VarFoo:SortFoo{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisFoo{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("1730b15b3df8c1ba505d757a95d3378b37691d6307ab5e39247f96643b5e212c")]
+
+// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b0c8eb86594a387398bf96f2dbf773cff29d14b8a45c5f6701f205bf3d2f33ba), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortGeneratedCounterCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(Var'Unds'Gen0:SortGeneratedCounterCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b0c8eb86594a387398bf96f2dbf773cff29d14b8a45c5f6701f205bf3d2f33ba"), owise{}()]
+
+// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarGeneratedCounterCell:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c")]
+
+// rule isGeneratedCounterCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(84cfc8e964ec28b1912ffec4e6f5fccfcbad2256a1cba113622d99b11c13afd6), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortGeneratedCounterCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'Gen0:SortGeneratedCounterCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("84cfc8e964ec28b1912ffec4e6f5fccfcbad2256a1cba113622d99b11c13afd6"), owise{}()]
+
+// rule isGeneratedCounterCellOpt(inj{GeneratedCounterCellOpt,KItem}(GeneratedCounterCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarGeneratedCounterCellOpt:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12")]
+
+// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ccb9226d9e6c0e476485f098ef162c6c2206ed3af1d8336ea3ae859b86bc4a8b), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedTopCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedTopCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ccb9226d9e6c0e476485f098ef162c6c2206ed3af1d8336ea3ae859b86bc4a8b"), owise{}()]
+
+// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarGeneratedTopCell:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2")]
+
+// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(98049f5819962c7ee2b01436957b6cf8460b106979fa2c24f4c606bbf6cb1592), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedTopCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedTopCellFragment{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("98049f5819962c7ee2b01436957b6cf8460b106979fa2c24f4c606bbf6cb1592"), owise{}()]
+
+// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271")]
+
+// rule isIOError(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c96fa3a271ec5957293f6ff8436703651f7e219c4364d65286dc134a6a6e7dda), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortIOError{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOError{}, SortKItem{}}(Var'Unds'Gen1:SortIOError{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOError{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("c96fa3a271ec5957293f6ff8436703651f7e219c4364d65286dc134a6a6e7dda"), owise{}()]
+
+// rule isIOError(inj{IOError,KItem}(IOError))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(af1461e241b050082a392e02da8a0d27eb78de77d591d7b2a949770399eea7d0)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOError{}, SortKItem{}}(VarIOError:SortIOError{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOError{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("af1461e241b050082a392e02da8a0d27eb78de77d591d7b2a949770399eea7d0")]
+
+// rule isIOFile(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bb21a59193df5500799f91683023dc97bc08ffce188c0fae38f4920cab8a0f5e), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortIOFile{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOFile{}, SortKItem{}}(Var'Unds'Gen0:SortIOFile{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOFile{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("bb21a59193df5500799f91683023dc97bc08ffce188c0fae38f4920cab8a0f5e"), owise{}()]
+
+// rule isIOFile(inj{IOFile,KItem}(IOFile))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e265f4f40b46b033479ce783a161791d2f3390b848921b8d137e83f3f513fc0a)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOFile{}, SortKItem{}}(VarIOFile:SortIOFile{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOFile{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e265f4f40b46b033479ce783a161791d2f3390b848921b8d137e83f3f513fc0a")]
+
+// rule isIOInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c0297d42abd0eb84ecc87316430c6a6e2961b3bc806b64f68256522680f8b19c), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortIOInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOInt{}, SortKItem{}}(Var'Unds'Gen0:SortIOInt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("c0297d42abd0eb84ecc87316430c6a6e2961b3bc806b64f68256522680f8b19c"), owise{}()]
+
+// rule isIOInt(inj{IOInt,KItem}(IOInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e744736c885f38e99587884080e17e1ddd231da39bcbdcb445d10f52b6675232)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOInt{}, SortKItem{}}(VarIOInt:SortIOInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e744736c885f38e99587884080e17e1ddd231da39bcbdcb445d10f52b6675232")]
+
+// rule isIOString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f878d7ff3c358cb31e185d67585786837797c18b9599b202e2f399e4dc91f178), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortIOString{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOString{}, SortKItem{}}(Var'Unds'Gen1:SortIOString{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f878d7ff3c358cb31e185d67585786837797c18b9599b202e2f399e4dc91f178"), owise{}()]
+
+// rule isIOString(inj{IOString,KItem}(IOString))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(febfbad427936ffed4a4f974d1061ec9b65a4d6751c5a4e0e31661905c3f9e1e)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOString{}, SortKItem{}}(VarIOString:SortIOString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("febfbad427936ffed4a4f974d1061ec9b65a4d6751c5a4e0e31661905c3f9e1e")]
+
+// rule isId(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f37abe49c9a4ee52b56a492679d7aab25802b3c05860fee32a4a09d72b2a322f), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortId{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortId{}, SortKItem{}}(Var'Unds'Gen1:SortId{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisId{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f37abe49c9a4ee52b56a492679d7aab25802b3c05860fee32a4a09d72b2a322f"), owise{}()]
+
+// rule isId(inj{Id,KItem}(Id))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f024b5fa3f428dab8c832862d8a13219a64369be25641326400611b32ae8843d)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortId{}, SortKItem{}}(VarId:SortId{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisId{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f024b5fa3f428dab8c832862d8a13219a64369be25641326400611b32ae8843d")]
+
+// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(105572a4ac107eeb518b37c4d6ed3e28732b83afb0ba085d02d339c4fc2140a0), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortInt{}, SortKItem{}}(Var'Unds'Gen0:SortInt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("105572a4ac107eeb518b37c4d6ed3e28732b83afb0ba085d02d339c4fc2140a0"), owise{}()]
+
+// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarInt:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5")]
+
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisK{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847")]
+
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d30be57718b4b3745eaf2e99f875cfec7d5be2ff76bacde8a89bd4ab659d857f), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortKCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKCell{}, SortKItem{}}(Var'Unds'Gen0:SortKCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d30be57718b4b3745eaf2e99f875cfec7d5be2ff76bacde8a89bd4ab659d857f"), owise{}()]
+
+// rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2695222b1238f711f8a356c0a1bc0ac418d7bd78fd3282e7c60882e2631a46df)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCell{}, SortKItem{}}(VarKCell:SortKCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2695222b1238f711f8a356c0a1bc0ac418d7bd78fd3282e7c60882e2631a46df")]
+
+// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a3f84195242c98b432c7c63a4189f4276cc3189445c5cf37ce08d9a6547b1f7), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortKCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'Gen0:SortKCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9a3f84195242c98b432c7c63a4189f4276cc3189445c5cf37ce08d9a6547b1f7"), owise{}()]
+
+// rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1516473b1e153a368c273997543a4378ad451e5e828db8e289f4447f7e5228a5)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarKCellOpt:SortKCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("1516473b1e153a368c273997543a4378ad451e5e828db8e289f4447f7e5228a5")]
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f68a616e301c35586f68e97b729ae274278c3ef8fe6634711cfd3e1746bc0bc2), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKConfigVar{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKConfigVar{}, SortKItem{}}(Var'Unds'Gen1:SortKConfigVar{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f68a616e301c35586f68e97b729ae274278c3ef8fe6634711cfd3e1746bc0bc2"), owise{}()]
+
+// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKConfigVar{}, SortKItem{}}(VarKConfigVar:SortKConfigVar{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd")]
+
+// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(83812b6b9e31a764d66d89fd1c7e65b9b162d52c5aebfe99b1536e200a9590c2), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKItem{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(Var'Unds'Gen1:SortKItem{},dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("83812b6b9e31a764d66d89fd1c7e65b9b162d52c5aebfe99b1536e200a9590c2"), owise{}()]
+
+// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarKItem:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c")]
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a9489adcf0279eca74c012bb1130bb9d30372cfbebc8e4ab4b173656c4d6613), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortList{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortList{}, SortKItem{}}(Var'Unds'Gen0:SortList{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9a9489adcf0279eca74c012bb1130bb9d30372cfbebc8e4ab4b173656c4d6613"), owise{}()]
+
+// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarList:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446")]
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(6f30a2087d0b19640df005437bc3f4665f41282666a72821b17b16c99ed5afee), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortMap{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMap{}, SortKItem{}}(Var'Unds'Gen0:SortMap{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("6f30a2087d0b19640df005437bc3f4665f41282666a72821b17b16c99ed5afee"), owise{}()]
+
+// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarMap:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795")]
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b5aadccd9b89faba72816867187d48d279d8c27c8bda1a1b3b0658bd82bb783), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortSet{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'Gen1:SortSet{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2b5aadccd9b89faba72816867187d48d279d8c27c8bda1a1b3b0658bd82bb783"), owise{}()]
+
+// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarSet:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80")]
+
+// rule isSignedness(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fdb4f75eac954bf992f8bef0826d300214e56ed18582ea34e002f78ab98c8a0f), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortSignedness{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortSignedness{}, SortKItem{}}(Var'Unds'Gen1:SortSignedness{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisSignedness{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fdb4f75eac954bf992f8bef0826d300214e56ed18582ea34e002f78ab98c8a0f"), owise{}()]
+
+// rule isSignedness(inj{Signedness,KItem}(Signedness))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d1de4cb84bd34d2dbc5bcaae03818af056fd81a68d3b9738c7a3f06055d74e93)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSignedness{}, SortKItem{}}(VarSignedness:SortSignedness{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisSignedness{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d1de4cb84bd34d2dbc5bcaae03818af056fd81a68d3b9738c7a3f06055d74e93")]
+
+// rule isStream(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(15e2e66b02746a7c3106ff32539631d15c0b184068a2767cfe37a26680aa442d), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortStream{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortStream{}, SortKItem{}}(Var'Unds'Gen1:SortStream{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisStream{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("15e2e66b02746a7c3106ff32539631d15c0b184068a2767cfe37a26680aa442d"), owise{}()]
+
+// rule isStream(inj{Stream,KItem}(Stream))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(27e703343d82a904ab8f74cc74fe8c6870a94fa1f4df39e1c0230ae06e4783cc)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortStream{}, SortKItem{}}(VarStream:SortStream{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisStream{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("27e703343d82a904ab8f74cc74fe8c6870a94fa1f4df39e1c0230ae06e4783cc")]
+
+// rule isString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fbe29b27977283e8cb5b35f1b17a6b7b2abc92a7fca608d496b346f7b6918961), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortString{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortString{}, SortKItem{}}(Var'Unds'Gen1:SortString{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fbe29b27977283e8cb5b35f1b17a6b7b2abc92a7fca608d496b346f7b6918961"), owise{}()]
+
+// rule isString(inj{String,KItem}(String))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(109ced650ead4a5092ddba090e1b8e181633ed0aa5c5f93bce9f88be215668ef)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortString{}, SortKItem{}}(VarString:SortString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("109ced650ead4a5092ddba090e1b8e181633ed0aa5c5f93bce9f88be215668ef")]
+
+// rule ite{K}(C,B1,_Gen0)=>B1 requires C ensures #token("true","Bool") [UNIQUE_ID(1ff8f4d71e4c13084eed473b08740da83c4cc7f1875d340d86dc72124c48b4a0), org.kframework.attributes.Location(Location(2318,8,2318,59)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        VarC:SortBool{},
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarB1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lblite{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB1:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("1ff8f4d71e4c13084eed473b08740da83c4cc7f1875d340d86dc72124c48b4a0"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2318,8,2318,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule ite{K}(C,_Gen0,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [UNIQUE_ID(2f3f58a93926913fc5ca147dfd8d3d612508bc8ff67412ef10935df7c09554d5), org.kframework.attributes.Location(Location(2319,8,2319,67)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        LblnotBool'Unds'{}(VarC:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            VarB2:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lblite{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB2:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("2f3f58a93926913fc5ca147dfd8d3d612508bc8ff67412ef10935df7c09554d5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2319,8,2319,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I1 requires `_<=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6), org.kframework.attributes.Location(Location(1435,8,1435,57)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI1:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1435,8,1435,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I2 requires `_>=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3), org.kframework.attributes.Location(Location(1436,8,1436,57)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI2:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1436,8,1436,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415), org.kframework.attributes.Location(Location(1128,8,1128,29)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1128,8,1128,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c), org.kframework.attributes.Location(Location(1127,8,1127,29)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1127,8,1127,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `project:#tempFile:fd`(#tempFile(K0,K1))=>K1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(adb3a6d90d2e5267333e61f4e4be032bebb5f7a513450887a845c863a2adf95d)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortIOFile{}, R} (
+            X0:SortIOFile{},
+            Lbl'Hash'tempFile{}(VarK0:SortString{},VarK1:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'ColnHash'tempFile'Coln'fd{}(X0:SortIOFile{}),
+     \and{SortInt{}} (
+       VarK1:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("adb3a6d90d2e5267333e61f4e4be032bebb5f7a513450887a845c863a2adf95d")]
+
+// rule `project:#tempFile:path`(#tempFile(K0,K1))=>K0 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0020b2718cda89e9c9f4d05915593ca66761a24dffb111c697ccc162278da8ea)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortIOFile{}, R} (
+            X0:SortIOFile{},
+            Lbl'Hash'tempFile{}(VarK0:SortString{},VarK1:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      Lblproject'ColnHash'tempFile'Coln'path{}(X0:SortIOFile{}),
+     \and{SortString{}} (
+       VarK0:SortString{},
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("0020b2718cda89e9c9f4d05915593ca66761a24dffb111c697ccc162278da8ea")]
+
+// rule `project:#unknownIOError:errno`(#unknownIOError(K0))=>K0 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a36cde36a6581696f3d54614cc0d2d0864c2da35c6c8dc8d56daaf8b24199241)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortIOError{}, R} (
+            X0:SortIOError{},
+            Lbl'Hash'unknownIOError{}(VarK0:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'ColnHash'unknownIOError'Coln'errno{}(X0:SortIOError{}),
+     \and{SortInt{}} (
+       VarK0:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("a36cde36a6581696f3d54614cc0d2d0864c2da35c6c8dc8d56daaf8b24199241")]
+
+// rule `project:Bool`(inj{Bool,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarK:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblproject'Coln'Bool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54")]
+
+// rule `project:Bytes`(inj{Bytes,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3dd796c6a5f8b672e77ec1deefb73e210491fa6a6b575e55995906d5853e0412), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBytes{}, SortKItem{}}(VarK:SortBytes{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBytes{},R} (
+      Lblproject'Coln'Bytes{}(X0:SortK{}),
+     \and{SortBytes{}} (
+       VarK:SortBytes{},
+        \top{SortBytes{}}())))
+  [UNIQUE'Unds'ID{}("3dd796c6a5f8b672e77ec1deefb73e210491fa6a6b575e55995906d5853e0412")]
+
+// rule `project:Endianness`(inj{Endianness,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(dbd19bfafbdcba20fb8bf650b93158c4bed0b9af2a0b7476d20cf061c0be7da3), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortEndianness{}, SortKItem{}}(VarK:SortEndianness{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortEndianness{},R} (
+      Lblproject'Coln'Endianness{}(X0:SortK{}),
+     \and{SortEndianness{}} (
+       VarK:SortEndianness{},
+        \top{SortEndianness{}}())))
+  [UNIQUE'Unds'ID{}("dbd19bfafbdcba20fb8bf650b93158c4bed0b9af2a0b7476d20cf061c0be7da3")]
+
+// rule `project:Float`(inj{Float,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ef206f477d884c0b6413273ff35b1206769cdb5a5ceba7b97d9e8e0a7b14e399), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortFloat{}, SortKItem{}}(VarK:SortFloat{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortFloat{},R} (
+      Lblproject'Coln'Float{}(X0:SortK{}),
+     \and{SortFloat{}} (
+       VarK:SortFloat{},
+        \top{SortFloat{}}())))
+  [UNIQUE'Unds'ID{}("ef206f477d884c0b6413273ff35b1206769cdb5a5ceba7b97d9e8e0a7b14e399")]
+
+// rule `project:Foo`(inj{Foo,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8351d968bf0243dab1cca650752271f3cfcf781a0fb4eb51eff242554c7fe59e), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortFoo{}, SortKItem{}}(VarK:SortFoo{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortFoo{},R} (
+      Lblproject'Coln'Foo{}(X0:SortK{}),
+     \and{SortFoo{}} (
+       VarK:SortFoo{},
+        \top{SortFoo{}}())))
+  [UNIQUE'Unds'ID{}("8351d968bf0243dab1cca650752271f3cfcf781a0fb4eb51eff242554c7fe59e")]
+
+// rule `project:GeneratedCounterCell`(inj{GeneratedCounterCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarK:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      Lblproject'Coln'GeneratedCounterCell{}(X0:SortK{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarK:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217")]
+
+// rule `project:GeneratedCounterCellOpt`(inj{GeneratedCounterCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarK:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCellOpt{},R} (
+      Lblproject'Coln'GeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortGeneratedCounterCellOpt{}} (
+       VarK:SortGeneratedCounterCellOpt{},
+        \top{SortGeneratedCounterCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca")]
+
+// rule `project:GeneratedTopCell`(inj{GeneratedTopCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarK:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      Lblproject'Coln'GeneratedTopCell{}(X0:SortK{}),
+     \and{SortGeneratedTopCell{}} (
+       VarK:SortGeneratedTopCell{},
+        \top{SortGeneratedTopCell{}}())))
+  [UNIQUE'Unds'ID{}("b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e")]
+
+// rule `project:GeneratedTopCellFragment`(inj{GeneratedTopCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarK:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCellFragment{},R} (
+      Lblproject'Coln'GeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortGeneratedTopCellFragment{}} (
+       VarK:SortGeneratedTopCellFragment{},
+        \top{SortGeneratedTopCellFragment{}}())))
+  [UNIQUE'Unds'ID{}("2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42")]
+
+// rule `project:IOError`(inj{IOError,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7ffe32516a0c3941ee4ba99c0f779b50c13a06e7eeb613f97334efb61b50c3aa), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOError{}, SortKItem{}}(VarK:SortIOError{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOError{},R} (
+      Lblproject'Coln'IOError{}(X0:SortK{}),
+     \and{SortIOError{}} (
+       VarK:SortIOError{},
+        \top{SortIOError{}}())))
+  [UNIQUE'Unds'ID{}("7ffe32516a0c3941ee4ba99c0f779b50c13a06e7eeb613f97334efb61b50c3aa")]
+
+// rule `project:IOFile`(inj{IOFile,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(09adbf7f680517f1f89e4e8c71d5bd247c4a2ea5d62e7c4aeb3153ab97239841), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOFile{}, SortKItem{}}(VarK:SortIOFile{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOFile{},R} (
+      Lblproject'Coln'IOFile{}(X0:SortK{}),
+     \and{SortIOFile{}} (
+       VarK:SortIOFile{},
+        \top{SortIOFile{}}())))
+  [UNIQUE'Unds'ID{}("09adbf7f680517f1f89e4e8c71d5bd247c4a2ea5d62e7c4aeb3153ab97239841")]
+
+// rule `project:IOInt`(inj{IOInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e39565377db8be1e421a86f0a0c31d0782a9af4aed7031245771fcb2a0152e06), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOInt{}, SortKItem{}}(VarK:SortIOInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOInt{},R} (
+      Lblproject'Coln'IOInt{}(X0:SortK{}),
+     \and{SortIOInt{}} (
+       VarK:SortIOInt{},
+        \top{SortIOInt{}}())))
+  [UNIQUE'Unds'ID{}("e39565377db8be1e421a86f0a0c31d0782a9af4aed7031245771fcb2a0152e06")]
+
+// rule `project:IOString`(inj{IOString,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(76a39386f0abf23155a1642ec64113306ae7c384a59c2e7f562d3c564efcc9a4), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOString{}, SortKItem{}}(VarK:SortIOString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOString{},R} (
+      Lblproject'Coln'IOString{}(X0:SortK{}),
+     \and{SortIOString{}} (
+       VarK:SortIOString{},
+        \top{SortIOString{}}())))
+  [UNIQUE'Unds'ID{}("76a39386f0abf23155a1642ec64113306ae7c384a59c2e7f562d3c564efcc9a4")]
+
+// rule `project:Id`(inj{Id,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(afcb3941b7c18d4b91d6ed8981582d58e0dc006425e9889e9891c2a7c2b93554), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortId{}, SortKItem{}}(VarK:SortId{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortId{},R} (
+      Lblproject'Coln'Id{}(X0:SortK{}),
+     \and{SortId{}} (
+       VarK:SortId{},
+        \top{SortId{}}())))
+  [UNIQUE'Unds'ID{}("afcb3941b7c18d4b91d6ed8981582d58e0dc006425e9889e9891c2a7c2b93554")]
+
+// rule `project:Int`(inj{Int,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarK:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'Coln'Int{}(X0:SortK{}),
+     \and{SortInt{}} (
+       VarK:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b")]
+
+// rule `project:K`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortK{},R} (
+      Lblproject'Coln'K{}(X0:SortK{}),
+     \and{SortK{}} (
+       VarK:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a")]
+
+// rule `project:KCell`(inj{KCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(894c13c4c410f11e35bc3781505aeddde4ff400ddda1daf8b35259dbf0de9a24), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCell{}, SortKItem{}}(VarK:SortKCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCell{},R} (
+      Lblproject'Coln'KCell{}(X0:SortK{}),
+     \and{SortKCell{}} (
+       VarK:SortKCell{},
+        \top{SortKCell{}}())))
+  [UNIQUE'Unds'ID{}("894c13c4c410f11e35bc3781505aeddde4ff400ddda1daf8b35259dbf0de9a24")]
+
+// rule `project:KCellOpt`(inj{KCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f684dd78d97feadf0cbcb3cbb8892e0842f137c7b29a904cb2f3fc9755b29b30), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarK:SortKCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCellOpt{},R} (
+      Lblproject'Coln'KCellOpt{}(X0:SortK{}),
+     \and{SortKCellOpt{}} (
+       VarK:SortKCellOpt{},
+        \top{SortKCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("f684dd78d97feadf0cbcb3cbb8892e0842f137c7b29a904cb2f3fc9755b29b30")]
+
+// rule `project:KItem`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarK:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKItem{},R} (
+      Lblproject'Coln'KItem{}(X0:SortK{}),
+     \and{SortKItem{}} (
+       VarK:SortKItem{},
+        \top{SortKItem{}}())))
+  [UNIQUE'Unds'ID{}("1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29")]
+
+// rule `project:List`(inj{List,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarK:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortList{},R} (
+      Lblproject'Coln'List{}(X0:SortK{}),
+     \and{SortList{}} (
+       VarK:SortList{},
+        \top{SortList{}}())))
+  [UNIQUE'Unds'ID{}("2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5")]
+
+// rule `project:Map`(inj{Map,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarK:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMap{},R} (
+      Lblproject'Coln'Map{}(X0:SortK{}),
+     \and{SortMap{}} (
+       VarK:SortMap{},
+        \top{SortMap{}}())))
+  [UNIQUE'Unds'ID{}("031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598")]
+
+// rule `project:Set`(inj{Set,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarK:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortSet{},R} (
+      Lblproject'Coln'Set{}(X0:SortK{}),
+     \and{SortSet{}} (
+       VarK:SortSet{},
+        \top{SortSet{}}())))
+  [UNIQUE'Unds'ID{}("0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0")]
+
+// rule `project:Signedness`(inj{Signedness,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(829c38fa75d4ab0af8ef1602244b1e03c3ba7cb56ef7ad938953f9b07c83161a), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSignedness{}, SortKItem{}}(VarK:SortSignedness{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortSignedness{},R} (
+      Lblproject'Coln'Signedness{}(X0:SortK{}),
+     \and{SortSignedness{}} (
+       VarK:SortSignedness{},
+        \top{SortSignedness{}}())))
+  [UNIQUE'Unds'ID{}("829c38fa75d4ab0af8ef1602244b1e03c3ba7cb56ef7ad938953f9b07c83161a")]
+
+// rule `project:Stream`(inj{Stream,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bb30b432f6a3a9b73f42f0d3a54e07645be55c26bdee9d5c513f06e8009d0a77), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortStream{}, SortKItem{}}(VarK:SortStream{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortStream{},R} (
+      Lblproject'Coln'Stream{}(X0:SortK{}),
+     \and{SortStream{}} (
+       VarK:SortStream{},
+        \top{SortStream{}}())))
+  [UNIQUE'Unds'ID{}("bb30b432f6a3a9b73f42f0d3a54e07645be55c26bdee9d5c513f06e8009d0a77")]
+
+// rule `project:String`(inj{String,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e491dad8f644d2344f08cb72af01ade1e6ce9f564010a2de7909b3b6c7e2ae85), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortString{}, SortKItem{}}(VarK:SortString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      Lblproject'Coln'String{}(X0:SortK{}),
+     \and{SortString{}} (
+       VarK:SortString{},
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("e491dad8f644d2344f08cb72af01ade1e6ce9f564010a2de7909b3b6c7e2ae85")]
+
+// rule pushList(K,L1)=>`_List_`(`ListItem`(K),L1) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f6967050cc4ec32c2d34d52f5577e09120f730420d2c5dc838cba81d04c57adf), org.kframework.attributes.Location(Location(954,8,954,54)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortKItem{}, R} (
+            X0:SortKItem{},
+            VarK:SortKItem{}
+          ),\and{R} (
+          \in{SortList{}, R} (
+            X1:SortList{},
+            VarL1:SortList{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortList{},R} (
+      LblpushList{}(X0:SortKItem{},X1:SortList{}),
+     \and{SortList{}} (
+       Lbl'Unds'List'Unds'{}(LblListItem{}(VarK:SortKItem{}),VarL1:SortList{}),
+        \top{SortList{}}())))
+  [UNIQUE'Unds'ID{}("f6967050cc4ec32c2d34d52f5577e09120f730420d2c5dc838cba81d04c57adf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(954,8,954,54)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,ToReplace,Replacement,Count)=>`_+String__STRING-COMMON_String_String_String`(`_+String__STRING-COMMON_String_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToReplace)),`lengthString(_)_STRING-COMMON_Int_String`(Source)),ToReplace,Replacement,`_-Int_`(Count,#token("1","Int")))) requires `_andBool_`(`_>Int_`(Count,#token("0","Int")),`_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int"))) ensures #token("true","Bool") [UNIQUE_ID(4d80f4d63262761f305ff16a13c7b187891f796dbdb8f8bc0c2387a37c01cd6d), org.kframework.attributes.Location(Location(1896,8,1899,79)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'Unds-GT-'Int'Unds'{}(VarCount:SortInt{},\dv{SortInt{}}("0")),Lbl'Unds-GT-Eqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0"))),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            VarReplacement:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X3:SortInt{},
+            VarCount:SortInt{}
+          ),
+          \top{R} ()
+        ))))),
+    \equals{SortString{},R} (
+      Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortString{},X3:SortInt{}),
+     \and{SortString{}} (
+       Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})),VarToReplace:SortString{},VarReplacement:SortString{},Lbl'Unds'-Int'Unds'{}(VarCount:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("4d80f4d63262761f305ff16a13c7b187891f796dbdb8f8bc0c2387a37c01cd6d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1896,8,1899,79)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,_Gen0,_Gen1,Count)=>Source requires `_>=Int_`(Count,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(8baee90bc16d350bd96511a574002886bac6fd9d5017c31b773c5064b69c5f79), org.kframework.attributes.Location(Location(1900,8,1901,31)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)]), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen9:SortInt{},
+          \exists{R} (Var'Unds'Gen6:SortString{},
+          \exists{R} (Var'Unds'Gen7:SortString{},
+          \exists{R} (Var'Unds'Gen8:SortString{},
+            \and{R} (
+              \equals{SortBool{},R}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'Unds-GT-'Int'Unds'{}(Var'Unds'Gen9:SortInt{},\dv{SortInt{}}("0")),Lbl'Unds-GT-Eqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(Var'Unds'Gen6:SortString{},Var'Unds'Gen7:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0"))),
+        \dv{SortBool{}}("true")),
+              \and{R} (
+                \in{SortString{}, R} (
+                  X0:SortString{},
+                  Var'Unds'Gen6:SortString{}
+                ),\and{R} (
+                \in{SortString{}, R} (
+                  X1:SortString{},
+                  Var'Unds'Gen7:SortString{}
+                ),\and{R} (
+                \in{SortString{}, R} (
+                  X2:SortString{},
+                  Var'Unds'Gen8:SortString{}
+                ),\and{R} (
+                \in{SortInt{}, R} (
+                  X3:SortInt{},
+                  Var'Unds'Gen9:SortInt{}
+                ),
+                \top{R} ()
+              ))))
+          ))))),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(VarCount:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+        \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            Var'Unds'Gen1:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X3:SortInt{},
+            VarCount:SortInt{}
+          ),
+          \top{R} ()
+        ))))
+    )),
+    \equals{SortString{},R} (
+      Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortString{},X3:SortInt{}),
+     \and{SortString{}} (
+       VarSource:SortString{},
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("8baee90bc16d350bd96511a574002886bac6fd9d5017c31b773c5064b69c5f79"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1900,8,1901,31)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), owise{}()]
+
+// rule `replaceAll(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,Replacement)=>`replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,ToReplace,Replacement,`countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToReplace)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(262167183c3ec2e214d12bac6e639d7ac1a9f973582e16eca6c1af1da7ecc0a5), org.kframework.attributes.Location(Location(1902,8,1902,154)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            VarReplacement:SortString{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortString{},R} (
+      LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+     \and{SortString{}} (
+       Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{})),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("262167183c3ec2e214d12bac6e639d7ac1a9f973582e16eca6c1af1da7ecc0a5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1902,8,1902,154)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `replaceFirst(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,Replacement)=>`_+String__STRING-COMMON_String_String_String`(`_+String__STRING-COMMON_String_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToReplace)),`lengthString(_)_STRING-COMMON_Int_String`(Source))) requires `_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(e290042e5b5b2f620c0ca1871e708c3713c62b63b283e317bb7568e13968fe0c), org.kframework.attributes.Location(Location(1886,8,1888,66)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            VarReplacement:SortString{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortString{},R} (
+      LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+     \and{SortString{}} (
+       Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{}))),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("e290042e5b5b2f620c0ca1871e708c3713c62b63b283e317bb7568e13968fe0c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1886,8,1888,66)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `replaceFirst(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,_Gen0)=>Source requires `_<Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(8fbd1c8efb9988236eddc95fc2af4a3e74f6ec94d696ee47209543fd0826dd34), org.kframework.attributes.Location(Location(1889,8,1890,57)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortString{},R} (
+      LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+     \and{SortString{}} (
+       VarSource:SortString{},
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("8fbd1c8efb9988236eddc95fc2af4a3e74f6ec94d696ee47209543fd0826dd34"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1889,8,1890,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,S2,I)=>`maxInt(_,_)_INT-COMMON_Int_Int_Int`(`rfindString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I)) requires `_=/=String__STRING-COMMON_Bool_String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [UNIQUE_ID(b7f740050d72a847424b022a9c8217325aba8a154a42831aa3c7a3b0727f3205), org.kframework.attributes.Location(Location(1878,8,1878,182)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("b7f740050d72a847424b022a9c8217325aba8a154a42831aa3c7a3b0727f3205"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1878,8,1878,182)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(_Gen0,#token("\"\"","String"),_Gen1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(23b9fa88124c547d94aed32124d1ccd1069732b059f4c8b430ab4617979690f6), org.kframework.attributes.Location(Location(1879,8,1879,33)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            \dv{SortString{}}("")
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            Var'Unds'Gen1:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("-1"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("23b9fa88124c547d94aed32124d1ccd1069732b059f4c8b430ab4617979690f6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1879,8,1879,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_-Int_`(`_modInt_`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))),`_<<Int_`(#token("1","Int"),LEN)),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f), org.kframework.attributes.Location(Location(1425,8,1425,164)), org.kframework.attributes.Source(Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds'modInt'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1425,8,1425,164)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(8,1,14,10)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/Users/brucecollie/code/llvm-backend/test/c/k-files/flat-namespace.k)")]

--- a/test/c/k-files/flat-namespace.k
+++ b/test/c/k-files/flat-namespace.k
@@ -1,0 +1,14 @@
+module FLAT-NAMESPACE-SYNTAX
+  imports BYTES-SYNTAX
+
+  syntax Foo ::= foo()      [symbol(foo)]
+               | bar(Bytes) [symbol(bar)]
+endmodule
+
+module FLAT-NAMESPACE
+  imports DOMAINS
+  imports BYTES
+  imports FLAT-NAMESPACE-SYNTAX
+
+  rule foo() => bar(Int2Bytes(10, 3489, BE))
+endmodule


### PR DESCRIPTION
This PR fixes two subtle, related issues that are blocking updates from going through downstream in the Kasmer project. At a high level, the issues are:
- Flat namespace linking on macOS produces incorrect symbol lookups in dynamic libraries.
- https://github.com/runtimeverification/llvm-backend/pull/1097 misses a subtle edge case related to tail-call optimisation.

The actual code changes required are small, but warrant some detailed explanation.

## Flat Namespaces

For a long time, macOS has implemented a system known as _two-level_ namespaces, whereby undefined symbol names in a dynamic library are prefixed with the name of the library in which the loader expects to be able to find them at run-time. This is a conservative behaviour; even if a symbol with the same name exists in a different library, it won't be selected. For example, the dynamic libraries built by `llvm-kompile` in `c` mode link against `libgmp`. Two-level namespaces produce dynamic symbol tables that look like:
```console
$ dyld_info test/c/Output/flat-namespace.kore.tmp.dir/libtest.so -symbolic_fixups | grep gmpz_clear
           +0x2B28      bind pointer   libgmp.10.dylib/___gmpz_clear
```

This behaviour is different to Linux, which does not have a notion of two-level namespaces. For legacy compatibility purposes, Apple supply a linker flag `-flat_namespace` that behaves more similarly to Linux behaviour. Its use is discouraged in new code, but we had enabled it to work around an issue in the Python bindings (https://github.com/python/cpython/issues/97524) that should be fixed in a future CPython / macOS combination.[^1] When enabled, the symbol table looks something like this for the same example:
```console
$ dyld_info test/c/Output/flat-namespace.kore.tmp.dir/libtest.so -symbolic_fixups | grep gmpz_clear
           +0x2EE8      bind pointer   flat-namespace/___gmpz_clear
```

As a consequence of this, if the symbol `___gmpz_clear` exists in multiple dynamic libraries loaded by the same process, then the order in which they will be selected by the dynamic loader is not clearly well-defined,[^2] and when it's referenced we could end up loading either the correct or the incorrect symbol. This caused the initial bug observed as follows:[^3]
- The Haskell backend statically links the `kore-rpc-booster` executable against `libgmp`, meaning that some GMP symbols appear in that binary.
- The backend compiles shared libraries that dynamically link against `libgmp`.
- `kore-rpc-booster` dynamically loads one of these libraries, and when resolving symbols to load, the flat namespace environment selects the static version for some and the dynamic version for others.
- A call to `__gmpz_clear` from a backend hook ends up referencing the statically linked symbol, rather than the dynamically linked version. Generally, I think this situation is harmless - GMP is very stable and it's plausible that doing this for most symbols is not observable.
- However, the dynamically-linked GMP library has been set up to use the KORE memory management functions. When the static version is called, it tries to `free()` a pointer allocated by the backend's GC, and crashes.

The fix for this issue is to drop our usage of `-flat_namespace` for C shared libraries compiled by the backend. This breaks a few places we were relying on the old (incorrect) behaviour in the presence of C++ RTTI; having multiple instances of identically-named typeinfo symbols in a process is known to be broken there:
- `libunwind` is actually implicitly linked via the macOS system library; if we explicitly link it as well, then code that handles exceptions will break.
- The `k-rule-apply` tool linked two copies of the KORE AST library, causing `dynamic_cast` to break. #1110 addresses this.

## Tail-Call Optimisation

In #1097, we made some changes that explicitly mark K functions as `musttail` when we know they're tail recursive. In doing so, we removed the need to use the `-tailcallopt` flag in most cases. However, the change in that PR missed that as well as IR-level transformations, `-tailcallopt` sets a lower-level flag in the backend[^4] code generator that guarantees tail-call code generation. For large programs, this meant I could observe stack overflows when traversing large terms.

The fix is just to enforce that this internal option gets set properly; doing so is just a restoration of the behaviour we got from `-tailcallopt` before.

[^1]: But isn't yet fixed, unfortunately - the underlying bug is still present on my system. Should be revisited in the future, ideally!
[^2]: It might be defined somewhere, but the initial manifestation of this bug appeared in an apparently unrelated commit, so I think we were just getting lucky previously. The fix in this PR is morally correct whether or not things worked accidentally beforehand.
[^3]: I intend to write this up fully later in a separate issue.
[^4]: As in the X86 or arm backend of LLVM itself.