### PR TITLE
Shared memory writer for proof hints

### DIFF
--- a/include/kllvm/binary/serializer.h
+++ b/include/kllvm/binary/serializer.h
@@ -199,6 +199,14 @@ public:
 
   ~proof_trace_ringbuffer_writer() override { shm_buffer_->~shm_ringbuffer(); }
 
+  proof_trace_ringbuffer_writer(proof_trace_ringbuffer_writer const &) = delete;
+  proof_trace_ringbuffer_writer(proof_trace_ringbuffer_writer &&) = delete;
+  proof_trace_ringbuffer_writer &
+  operator=(proof_trace_ringbuffer_writer const &)
+      = delete;
+  proof_trace_ringbuffer_writer &operator=(proof_trace_ringbuffer_writer &&)
+      = delete;
+
   void write(void const *ptr, size_t len) override;
   void write_string(char const *str, size_t len) override;
   void write_string(char const *str) override;

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -231,17 +231,17 @@ void proof_trace_ringbuffer_writer::write(uint8_t const *ptr, size_t len) {
 }
 
 void proof_trace_ringbuffer_writer::write(void const *ptr, size_t len) {
-  auto *data = reinterpret_cast<uint8_t const *>(ptr);
+  auto const *data = reinterpret_cast<uint8_t const *>(ptr);
   write(data, len);
 }
 
 void proof_trace_ringbuffer_writer::write_string(char const *str, size_t len) {
-  auto *data = reinterpret_cast<uint8_t const *>(str);
+  auto const *data = reinterpret_cast<uint8_t const *>(str);
   write(data, len);
 }
 
 void proof_trace_ringbuffer_writer::write_string(char const *str) {
-  auto *data = reinterpret_cast<uint8_t const *>(str);
+  auto const *data = reinterpret_cast<uint8_t const *>(str);
   write(data, strlen(str));
 }
 

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -222,4 +222,31 @@ void proof_trace_file_writer::write_string(char const *str) {
   fputs(str, file_);
 }
 
+void proof_trace_ringbuffer_writer::write(uint8_t const *ptr, size_t len) {
+  for (size_t i = 0; i < len; i++) {
+    sem_wait(space_avail_);
+    shm_buffer_->put(&ptr[i]);
+    sem_post(data_avail_);
+  }
+}
+
+void proof_trace_ringbuffer_writer::write(void const *ptr, size_t len) {
+  auto *data = reinterpret_cast<uint8_t const *>(ptr);
+  write(data, len);
+}
+
+void proof_trace_ringbuffer_writer::write_string(char const *str, size_t len) {
+  auto *data = reinterpret_cast<uint8_t const *>(str);
+  write(data, len);
+}
+
+void proof_trace_ringbuffer_writer::write_string(char const *str) {
+  auto *data = reinterpret_cast<uint8_t const *>(str);
+  write(data, strlen(str));
+}
+
+void proof_trace_ringbuffer_writer::write_eof() {
+  shm_buffer_->put_eof();
+}
+
 } // namespace kllvm

--- a/runtime/main/main.ll
+++ b/runtime/main/main.ll
@@ -19,11 +19,13 @@ declare void @print_proof_hint_header(ptr)
 @statistics.flag = private constant [13 x i8] c"--statistics\00"
 @binary_out.flag = private constant [16 x i8] c"--binary-output\00"
 @proof_out.flag = private constant [15 x i8] c"--proof-output\00"
+@use_shm.flag = private constant [20 x i8] c"--use-shared-memory\00"
 
 @proof_writer = external global ptr
 @statistics = external global i1
 @binary_output = external global i1
 @proof_output = external global i1
+@use_shm = external global i1
 
 declare i32 @strcmp(ptr %a, ptr %b)
 
@@ -63,10 +65,19 @@ binary.set:
 proof.body:
   %proof.cmp = call i32 @strcmp(ptr %arg, ptr getelementptr inbounds ([15 x i8], ptr @proof_out.flag, i64 0, i64 0))
   %proof.eq = icmp eq i32 %proof.cmp, 0
-  br i1 %proof.eq, label %proof.set, label %body.tail
+  br i1 %proof.eq, label %proof.set, label %shm.body
 
 proof.set:
   store i1 1, ptr @proof_output
+  br label %shm.body
+
+shm.body:
+  %shm.cmp = call i32 @strcmp(ptr %arg, ptr getelementptr inbounds ([20 x i8], ptr @use_shm.flag, i64 0, i64 0))
+  %shm.eq = icmp eq i32 %shm.cmp, 0
+  br i1 %shm.eq, label %shm.set, label %body.tail
+
+shm.set:
+  store i1 1, ptr @use_shm
   br label %body.tail
 
 body.tail:

--- a/runtime/util/finish_rewriting.cpp
+++ b/runtime/util/finish_rewriting.cpp
@@ -1,16 +1,21 @@
+#include <kllvm/binary/serializer.h>
+
 #include <runtime/header.h>
 
 #include <cstdint>
+#include <fcntl.h>
 #include <iostream>
 #include <memory>
+#include <sys/mman.h>
 
 extern "C" {
 
 FILE *output_file = nullptr;
-kllvm::proof_trace_writer *proof_writer = nullptr;
+void *proof_writer = nullptr;
 bool statistics = false;
 bool binary_output = false;
 bool proof_output = false;
+bool use_shm = false;
 
 extern int64_t steps;
 extern bool safe_partial;
@@ -18,7 +23,55 @@ extern bool proof_hint_instrumentation_slow;
 
 int32_t get_exit_code(block *);
 
+#define ERR_EXIT(msg)                                                          \
+  do {                                                                         \
+    perror(msg);                                                               \
+    exit(1);                                                                   \
+  } while (0)
+
+static void set_up_shm_writer(char const *output_filename) {
+  // Open existing shared memory object
+  int fd = shm_open(output_filename, O_RDWR, 0);
+  if (fd == -1) {
+    ERR_EXIT("shm_open writer");
+  }
+
+  // Map the object into the caller's address space
+  size_t shm_size = sizeof(kllvm::shm_ringbuffer);
+  void *shm_object
+      = mmap(nullptr, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  if (shm_object == MAP_FAILED) {
+    ERR_EXIT("mmap writer");
+  }
+
+  // MacOS has deprecated unnamed semaphores, so we need to use named ones
+  std::string base_name(output_filename);
+  std::string data_avail_sem_name = base_name + ".d";
+  std::string space_avail_sem_name = base_name + ".s";
+
+  // Open existing semaphores
+  // NOLINTNEXTLINE(*-pro-type-vararg)
+  sem_t *data_avail = sem_open(data_avail_sem_name.c_str(), 0);
+  if (data_avail == SEM_FAILED) {
+    ERR_EXIT("sem_init data_avail writer");
+  }
+  // NOLINTNEXTLINE(*-pro-type-vararg)
+  sem_t *space_avail = sem_open(space_avail_sem_name.c_str(), 0);
+  if (space_avail == SEM_FAILED) {
+    ERR_EXIT("sem_init space_avail writer");
+  }
+
+  // Create the proof_trace_ringbuffer_writer object
+  proof_writer = new kllvm::proof_trace_ringbuffer_writer(
+      shm_object, data_avail, space_avail);
+}
+
 void init_outputs(char const *output_filename) {
+  if (proof_output && use_shm) {
+    set_up_shm_writer(output_filename);
+    return;
+  }
+
   output_file = fopen(output_filename, "a");
   if (proof_output) {
     proof_writer = new kllvm::proof_trace_file_writer(output_file);
@@ -34,8 +87,8 @@ void init_outputs(char const *output_filename) {
       = std::unique_ptr<FILE, decltype(&fclose)>(output_file, fclose);
 
   // Similar for deletinging the proof_output_buffer data structure
-  [[maybe_unused]] auto deleter
-      = std::unique_ptr<kllvm::proof_trace_writer>(proof_writer);
+  auto *w = static_cast<kllvm::proof_trace_writer *>(proof_writer);
+  [[maybe_unused]] auto deleter = std::unique_ptr<kllvm::proof_trace_writer>(w);
 
   if (error && safe_partial) {
     throw std::runtime_error(
@@ -43,8 +96,10 @@ void init_outputs(char const *output_filename) {
   }
 
   if (!output_file) {
-    throw std::runtime_error(
-        "Called finish_rewriting with no output file specified");
+    if (!proof_output || !use_shm) {
+      throw std::runtime_error(
+          "Called finish_rewriting with no output file specified");
+    }
   }
 
   if (statistics) {
@@ -58,11 +113,16 @@ void init_outputs(char const *output_filename) {
       print_configuration(output_file, subject);
     }
   } else if (!error && !proof_hint_instrumentation_slow) {
-    write_uint64_to_proof_trace(proof_writer, 0xFFFFFFFFFFFFFFFF);
+    w->write_uint64(0xFFFFFFFFFFFFFFFF);
     serialize_configuration_to_proof_writer(proof_writer, subject);
   }
 
   auto exit_code = error ? 113 : get_exit_code(subject);
+
+  if (proof_output) {
+    w->write_eof();
+  }
+
   std::exit(exit_code);
 }
 }

--- a/test/defn/imp-sum-slow.kore
+++ b/test/defn/imp-sum-slow.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-slow-interpreter
 // RUN: %check-proof-out
+// RUN: %check-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/llvm-backend/src/main/native/llvm-backend/test/defn/k-files/imp.md)")]
 
 module BASIC-K

--- a/test/defn/imp-sum.kore
+++ b/test/defn/imp-sum.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-proof-out
+// RUN: %check-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/llvm-backend/src/main/native/llvm-backend/test/defn/k-files/imp.md)")]
 
 module BASIC-K

--- a/test/defn/imp.kore
+++ b/test/defn/imp.kore
@@ -2,6 +2,7 @@
 // RUN: %check-grep
 // RUN: %proof-interpreter
 // RUN: %check-proof-out
+// RUN: %check-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/llvm-backend/src/main/native/llvm-backend/test/defn/k-files/imp.md)")]
 
 module BASIC-K

--- a/test/defn/kool-static.kore
+++ b/test/defn/kool-static.kore
@@ -2,6 +2,7 @@
 // RUN: %check-diff
 // RUN: %proof-interpreter
 // RUN: %check-proof-out
+// RUN: %check-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/kool-typed-static.md)")]
 
 module BASIC-K

--- a/test/proof/add-rewrite.kore
+++ b/test/proof/add-rewrite.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 // RUN: %check-proof-debug-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/add-rewrite/add-rewrite.k)")]
 

--- a/test/proof/arith.kore
+++ b/test/proof/arith.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/arith/arith.k)")]
 
 module BASIC-K

--- a/test/proof/assoc-function.kore
+++ b/test/proof/assoc-function.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/assoc-function/assoc-function.k)")]
 
 module BASIC-K

--- a/test/proof/builtin-functions.kore
+++ b/test/proof/builtin-functions.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/builtin-functions/builtin-functions.k)")]
 
 module BASIC-K

--- a/test/proof/builtin-hook-events.kore
+++ b/test/proof/builtin-hook-events.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/builtin-hook-events/builtin-hook-events.k)")]
 
 module BASIC-K

--- a/test/proof/builtin-int.kore
+++ b/test/proof/builtin-int.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/builtin-int/builtin-int.k)")]
 
 module BASIC-K

--- a/test/proof/builtin-io.kore
+++ b/test/proof/builtin-io.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/builtin-io/builtin-io.k)")]
 
 module BASIC-K

--- a/test/proof/builtin-json.kore
+++ b/test/proof/builtin-json.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/builtin-json/builtin-json.k)")]
 
 module BASIC-K

--- a/test/proof/cast.kore
+++ b/test/proof/cast.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/cast/cast.k)")]
 
 module BASIC-K

--- a/test/proof/cell-collection.kore
+++ b/test/proof/cell-collection.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/cell-collection/cell-collection.k)")]
 
 module BASIC-K

--- a/test/proof/cell-value.kore
+++ b/test/proof/cell-value.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/cell-value/cell-value.k)")]
 
 module BASIC-K

--- a/test/proof/concurrent-counters.kore
+++ b/test/proof/concurrent-counters.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/concurrent-counters/concurrent-counters.k)")]
 
 module BASIC-K

--- a/test/proof/conditional-function.kore
+++ b/test/proof/conditional-function.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/conditional-function/conditional-function.k)")]
 
 module BASIC-K

--- a/test/proof/custom-klabel-fun.kore
+++ b/test/proof/custom-klabel-fun.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/custom-klabel-fun/custom-klabel-fun.k)")]
 
 module BASIC-K

--- a/test/proof/decrement-int.kore
+++ b/test/proof/decrement-int.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/decrement-int/decrement-int.k)")]
 
 module BASIC-K

--- a/test/proof/decrement.kore
+++ b/test/proof/decrement.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/decrement/decrement.k)")]
 
 module BASIC-K

--- a/test/proof/double-rewrite.kore
+++ b/test/proof/double-rewrite.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/double-rewrite/double-rewrite.k)")]
 
 module BASIC-K

--- a/test/proof/dv.kore
+++ b/test/proof/dv.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/dv/dv.k)")]
 
 module BASIC-K

--- a/test/proof/exit-cell.kore
+++ b/test/proof/exit-cell.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/exit-cell/exit-cell.k)")]
 
 module BASIC-K

--- a/test/proof/fresh-gen.kore
+++ b/test/proof/fresh-gen.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/fresh-gen/fresh-gen.k)")]
 
 module BASIC-K

--- a/test/proof/fun-context.kore
+++ b/test/proof/fun-context.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/fun-context/fun-context.k)")]
 
 module BASIC-K

--- a/test/proof/imp.kore
+++ b/test/proof/imp.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/imp/imp.k)")]
 
 module BASIC-K

--- a/test/proof/imp5-rw-literal.kore
+++ b/test/proof/imp5-rw-literal.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/imp5-rw-literal/imp5-rw-literal.k)")]
 
 module BASIC-K

--- a/test/proof/imp5-rw-succ.kore
+++ b/test/proof/imp5-rw-succ.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/imp5-rw-succ/imp5-rw-succ.k)")]
 
 module BASIC-K

--- a/test/proof/imp5.kore
+++ b/test/proof/imp5.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/imp5/imp5.k)")]
 
 module BASIC-K

--- a/test/proof/injections.kore
+++ b/test/proof/injections.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/injections/injections.k)")]
 
 module BASIC-K

--- a/test/proof/is-zero.kore
+++ b/test/proof/is-zero.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/is-zero/is-zero.k)")]
 
 module BASIC-K

--- a/test/proof/lambda-explicit-subst.kore
+++ b/test/proof/lambda-explicit-subst.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/lambda-explicit-subst/lambda-explicit-subst.k)")]
 
 module BASIC-K

--- a/test/proof/let.kore
+++ b/test/proof/let.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/let/let.k)")]
 
 module BASIC-K

--- a/test/proof/list-assoc.kore
+++ b/test/proof/list-assoc.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/list-assoc/list-assoc.k)")]
 
 module BASIC-K

--- a/test/proof/list-cons.kore
+++ b/test/proof/list-cons.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/list-cons/list-cons.k)")]
 
 module BASIC-K

--- a/test/proof/list-factory.kore
+++ b/test/proof/list-factory.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/list-factory/list-factory.k)")]
 
 module BASIC-K

--- a/test/proof/list-semantic.kore
+++ b/test/proof/list-semantic.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/list-semantic/list-semantic.k)")]
 
 module BASIC-K

--- a/test/proof/macro.kore
+++ b/test/proof/macro.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/macro/macro.k)")]
 
 module BASIC-K

--- a/test/proof/map-fun.kore
+++ b/test/proof/map-fun.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/map-fun/map-fun.k)")]
 
 module BASIC-K

--- a/test/proof/memo-function.kore
+++ b/test/proof/memo-function.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/memo-function/memo-function.k)")]
 
 module BASIC-K

--- a/test/proof/modular-config.kore
+++ b/test/proof/modular-config.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/modular-config/modular-config.k)")]
 
 module BASIC-K

--- a/test/proof/nested-cells.kore
+++ b/test/proof/nested-cells.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/nested-cells/nested-cells.k)")]
 
 module BASIC-K

--- a/test/proof/non-rec-function.kore
+++ b/test/proof/non-rec-function.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/non-rec-function/non-rec-function.k)")]
 
 module BASIC-K

--- a/test/proof/pcf.kore
+++ b/test/proof/pcf.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/pcf/pcf.k)")]
 
 module BASIC-K

--- a/test/proof/peano.kore
+++ b/test/proof/peano.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/peano/peano.k)")]
 
 module BASIC-K

--- a/test/proof/prioritized-rule.kore
+++ b/test/proof/prioritized-rule.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/prioritized-rule/prioritized-rule.k)")]
 
 module BASIC-K

--- a/test/proof/projection.kore
+++ b/test/proof/projection.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/projection/projection.k)")]
 
 module BASIC-K

--- a/test/proof/reg.kore
+++ b/test/proof/reg.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/reg/reg.k)")]
 
 module BASIC-K

--- a/test/proof/set-fun.kore
+++ b/test/proof/set-fun.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/set-fun/set-fun.k)")]
 
 module BASIC-K

--- a/test/proof/simple.kore
+++ b/test/proof/simple.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/simple/simple.k)")]
 
 module BASIC-K

--- a/test/proof/single-rewrite.kore
+++ b/test/proof/single-rewrite.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/single-rewrite/single-rewrite.k)")]
 
 module BASIC-K

--- a/test/proof/sum-cell.kore
+++ b/test/proof/sum-cell.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/sum-cell/sum-cell.k)")]
 
 module BASIC-K

--- a/test/proof/tree-reverse-int.kore
+++ b/test/proof/tree-reverse-int.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/tree-reverse-int/tree-reverse-int.k)")]
 
 module BASIC-K

--- a/test/proof/tree-reverse.kore
+++ b/test/proof/tree-reverse.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/tree-reverse/tree-reverse.k)")]
 
 module BASIC-K

--- a/test/proof/two-counters.kore
+++ b/test/proof/two-counters.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/two-counters/two-counters.k)")]
 
 module BASIC-K

--- a/test/proof/type-cast.kore
+++ b/test/proof/type-cast.kore
@@ -1,5 +1,6 @@
 // RUN: %proof-interpreter
 // RUN: %check-dir-proof-out
+// RUN: %check-dir-proof-shm-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/proof-checker/generation/k-benchmarks/type-cast/type-cast.k)")]
 
 module BASIC-K

--- a/tools/kore-proof-trace-shm-writer/CMakeLists.txt
+++ b/tools/kore-proof-trace-shm-writer/CMakeLists.txt
@@ -5,8 +5,3 @@ kllvm_add_tool(kore-proof-trace-shm-writer
 target_link_libraries(kore-proof-trace-shm-writer
   PUBLIC BinaryKore
 )
-
-install(
-  TARGETS kore-proof-trace-shm-writer
-  RUNTIME DESTINATION bin
-)


### PR DESCRIPTION
This PR adds a subclass of the abstract `proof_trace_writer` for outputting hints into a ringbuffer that lives in shared memory. This output method is intended to be used with the shared memory option of the `kore-proof-trace` parser to communicate hints through shared memory instead of through a file.

Since we now can test the shared memory based proof generation/consumption loop, we also do not include the helper `kore-proof-trace-shm-writer` tool in the installation.