### PR TITLE
INSTALL: Remove libunwind from MacOS dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,7 +41,6 @@ brew install  \
   git         \
   gmp         \
   jemalloc    \
-  libunwind   \
   libyaml     \
   llvm@15     \
   maven       \


### PR DESCRIPTION
libunwind is not available from Brew, and we don't need it anyway because MacOS LLVM doesn't need it.