### PR TITLE
Accept public PRs for CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,48 @@ jobs:
             --yes                                   \
             --cleanup-tag
             
+  cachix:
+    name: 'Publish to Cachix'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: [self-hosted, linux, normal]
+            os: ubuntu-24.04
+          - runner: MacM1
+            os: self-macos-12
+
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+
+      - name: 'Install Nix'
+        if: ${{ !startsWith(matrix.os, 'self') }}
+        uses: cachix/install-nix-action@v22
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Install Cachix'
+        uses: cachix/cachix-action@v12
+        with:
+          name: k-framework
+          authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
+          skipPush: true
+
+      - name: 'Push Flake to Cachix'
+        run: |
+          GC_DONT_GC=1 nix build --print-build-logs . --json \
+            | jq -r '.[].outputs | to_entries[].value' \
+            | cachix push k-framework
 
   release:
     name: 'Publish Release'
     runs-on: ubuntu-latest
     environment: production
-    needs: build-ubuntu-package
+    needs: [build-ubuntu-package, cachix]
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,11 @@ jobs:
         uses: cachix/install-nix-action@v22
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v12
         with:
           name: k-framework
-          authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
           skipPush: true
 
       - name: 'Build LLVM backend'
@@ -50,12 +47,6 @@ jobs:
 
       - name: 'Test LLVM backend'
         run: GC_DONT_GC=1 nix flake check --print-build-logs
-
-      - name: 'Push Flake to Cachix'
-        run: |
-          GC_DONT_GC=1 nix build --print-build-logs . --json \
-            | jq -r '.[].outputs | to_entries[].value' \
-            | cachix push k-framework
 
   build-from-source:
     name: 'Build LLVM backend from source'


### PR DESCRIPTION
This PR removes usages of github secrets in the testing workflow run on CI; this means that external contributors should be able to open PRs from forked repos properly. Making the change here required one step more than the K repo needed (moving a cachix push from testing to release), but I'm pretty confident everything is wired up correctly.