### PR TITLE
Remove references to my contact details from repo

### DIFF
--- a/package/debian/changelog
+++ b/package/debian/changelog
@@ -2,4 +2,4 @@ k-llvm-backend (0.1.5) unstable; urgency=medium
 
   * Initial release
 
- -- Bruce Collie <bruce.collie@runtimeverification.com>  Fri, 26 Apr 2024 15:43:00 +0100
+ -- Guy Repta <guy.repta@runtimeverification.com>  Fri, 26 Apr 2024 15:43:00 +0100

--- a/package/debian/control.jammy
+++ b/package/debian/control.jammy
@@ -1,7 +1,7 @@
 Source: k-llvm-backend
 Section: devel
 Priority: optional
-Maintainer: Bruce Collie <bruce.collie@runtimeverification.com>
+Maintainer: Guy Repta <guy.repta@runtimeverification.com>
 Build-Depends: clang-15 , cmake , debhelper (>=10) , flex , libboost-dev , libboost-test-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libunwind-dev , libyaml-dev , llvm-15-tools , pkg-config , python3 , python3-dev , xxd
 Standards-Version: 3.9.6
 Homepage: https://github.com/runtimeverification/llvm-backend

--- a/package/debian/control.noble
+++ b/package/debian/control.noble
@@ -1,7 +1,7 @@
 Source: k-llvm-backend
 Section: devel
 Priority: optional
-Maintainer: Bruce Collie <bruce.collie@runtimeverification.com>
+Maintainer: Guy Repta <guy.repta@runtimeverification.com>
 Build-Depends: clang-17 , cmake , debhelper (>=10) , flex , libboost-dev , libboost-test-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libunwind-dev , libyaml-dev , llvm-17-tools , pkg-config , python3 , python3-dev , xxd
 Standards-Version: 3.9.6
 Homepage: https://github.com/runtimeverification/llvm-backend

--- a/package/debian/copyright
+++ b/package/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: k-llvm-backend
-Upstream-Contact: Bruce Collie <bruce.collie@runtimeverification.com>
+Upstream-Contact: Guy Repta <guy.repta@runtimeverification.com>
 Source: https://github.com/runtimeverification/llvm-backend
 
 Files: *


### PR DESCRIPTION
This PR removes any final references to my contact details from the LLVM backend repo, and assigns them to @gtrepta instead.