### PR TITLE
Fixing debugger scripts

### DIFF
--- a/debug/kgdb.py
+++ b/debug/kgdb.py
@@ -375,10 +375,10 @@ class termPrinter:
         self.kompiled_dir = getKompiledDir()
 
     def getSymbolNameForTag(self, tag):
-        return gdb.lookup_global_symbol("table_getSymbolNameForTag").value()[tag]
+        return gdb.lookup_global_symbol("table_get_symbol_name_for_tag").value()[tag]
 
     def isSymbolABinder(self, tag):
-        return gdb.lookup_global_symbol("table_isSymbolABinder").value()[tag]
+        return gdb.lookup_global_symbol("table_is_symbol_a_binder").value()[tag]
 
     def getLayoutData(self, layout):
         return gdb.lookup_global_symbol("layout_" + str(layout)).value()
@@ -610,7 +610,7 @@ class termPrinter:
             argData = layoutData['args'] + i
             arg = subject.cast(self.long_int) + int(argData.dereference()['offset'])
             cat = argData.dereference()['cat']
-            sort = gdb.lookup_global_symbol("table_getArgumentSortsForTag").value()[tag][i].string("iso-8859-1")
+            sort = gdb.lookup_global_symbol("table_get_argument_sorts_for_tag").value()[tag][i].string("iso-8859-1")
             if cat == @MAP_LAYOUT@:
                 self.appendMap(arg.cast(self.map_ptr), sort)
             elif cat == @RANGEMAP_LAYOUT@:
@@ -748,7 +748,7 @@ Does not actually take a step if matching succeeds.
             argv = gdb.string_to_argv(arg)
             if gdb.selected_inferior().pid == 0:
                 raise gdb.GdbError("You can't do that without a process to debug.")
-            gdb.lookup_global_symbol("resetMatchReason").value()()
+            gdb.lookup_global_symbol("reset_match_reason").value()()
             if (len(argv) != 2):
                 raise gdb.GdbError("k match takes two arguments.")
             fun = gdb.lookup_global_symbol(argv[0] + '.match')
@@ -759,8 +759,8 @@ Does not actually take a step if matching succeeds.
             except gdb.error as err:
                 raise gdb.GdbError(*err.args)
             fun.value()(subject)
-            entries = gdb.lookup_global_symbol("getMatchLog").value()()
-            size = int(gdb.lookup_global_symbol("getMatchLogSize").value()())
+            entries = gdb.lookup_global_symbol("getmatch_log").value()()
+            size = int(gdb.lookup_global_symbol("getmatch_log_size").value()())
             for i in range(size):
                 entry = entries[i]
                 if entry['kind'] == self.SUCCESS:
@@ -771,7 +771,7 @@ Does not actually take a step if matching succeeds.
                     print(debugFunctionName + '(', end='')
                     name = functionName if functionName[:5] == 'hook_' else debugFunctionName
                     function = gdb.lookup_global_symbol(name).value().type
-                    front = gdb.lookup_global_symbol("getMatchFnArgs").value()(entry.address)
+                    front = gdb.lookup_global_symbol("get_match_fn_args").value()(entry.address)
                     conn = ""
                     for i in range(len(function.fields())):
                         arg = front[i]

--- a/debug/klldb.py
+++ b/debug/klldb.py
@@ -141,7 +141,7 @@ class LogEntry:
         return self.exe_ctx.target.EvaluateExpression(ptr_exp)
 
     def get_match_function_args(self):
-        return target_call(self.exe_ctx, 'getMatchFnArgs', 'void **',
+        return target_call(self.exe_ctx, 'get_match_fn_args', 'void **',
                            ['MatchLog *'], [self.root])
 
     @property
@@ -190,7 +190,7 @@ class RuleMatcher:
         self.exe_ctx = exe_ctx
 
     def _reset_match_reason(self):
-        target_call(self.exe_ctx, 'resetMatchReason', 'void')
+        target_call(self.exe_ctx, 'reset_match_reason', 'void')
 
     def _try_match(self, rule_name, subject):
         expr = self.exe_ctx.target.EvaluateExpression(subject)
@@ -198,10 +198,10 @@ class RuleMatcher:
                     'void', ['block *'], [expr])
 
     def _get_match_log_size(self):
-        return target_call(self.exe_ctx, 'getMatchLogSize', 'size_t').data.uint64[0]
+        return target_call(self.exe_ctx, 'getmatch_log_size', 'size_t').data.uint64[0]
 
     def _get_match_log(self):
-        return target_call(self.exe_ctx, 'getMatchLog', 'MatchLog *')
+        return target_call(self.exe_ctx, 'getmatch_log', 'MatchLog *')
 
     def _type_to_sort(self, ty):
         return {


### PR DESCRIPTION
GDB/LLDB has been broken for a while, and I suspect it has been broken since PR #1000. 

When `k start` was typed in GDB, we had the following error when pretty-printing the subject:
```Bash
Temporary breakpoint 1, 0x00005555555c00f0 in main ()
0x00005555555bb080 in k_step (subject=Traceback (most recent call last):
  File "<string>", line 392, in to_string
  File "<string>", line 599, in append
  File "<string>", line 381, in isSymbolABinder
AttributeError: 'NoneType' object has no attribute 'value'

Python Exception <class 'AttributeError'>: 'NoneType' object has no attribute 'value'
) at /home/robertorosmaninho/pi2-inc/tests/add-rewrite.k:20
20        rule [state-succ] : s(M:Nat) ~> state(N:Nat, _:Nat) => state(N, s(M))
(gdb)
```
This happens due to the renaming of `table_getSymbolNameForTag` and other global symbols to follow a unique snake_case pattern not being reflected on these debug scripts.

The same should be applied to lldb. But honestly not tested.
