### PR TITLE
Buffered reads/writes for hint generation with shared memory

### DIFF
--- a/include/kllvm/binary/deserializer.h
+++ b/include/kllvm/binary/deserializer.h
@@ -384,7 +384,8 @@ public:
       void *shm_object, sem_t *data_avail, sem_t *space_avail)
       : shm_buffer_(static_cast<shm_ringbuffer *>(shm_object))
       , data_avail_(data_avail)
-      , space_avail_(space_avail) {
+      , space_avail_(space_avail)
+      , buffer_() {
     new (shm_buffer_) shm_ringbuffer;
   }
 

--- a/include/kllvm/binary/ringbuffer.h
+++ b/include/kllvm/binary/ringbuffer.h
@@ -18,11 +18,15 @@ public:
   // empty, we maintain the invariant that the capacity of the buffer is one byte
   // less than its size. This way, the buffer is empty iff read_pos == write_pos,
   // and it is full iff read_pos == (write_pos+1)%size.
-  static constexpr size_t size = 1024;
+  static constexpr size_t size = 4096;
 
   // Ringbuffer capacity in bytes.
   // As commented above, the capacity is always equal to size-1.
   static constexpr size_t capacity = size - 1;
+
+  // The default size in bytes for put and get operations.
+  static constexpr size_t buffered_access_sz = 64;
+  static_assert(buffered_access_sz <= capacity);
 
 private:
   bool eof_{false};
@@ -42,9 +46,8 @@ public:
   // undefined behavior.
   void put_eof();
 
-  // Returns true when the ringbuffer is empty and the EOF has been written, and
-  // false otherwise. As commented above, the ringbuffer is empty iff
-  // read_pos == write_pos.
+  // Returns true when eof has been written in the ringbuffer. At that point,
+  // the ringbuffer may still contain data, but no further writes can happen.
   [[nodiscard]] bool eof() const;
 
   // Add data to the ringbuffer. The behavior is undefined if the buffer does not
@@ -52,13 +55,13 @@ public:
   // ringbuffer. The behavior is also undefined if the data pointer passed to this
   // function does not point to a contiguous memory chunk of the corresponding
   // size.
-  void put(uint8_t const *data, size_t count = 1);
+  void put(uint8_t const *data, size_t count = buffered_access_sz);
 
   // Get and remove data from the ringbuffer. The behavior is undefined if more
   // data is requested than it is currently available in the ringbuffer. The
   // behavior is also undefined if the data pointer passed to this function does
   // not point to a contiguous memory chunk of the corresponding size.
-  void get(uint8_t *data, size_t count = 1);
+  void get(uint8_t *data, size_t count = buffered_access_sz);
 };
 
 } // namespace kllvm

--- a/include/kllvm/binary/serializer.h
+++ b/include/kllvm/binary/serializer.h
@@ -188,6 +188,9 @@ private:
   sem_t *data_avail_;
   sem_t *space_avail_;
 
+  std::array<uint8_t, shm_ringbuffer::buffered_access_sz> buffer_;
+  size_t buffer_data_size_{0};
+
   void write(uint8_t const *ptr, size_t len = 1);
 
 public:

--- a/include/kllvm/binary/serializer.h
+++ b/include/kllvm/binary/serializer.h
@@ -198,7 +198,8 @@ public:
       void *shm_object, sem_t *data_avail, sem_t *space_avail)
       : shm_buffer_(reinterpret_cast<shm_ringbuffer *>(shm_object))
       , data_avail_(data_avail)
-      , space_avail_(space_avail) { }
+      , space_avail_(space_avail)
+      , buffer_() { }
 
   ~proof_trace_ringbuffer_writer() override { shm_buffer_->~shm_ringbuffer(); }
 

--- a/lib/binary/ringbuffer.cpp
+++ b/lib/binary/ringbuffer.cpp
@@ -22,14 +22,7 @@ void shm_ringbuffer::put_eof() {
 }
 
 bool shm_ringbuffer::eof() const {
-  // NOTE: for synchronization purposes, it is important that the eof_ field is
-  // checked first. Typically, the reader process will call this, so we want to
-  // avoid a race where the writer updates buf.writer_pos after the reader has
-  // accessed it but before the reader has fully evaluated the condition. If
-  // eof_ is checked first, and due to short-circuiting, we know that if eof_ is
-  // true, the writer will not do any further updates to the write_pos_ field,
-  // and if eof_ is false, the reader will not access write_pos_ at all.
-  return eof_ && write_pos_ == read_pos_;
+  return eof_;
 }
 
 void shm_ringbuffer::put(uint8_t const *data, size_t count) {

--- a/tools/kore-proof-trace/main.cpp
+++ b/tools/kore-proof-trace/main.cpp
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
     // NOLINTNEXTLINE(*-pro-type-vararg)
     sem_t *space_avail = sem_open(
         space_avail_sem_name.c_str(), O_CREAT | O_EXCL, S_IRUSR | S_IWUSR,
-        shm_ringbuffer::capacity);
+        shm_ringbuffer::capacity / shm_ringbuffer::buffered_access_sz);
     if (space_avail == SEM_FAILED) {
       ERR_EXIT("sem_init space_avail reader");
     }

--- a/tools/kore-proof-trace/main.cpp
+++ b/tools/kore-proof-trace/main.cpp
@@ -50,6 +50,9 @@ cl::opt<bool> use_shared_memory(
     exit(1);                                                                   \
   } while (0)
 
+static constexpr mode_t perms
+    = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
+
 // NOLINTNEXTLINE(*-cognitive-complexity)
 int main(int argc, char **argv) {
   cl::HideUnrelatedOptions({&kore_proof_trace_cat});
@@ -86,8 +89,7 @@ int main(int argc, char **argv) {
     shm_unlink(input_filename.c_str());
 
     // Open shared memory object
-    int fd = shm_open(
-        input_filename.c_str(), O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);
+    int fd = shm_open(input_filename.c_str(), O_CREAT | O_EXCL | O_RDWR, perms);
     if (fd == -1) {
       ERR_EXIT("shm_open reader");
     }
@@ -114,15 +116,15 @@ int main(int argc, char **argv) {
     sem_unlink(space_avail_sem_name.c_str());
 
     // Initialize semaphores
-    // NOLINTNEXTLINE(*-pro-type-vararg)
-    sem_t *data_avail = sem_open(
-        data_avail_sem_name.c_str(), O_CREAT | O_EXCL, S_IRUSR | S_IWUSR, 0);
+    sem_t *data_avail
+        // NOLINTNEXTLINE(*-pro-type-vararg)
+        = sem_open(data_avail_sem_name.c_str(), O_CREAT | O_EXCL, perms, 0);
     if (data_avail == SEM_FAILED) {
       ERR_EXIT("sem_init data_avail reader");
     }
     // NOLINTNEXTLINE(*-pro-type-vararg)
     sem_t *space_avail = sem_open(
-        space_avail_sem_name.c_str(), O_CREAT | O_EXCL, S_IRUSR | S_IWUSR,
+        space_avail_sem_name.c_str(), O_CREAT | O_EXCL, perms,
         shm_ringbuffer::capacity / shm_ringbuffer::buffered_access_sz);
     if (space_avail == SEM_FAILED) {
       ERR_EXIT("sem_init space_avail reader");
@@ -132,7 +134,10 @@ int main(int argc, char **argv) {
     auto trace = parser.parse_proof_trace_from_shmem(
         shm_object, data_avail, space_avail);
 
-    // Close semaphores
+    // Close the shared memory object and semaphores
+    if (close(fd) == -1) {
+      ERR_EXIT("close shm object reader");
+    }
     if (sem_close(data_avail) == -1) {
       ERR_EXIT("sem_close data reader");
     }

--- a/unittests/compiler/ringbuffer.cpp
+++ b/unittests/compiler/ringbuffer.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(smoke) {
   BOOST_CHECK(!buffer.eof());
 
   buffer.put_eof();
-  BOOST_CHECK(!buffer.eof());
+  BOOST_CHECK(buffer.eof());
 
   std::string read_data;
   read_data.resize(message.size());
@@ -58,9 +58,9 @@ BOOST_AUTO_TEST_CASE(write_read_loop) {
   }
 
   buffer.put_eof();
-  BOOST_CHECK(!buffer.eof());
+  BOOST_CHECK(buffer.eof());
 
-  while (!buffer.eof()) {
+  while (buffer.data_size()) {
     if (read_offs + read_chunk_size <= message.size()) {
       BOOST_CHECK(read_chunk_size <= buffer.data_size());
       buffer.get((uint8_t *)read_data.data() + read_offs, read_chunk_size);


### PR DESCRIPTION
This PR adds implementation for buffered reads/writes from and to the shared memory ringbuffer during hint generation. The previous implementation would synchronize reads and writes at the granularity of one byte which is not ideal for performance. In this PR, we add support for synchronization across reads and writes of larger sizes. Both the ringbuffer-based proof trace reader and writer classes are updated to buffer incoming reads and writes: They collect data into an internal buffer and only interacting with the shared memory ringbuffer when that buffer is full in case of the writer or empty in case of the reader.