### PR TITLE
Introducing new `llvm_pattern_matching_failure_event` to Proof Events

### DIFF
--- a/docs/proof-trace.md
+++ b/docs/proof-trace.md
@@ -49,6 +49,9 @@ name              ::= string
 location          ::= string
 function          ::= WORD(0xDD) name location arg* WORD(0x11) // the arg list is ommited in normal mode
 
+function_name     ::= string
+pattern_matching_failure ::= WORD(0x44) function_name
+
 symbol_name       ::= string
 hook              ::= WORD(0xAA) name symbol_name location arg* WORD(0xBB) kore_term
 

--- a/include/kllvm/binary/ProofTraceParser.h
+++ b/include/kllvm/binary/ProofTraceParser.h
@@ -34,6 +34,7 @@ constexpr uint64_t hook_result_sentinel = detail::word(0xBB);
 constexpr uint64_t rule_event_sentinel = detail::word(0x22);
 constexpr uint64_t side_condition_event_sentinel = detail::word(0xEE);
 constexpr uint64_t side_condition_end_sentinel = detail::word(0x33);
+constexpr uint64_t pattern_matching_failure_sentinel = detail::word(0x44);
 
 class llvm_step_event : public std::enable_shared_from_this<llvm_step_event> {
 public:
@@ -144,6 +145,28 @@ public:
 
   [[nodiscard]] uint64_t get_rule_ordinal() const { return rule_ordinal_; }
   [[nodiscard]] bool get_result() const { return result_; }
+
+  void print(std::ostream &out, bool expand_terms, unsigned indent = 0U)
+      const override;
+};
+
+class llvm_pattern_matching_failure_event : public llvm_step_event {
+private:
+  std::string function_name_;
+
+  llvm_pattern_matching_failure_event(std::string function_name)
+      : function_name_(std::move(function_name)) { }
+
+public:
+  static sptr<llvm_pattern_matching_failure_event>
+  create(std::string function_name) {
+    return sptr<llvm_pattern_matching_failure_event>(
+        new llvm_pattern_matching_failure_event(std::move(function_name)));
+  }
+
+  [[nodiscard]] std::string const &get_function_name() const {
+    return function_name_;
+  }
 
   void print(std::ostream &out, bool expand_terms, unsigned indent = 0U)
       const override;
@@ -545,6 +568,22 @@ private:
     return event;
   }
 
+  sptr<llvm_pattern_matching_failure_event> static parse_pattern_matching_failure(
+      proof_trace_buffer &buffer) {
+    if (!buffer.check_word(pattern_matching_failure_sentinel)) {
+      return nullptr;
+    }
+
+    std::string function_name;
+    if (!buffer.read_string(function_name)) {
+      return nullptr;
+    }
+
+    auto event = llvm_pattern_matching_failure_event::create(function_name);
+
+    return event;
+  }
+
   bool parse_argument(proof_trace_buffer &buffer, llvm_event &event) {
     if (!buffer.eof() && buffer.peek() == '\x7F') {
       uint64_t pattern_len = 0;
@@ -608,6 +647,16 @@ private:
       return true;
     }
 
+    case pattern_matching_failure_sentinel: {
+      auto pattern_matching_failure_event
+          = parse_pattern_matching_failure(buffer);
+      if (!pattern_matching_failure_event) {
+        return false;
+      }
+      event.set_step_event(pattern_matching_failure_event);
+      return true;
+    }
+
     default: return false;
     }
   }
@@ -628,6 +677,9 @@ private:
     case side_condition_event_sentinel: return parse_side_condition(buffer);
 
     case side_condition_end_sentinel: return parse_side_condition_end(buffer);
+
+    case pattern_matching_failure_sentinel:
+      return parse_pattern_matching_failure(buffer);
 
     default: return nullptr;
     }

--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -129,6 +129,9 @@ public:
       kore_axiom_declaration const &axiom, llvm::Value *check_result,
       llvm::BasicBlock *current_block);
 
+  [[nodiscard]] llvm::BasicBlock *pattern_matching_failure(
+      kore_composite_pattern const &pattern, llvm::BasicBlock *current_block);
+
   proof_event(kore_definition *definition, llvm::Module *module)
       : definition_(definition)
       , module_(module)

--- a/lib/binary/ProofTraceParser.cpp
+++ b/lib/binary/ProofTraceParser.cpp
@@ -77,6 +77,13 @@ void llvm_side_condition_end_event::print(
       (result_ ? "true" : "false"));
 }
 
+void llvm_pattern_matching_failure_event::print(
+    std::ostream &out, bool expand_terms, unsigned ind) const {
+  std::string indent(ind * indent_size, ' ');
+  out << fmt::format(
+      "{}pattern matching failure: {}\n", indent, function_name_);
+}
+
 void llvm_function_event::print(
     std::ostream &out, bool expand_terms, unsigned ind) const {
   std::string indent(ind * indent_size, ' ');

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -920,6 +920,8 @@ void add_owise(
     auto var = kore_variable_pattern::create(name, symbol->get_arguments()[i]);
     pat->add_argument(std::move(var));
   }
+  proof_event p(d, module);
+  stuck = p.pattern_matching_failure(*pat, stuck);
   create_term creator = create_term(final_subst, d, stuck, module, true);
   llvm::Value *retval = creator(pat.get()).first;
 

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -381,4 +381,24 @@ llvm::BasicBlock *proof_event::side_condition_event_post(
   return merge_block;
 }
 
+llvm::BasicBlock *proof_event::pattern_matching_failure(
+    kore_composite_pattern const &pattern, llvm::BasicBlock *current_block) {
+
+  if (!proof_hint_instrumentation) {
+    return current_block;
+  }
+
+  auto [true_block, merge_block, proof_writer]
+      = event_prelude("pattern_matching_failure", current_block);
+
+  std::string function_name = ast_to_string(*pattern.get_constructor());
+
+  emit_write_uint64(proof_writer, detail::word(0x44), true_block);
+  emit_write_string(proof_writer, function_name, true_block);
+
+  llvm::BranchInst::Create(merge_block, true_block);
+
+  return merge_block;
+}
+
 } // namespace kllvm


### PR DESCRIPTION
This PR introduces a new function event called `llvm_pattern_matching_failure_event`, which is identified by the `pattern_matching_failure_sentinel`. This new event flags to the user that an attempt to apply a rule failed in pattern matching its constructor; therefore, no further simplification can be done at this point. 