### PR TITLE
Refactor `k-rule-apply` tool

### DIFF
--- a/bindings/c/include/kllvm-c/kllvm-c.h
+++ b/bindings/c/include/kllvm-c/kllvm-c.h
@@ -162,6 +162,18 @@ void kllvm_free_all_memory(void);
 
 bool kllvm_mutable_bytes_enabled(void);
 
+/* Definitions */
+
+/**
+ * Parse the given KORE definition, then if any of its axioms have a `label`
+ * attribute that matches the supplied label, return the name of the function
+ * symbol that attempts matching a pattern against that axiom (and will
+ * therefore populate the backend's global matching log).
+ *
+ * If no such axiom exists, return `nullptr`.
+ */
+char *kore_match_function_name(char const *defn_path, char const *label);
+
 #ifdef __cplusplus
 }
 #endif

--- a/bindings/c/lib.cpp
+++ b/bindings/c/lib.cpp
@@ -434,6 +434,17 @@ void kllvm_free_all_memory(void) {
 bool kllvm_mutable_bytes_enabled(void) {
   return hook_BYTES_mutableBytesEnabled();
 }
+
+/* Definitions */
+
+char *kore_match_function_name(char const *defn_path, char const *label) {
+  auto result = kllvm::bindings::get_match_function_name(defn_path, label);
+  if (!result) {
+    return nullptr;
+  }
+
+  return get_c_string(*result);
+}
 }
 
 namespace {

--- a/bindings/core/CMakeLists.txt
+++ b/bindings/core/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(BindingsCore
 )
 
 target_link_libraries(BindingsCore
-  PUBLIC AST fmt::fmt-header-only
+  PUBLIC AST Parser fmt::fmt-header-only
 )
 
 install(

--- a/bindings/core/src/core.cpp
+++ b/bindings/core/src/core.cpp
@@ -1,4 +1,5 @@
 #include <kllvm/bindings/core/core.h>
+#include <kllvm/parser/KOREParser.h>
 
 using namespace kllvm;
 
@@ -114,6 +115,27 @@ bool is_sort_k(std::shared_ptr<kore_sort> const &sort) {
   }
 
   return false;
+}
+
+std::optional<std::string> get_match_function_name(
+    std::string const &definition_path, std::string const &label) {
+  // Parse the definition.kore to get the AST.
+  parser::kore_parser parser(definition_path);
+  auto kore_ast = parser.definition();
+  kore_ast->preprocess();
+
+  // Iterate through axioms and return the one with the give rulen label if exits.
+  for (auto *axiom : kore_ast.get()->get_axioms()) {
+    // Check if the current axiom has the attribute label.
+    if (axiom->attributes().contains(attribute_set::key::Label)) {
+      // Compare the axiom's label with the given rule label.
+      if (label == axiom->attributes().get_string(attribute_set::key::Label)) {
+        return "intern_match_" + std::to_string(axiom->get_ordinal());
+      }
+    }
+  }
+
+  return std::nullopt;
 }
 
 } // namespace kllvm::bindings

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -1034,7 +1034,8 @@ public:
   }
   kore_symbol *get_inj_symbol() { return inj_symbol_; }
 
-  std::vector<kore_composite_sort *> const &get_all_sorts() const {
+  [[nodiscard]] std::vector<kore_composite_sort *> const &
+  get_all_sorts() const {
     return all_sorts_;
   }
 };

--- a/include/kllvm/bindings/core/core.h
+++ b/include/kllvm/bindings/core/core.h
@@ -4,6 +4,7 @@
 #include <kllvm/ast/AST.h>
 
 #include <memory>
+#include <optional>
 
 // These headers need to be included last because they pollute a number of macro
 // definitions into the global namespace.
@@ -40,6 +41,13 @@ bool is_sort_k(std::shared_ptr<kllvm::kore_sort> const &sort);
 
 std::shared_ptr<kore_pattern>
 evaluate_function(std::shared_ptr<kore_composite_pattern> const &term);
+
+/**
+ * Get the name of the LLVM function that attempts matching on the rule with
+ * this label by parsing a KORE definition and examining its axioms.
+ */
+std::optional<std::string> get_match_function_name(
+    std::string const &definition_path, std::string const &label);
 
 } // namespace kllvm::bindings
 

--- a/tools/k-rule-apply/CMakeLists.txt
+++ b/tools/k-rule-apply/CMakeLists.txt
@@ -1,5 +1,6 @@
 kllvm_add_tool(k-rule-apply
   main.cpp
+  shims.cpp
 )
 
 target_link_libraries(k-rule-apply 

--- a/tools/k-rule-apply/CMakeLists.txt
+++ b/tools/k-rule-apply/CMakeLists.txt
@@ -3,10 +3,6 @@ kllvm_add_tool(k-rule-apply
   shims.cpp
 )
 
-target_link_libraries(k-rule-apply 
-  PUBLIC Parser AST gmp gmpxx
-)
-
 install(
   TARGETS k-rule-apply
   RUNTIME DESTINATION bin

--- a/tools/k-rule-apply/main.cpp
+++ b/tools/k-rule-apply/main.cpp
@@ -32,37 +32,9 @@ cl::opt<std::string> kore_pattern_filename(
 cl::opt<std::string> shared_lib_path(
     cl::Positional, cl::desc("<path_to_shared_lib>"), cl::cat(k_rule_cat));
 
-std::optional<std::string> get_match_function_name(
-    std::string const &definition_path, std::string const &label) {
-  // Parse the definition.kore to get the AST.
-  parser::kore_parser parser(definition_path);
-  auto kore_ast = parser.definition();
-  kore_ast->preprocess();
-
-  // Iterate through axioms and return the one with the give rulen label if exits.
-  for (auto *axiom : kore_ast.get()->get_axioms()) {
-    // Check if the current axiom has the attribute label.
-    if (axiom->attributes().contains(attribute_set::key::Label)) {
-      // Compare the axiom's label with the given rule label.
-      if (label == axiom->attributes().get_string(attribute_set::key::Label)) {
-        return "intern_match_" + std::to_string(axiom->get_ordinal());
-      }
-    }
-  }
-
-  return std::nullopt;
-}
-
 int main(int argc, char **argv) {
   cl::HideUnrelatedOptions({&k_rule_cat});
   cl::ParseCommandLineOptions(argc, argv);
-
-  auto match_function_name
-      = get_match_function_name(kompiled_dir + "/definition.kore", rule_label);
-  if (!match_function_name) {
-    std::cerr << "Rule with label " << rule_label << " does not exist.\n";
-    return EXIT_FAILURE;
-  }
 
   // Open the shared library that contains the llvm match functions.
   auto *handle = dlopen(shared_lib_path.c_str(), RTLD_LAZY);
@@ -73,9 +45,16 @@ int main(int argc, char **argv) {
     return EXIT_FAILURE;
   }
 
+  auto match_function_name = get_match_function_name(
+      kompiled_dir + "/definition.kore", rule_label, handle);
+  if (!match_function_name) {
+    std::cerr << "Rule with label " << rule_label << " does not exist.\n";
+    return EXIT_FAILURE;
+  }
+
   // Get util function from the shared lib, cast it to its right type, and call
   // with its appropriate argument if any.
-  void *match_function_ptr = dlsym(handle, match_function_name->c_str());
+  void *match_function_ptr = dlsym(handle, match_function_name);
   if (match_function_ptr == nullptr) {
     std::cerr << "Error: " << dlerror() << "\n";
     dlclose(handle);

--- a/tools/k-rule-apply/main.cpp
+++ b/tools/k-rule-apply/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
     return EXIT_FAILURE;
   }
 
-  auto match_function_name = get_match_function_name(
+  auto *match_function_name = get_match_function_name(
       kompiled_dir + "/definition.kore", rule_label, handle);
   if (!match_function_name) {
     std::cerr << "Rule with label " << rule_label << " does not exist.\n";

--- a/tools/k-rule-apply/main.cpp
+++ b/tools/k-rule-apply/main.cpp
@@ -58,11 +58,6 @@ int main(int argc, char **argv) {
   cl::HideUnrelatedOptions({&k_rule_cat});
   cl::ParseCommandLineOptions(argc, argv);
 
-  // Parse the given KORE Pattern and get the block* to use as input for the
-  // match function.
-  parser::kore_parser parser(kore_pattern_filename.getValue());
-  auto initial_configuration = parser.pattern();
-
   auto match_function_name = get_match_function_name();
   if (!match_function_name.has_value()) {
     std::cerr << "Rule with label " << rule_label << " does not exist.\n";
@@ -92,8 +87,7 @@ int main(int argc, char **argv) {
 
   reset_match_reason(handle);
   init_static_objects(handle);
-  auto *b
-      = construct_initial_configuration(initial_configuration.get(), handle);
+  auto *b = parse_initial_configuration(kore_pattern_filename, handle);
   if (b == nullptr) {
     std::cerr << "Error: " << dlerror() << "\n";
     return EXIT_FAILURE;

--- a/tools/k-rule-apply/main.cpp
+++ b/tools/k-rule-apply/main.cpp
@@ -1,4 +1,16 @@
-#include "auxiliar.h"
+#include "shims.h"
+
+#include <kllvm/parser/KOREParser.h>
+
+#include <llvm/Support/CommandLine.h>
+
+#include <cstdlib>
+#include <dlfcn.h>
+#include <fstream>
+#include <iostream>
+#include <optional>
+
+#include "runtime/header.h"
 
 using namespace llvm;
 using namespace kllvm;

--- a/tools/k-rule-apply/main.cpp
+++ b/tools/k-rule-apply/main.cpp
@@ -1,7 +1,5 @@
 #include "shims.h"
 
-#include <kllvm/parser/KOREParser.h>
-
 #include <llvm/Support/CommandLine.h>
 
 #include <cstdlib>

--- a/tools/k-rule-apply/shims.cpp
+++ b/tools/k-rule-apply/shims.cpp
@@ -10,13 +10,13 @@
 namespace kllvm {
 
 block *parse_initial_configuration(std::string const &filename, void *handle) {
-  auto *parse_file = reinterpret_cast<void *(*)(char const *)>(
+  auto *parse_file = reinterpret_cast<kore_pattern *(*)(char const *)>(
       dlsym(handle, "kore_pattern_parse_file"));
   if (!parse_file) {
     return nullptr;
   }
 
-  auto *construct = reinterpret_cast<block *(*)(void *)>(
+  auto *construct = reinterpret_cast<block *(*)(kore_pattern *)>(
       dlsym(handle, "kore_pattern_construct"));
   if (!construct) {
     return nullptr;

--- a/tools/k-rule-apply/shims.cpp
+++ b/tools/k-rule-apply/shims.cpp
@@ -1,27 +1,13 @@
+#include "shims.h"
+
 #include <kllvm/ast/AST.h>
-#include <kllvm/parser/KOREParser.h>
 
-#include <llvm/Support/CommandLine.h>
-
-#include <cstdlib>
 #include <dlfcn.h>
-#include <fstream>
 #include <iostream>
-#include <optional>
 
 #include "runtime/header.h"
 
-using namespace kllvm;
-
-extern "C" {
-void *construct_initial_configuration(kore_pattern const *);
-void reset_match_reason();
-match_log *getmatch_log();
-size_t getmatch_log_size();
-void print_match_result(
-    std::ostream &, match_log *, size_t, std::string const &);
-void init_static_objects();
-}
+namespace kllvm {
 
 void *
 construct_initial_configuration(kore_pattern const *pattern, void *handle) {
@@ -67,9 +53,8 @@ void *print_match_result(
   if (funcPtr == NULL) {
     return NULL;
   }
-  auto f = reinterpret_cast<
-      void *(*)(std::ostream &, match_log *, size_t, std::string const &)>(
-      funcPtr);
+  auto f = reinterpret_cast<void *(*)(std::ostream &, match_log *, size_t,
+                                      std::string const &)>(funcPtr);
   return f(os, log, logSize, dir);
 }
 
@@ -81,3 +66,5 @@ void *init_static_objects(void *handle) {
   auto f = reinterpret_cast<void *(*)()>(funcPtr);
   return f();
 }
+
+} // namespace kllvm

--- a/tools/k-rule-apply/shims.cpp
+++ b/tools/k-rule-apply/shims.cpp
@@ -9,14 +9,20 @@
 
 namespace kllvm {
 
-void *
-construct_initial_configuration(kore_pattern const *pattern, void *handle) {
-  void *funcPtr = dlsym(handle, "construct_initial_configuration");
-  if (funcPtr == NULL) {
-    return NULL;
+block *parse_initial_configuration(std::string const &filename, void *handle) {
+  auto *parse_file = reinterpret_cast<void *(*)(char const *)>(
+      dlsym(handle, "kore_pattern_parse_file"));
+  if (!parse_file) {
+    return nullptr;
   }
-  auto f = reinterpret_cast<void *(*)(kore_pattern const *)>(funcPtr);
-  return f(pattern);
+
+  auto *construct = reinterpret_cast<block *(*)(void *)>(
+      dlsym(handle, "kore_pattern_construct"));
+  if (!construct) {
+    return nullptr;
+  }
+
+  return construct(parse_file(filename.c_str()));
 }
 
 void *reset_match_reason(void *handle) {

--- a/tools/k-rule-apply/shims.cpp
+++ b/tools/k-rule-apply/shims.cpp
@@ -35,50 +35,51 @@ char *get_match_function_name(
 }
 
 void *reset_match_reason(void *handle) {
-  void *funcPtr = dlsym(handle, "reset_match_reason");
-  if (funcPtr == NULL) {
-    return NULL;
+  void *func_ptr = dlsym(handle, "reset_match_reason");
+  if (func_ptr == nullptr) {
+    return nullptr;
   }
-  auto f = reinterpret_cast<void *(*)()>(funcPtr);
+  auto f = reinterpret_cast<void *(*)()>(func_ptr);
   return f();
 }
 
 match_log *getmatch_log(void *handle) {
-  void *funcPtr = dlsym(handle, "getmatch_log");
-  if (funcPtr == NULL) {
-    return NULL;
+  void *func_ptr = dlsym(handle, "getmatch_log");
+  if (func_ptr == nullptr) {
+    return nullptr;
   }
-  auto f = reinterpret_cast<match_log *(*)()>(funcPtr);
+  auto f = reinterpret_cast<match_log *(*)()>(func_ptr);
   return f();
 }
 
 size_t getmatch_log_size(void *handle) {
-  void *funcPtr = dlsym(handle, "getmatch_log_size");
-  if (funcPtr == NULL) {
+  void *func_ptr = dlsym(handle, "getmatch_log_size");
+  if (func_ptr == nullptr) {
     return -1;
   }
-  auto f = reinterpret_cast<size_t (*)()>(funcPtr);
+  auto f = reinterpret_cast<size_t (*)()>(func_ptr);
   return f();
 }
 
 void *print_match_result(
-    std::ostream &os, match_log *log, size_t logSize, std::string const &dir,
+    std::ostream &os, match_log *log, size_t log_size, std::string const &dir,
     void *handle) {
-  void *funcPtr = dlsym(handle, "print_match_result");
-  if (funcPtr == NULL) {
-    return NULL;
+  void *func_ptr = dlsym(handle, "print_match_result");
+  if (func_ptr == nullptr) {
+    return nullptr;
   }
-  auto f = reinterpret_cast<void *(*)(std::ostream &, match_log *, size_t,
-                                      std::string const &)>(funcPtr);
-  return f(os, log, logSize, dir);
+  auto f = reinterpret_cast<
+      void *(*)(std::ostream &, match_log *, size_t, std::string const &)>(
+      func_ptr);
+  return f(os, log, log_size, dir);
 }
 
 void *init_static_objects(void *handle) {
-  void *funcPtr = dlsym(handle, "init_static_objects");
-  if (funcPtr == NULL) {
-    return NULL;
+  void *func_ptr = dlsym(handle, "init_static_objects");
+  if (func_ptr == nullptr) {
+    return nullptr;
   }
-  auto f = reinterpret_cast<void *(*)()>(funcPtr);
+  auto f = reinterpret_cast<void *(*)()>(func_ptr);
   return f();
 }
 

--- a/tools/k-rule-apply/shims.cpp
+++ b/tools/k-rule-apply/shims.cpp
@@ -1,7 +1,5 @@
 #include "shims.h"
 
-#include <kllvm/ast/AST.h>
-
 #include <dlfcn.h>
 #include <iostream>
 

--- a/tools/k-rule-apply/shims.cpp
+++ b/tools/k-rule-apply/shims.cpp
@@ -25,6 +25,17 @@ block *parse_initial_configuration(std::string const &filename, void *handle) {
   return construct(parse_file(filename.c_str()));
 }
 
+char *get_match_function_name(
+    std::string const &definition, std::string const &label, void *handle) {
+  auto *get_name = reinterpret_cast<char *(*)(char const *, char const *)>(
+      dlsym(handle, "kore_match_function_name"));
+  if (!get_name) {
+    return nullptr;
+  }
+
+  return get_name(definition.c_str(), label.c_str());
+}
+
 void *reset_match_reason(void *handle) {
   void *funcPtr = dlsym(handle, "reset_match_reason");
   if (funcPtr == NULL) {

--- a/tools/k-rule-apply/shims.h
+++ b/tools/k-rule-apply/shims.h
@@ -1,0 +1,30 @@
+#ifndef KLLVM_SHIMS_H
+#define KLLVM_SHIMS_H
+
+#include <cstddef>
+#include <string>
+
+struct match_log;
+
+namespace kllvm {
+
+class kore_pattern;
+
+void *
+construct_initial_configuration(kore_pattern const *pattern, void *handle);
+
+void *reset_match_reason(void *handle);
+
+match_log *getmatch_log(void *handle);
+
+size_t getmatch_log_size(void *handle);
+
+void *print_match_result(
+    std::ostream &os, match_log *log, size_t logSize, std::string const &dir,
+    void *handle);
+
+void *init_static_objects(void *handle);
+
+} // namespace kllvm
+
+#endif

--- a/tools/k-rule-apply/shims.h
+++ b/tools/k-rule-apply/shims.h
@@ -23,7 +23,7 @@ match_log *getmatch_log(void *handle);
 size_t getmatch_log_size(void *handle);
 
 void *print_match_result(
-    std::ostream &os, match_log *log, size_t logSize, std::string const &dir,
+    std::ostream &os, match_log *log, size_t log_size, std::string const &dir,
     void *handle);
 
 void *init_static_objects(void *handle);

--- a/tools/k-rule-apply/shims.h
+++ b/tools/k-rule-apply/shims.h
@@ -5,13 +5,13 @@
 #include <string>
 
 struct match_log;
+struct block;
 
 namespace kllvm {
 
 class kore_pattern;
 
-void *
-construct_initial_configuration(kore_pattern const *pattern, void *handle);
+block *parse_initial_configuration(std::string const &filename, void *handle);
 
 void *reset_match_reason(void *handle);
 

--- a/tools/k-rule-apply/shims.h
+++ b/tools/k-rule-apply/shims.h
@@ -13,6 +13,9 @@ class kore_pattern;
 
 block *parse_initial_configuration(std::string const &filename, void *handle);
 
+char *get_match_function_name(
+    std::string const &definition, std::string const &label, void *handle);
+
 void *reset_match_reason(void *handle);
 
 match_log *getmatch_log(void *handle);


### PR DESCRIPTION
This PR is a preparatory refactoring that will enable me to fix a problematic bug in the Kasmer project; I've factored out the changes here because they include other related cleanups not directly relevant to the bug I'm fixing in the subsequent PR.

Currently, the `k-rule-apply` tool is explicitly linked against the KORE AST library in order for it to be able to parse a KORE definition and search for an axiom with a particular label. This works fine, but on changing the way that the LLVM backend is linked on macOS, this AST linkage caused a subtle bug to manifest because of the way that `k-rule-apply` uses `dlopen` to inspect a shared library compiled by the backend.[^1]

The fix here is to remove the explicit dependency of this tool on the AST + Parser libraries, and instead push all the required behaviour of the tool into the C bindings so that it can be used fully with `dlopen`.

The changes in this PR are as follows:
- Reorganise the existing code in the `k-rule-apply` tool to be more hygienic in its usage of header files etc.
- Push calls to the KORE parser library and references to the KORE AST structures out in favour of C-linkage calls to the bindings module, which is available and compiled into the same shared library as we're already `dlopen`ing.
- Extract the one non-trivial usage of the AST library (mapping rule labels to matching function names via their axiom) into the core C bindings.
- Remove the dependency of this tool on the AST and Parser libraries, finally enabling the downstream bugfix that motivated this change in the first place.

[^1]: I have a full writeup of this on the way; in the context of this PR the specifics aren't important.