### PR TITLE
Add interactive testing shell for Nix builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,9 @@ jobs:
       - name: 'Build pattern matching compiler'
         run: GC_DONT_GC=1 nix build --print-build-logs .#llvm-backend-matching
 
+      - name: 'Smoke test integration test shell'
+        run: GC_DONT_GC=1 nix develop --print-build-logs .#integration-test-shell-18 --command lit -v test/defn/imp.kore
+
       - name: 'Test LLVM backend'
         run: GC_DONT_GC=1 nix flake check --print-build-logs
 

--- a/flake.nix
+++ b/flake.nix
@@ -111,7 +111,7 @@
             {
               name = "llvm-backend-${toString args.llvm-version}-${args.build-type}";
               value = {
-                inherit (pkgs) llvm-backend llvm-backend-matching llvm-kompile-testing integration-tests;
+                inherit (pkgs) llvm-backend llvm-backend-matching llvm-kompile-testing integration-tests integration-test-shell;
               };
             }
         ));
@@ -120,6 +120,11 @@
           inherit (llvm-backend-18-FastBuild) llvm-backend llvm-backend-matching llvm-kompile-testing;
           default = llvm-backend-18-FastBuild.llvm-backend;
           llvm-backend-release = llvm-backend-18-Release.llvm-backend;
+
+          integration-test-shell-15 = llvm-backend-15-Debug.integration-test-shell;
+          integration-test-shell-16 = llvm-backend-16-Debug.integration-test-shell;
+          integration-test-shell-17 = llvm-backend-17-Debug.integration-test-shell;
+          integration-test-shell-18 = llvm-backend-18-Debug.integration-test-shell;
         };
 
         checks = listToChecks [

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -77,7 +77,7 @@ let
     buildPhase = ''
       runHook preBuild
 
-      ${integration-test-env};
+      ${integration-test-env}
       lit -v test
 
       runHook postBuild

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -54,6 +54,13 @@ let
     patchShebangs "$out/bin/llvm-kompile-testing"
   '';
 
+  integration-test-env = ''
+    export PYTHON_INTERPRETER=${llvm-backend.python-interpreter}
+    export BINDINGS_INSTALL_PATH=${llvm-backend}/lib/kllvm/python
+    export INCLUDE_INSTALL_PATH=${llvm-backend}/include
+    export LIT_USE_NIX=1
+  '';
+
   integration-tests = prev.stdenv.mkDerivation {
     name = "llvm-backend-integration-tests";
     src = llvm-backend.src;
@@ -66,16 +73,16 @@ let
       llvm-backend # the system under test
     ];
     configurePhase = "true";
+
     buildPhase = ''
       runHook preBuild
 
-      PYTHON_INTERPRETER=${llvm-backend.python-interpreter} \
-      BINDINGS_INSTALL_PATH=${llvm-backend}/lib/kllvm/python \
-      INCLUDE_INSTALL_PATH=${llvm-backend}/include \
-        LIT_USE_NIX=1 lit -v test
+      ${integration-test-env};
+      lit -v test
 
       runHook postBuild
     '';
+
     installPhase = ''
       runHook preInstall
 
@@ -85,8 +92,13 @@ let
       runHook postInstall
     '';
   };
+
+  integration-test-shell = prev.mkShell {
+    inputsFrom = [ integration-tests ];
+    shellHook = integration-test-env;
+  };
 in {
   inherit kllvm llvm-backend llvm-backend-matching llvm-kompile-testing
-    integration-tests;
+    integration-tests integration-test-shell;
   inherit (prev) clang; # for compatibility
 }


### PR DESCRIPTION
This PR adapts the existing integration testing derivation into a development shell that can be used to run individual `lit` test cases more selectively than the broad-strokes `nix flake check` command allows for.

To get a shell with a particular version of LLVM, run:
```console
$ nix develop .#integration-test-shell-18
(nix:nix-shell-env) $
```

Then, you can run `lit` commands as usual.

Fixes #865