### PR TITLE
Fixes for MInt serialization into the proof trace

### DIFF
--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -84,6 +84,13 @@ private:
   llvm::LoadInst *emit_get_proof_chunk_size(llvm::BasicBlock *insert_at_end);
 
   /*
+   * Check if a value of the given `sort` corresponds to an llvm scalar and
+   * return the size in bits of that scalar. Returns 0 if the given `sort` does
+   * not correspond to an llvm scalar.
+   */
+  uint64_t get_llvm_scalar_bits(kore_composite_sort &sort);
+
+  /*
    * Get the block header value for the given `sort_name`.
    */
   uint64_t get_block_header(std::string const &sort_name);

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -346,7 +346,7 @@ void serialize_raw_term_to_file(
 void serialize_configuration_to_proof_trace(
     FILE *file, block *subject, uint32_t sort);
 void serialize_term_to_proof_trace(
-    FILE *file, void *subject, uint64_t block_header, bool indirect);
+    FILE *file, void *subject, uint64_t block_header, uint64_t bits);
 
 // The following functions are called by the generated code and runtime code to
 // ouput the proof trace data.
@@ -355,16 +355,16 @@ void write_hook_event_pre_to_proof_trace(
     char const *location_stack);
 void write_hook_event_post_to_proof_trace(
     void *proof_writer, void *hook_result, uint64_t block_header,
-    bool indirect);
+    uint64_t bits);
 void write_argument_to_proof_trace(
-    void *proof_writer, void *arg, uint64_t block_header, bool indirect);
+    void *proof_writer, void *arg, uint64_t block_header, uint64_t bits);
 void write_rewrite_event_pre_to_proof_trace(
     void *proof_writer, uint64_t ordinal, uint64_t arity);
 void write_variable_to_proof_trace(
     void *proof_writer, char const *name, void *var, uint64_t block_header,
-    bool indirect);
+    uint64_t bits);
 void write_rewrite_event_post_to_proof_trace(
-    void *proof_writer, void *config, uint64_t block_header, bool indirect);
+    void *proof_writer, void *config, uint64_t block_header, uint64_t bits);
 void write_function_event_pre_to_proof_trace(
     void *proof_writer, char const *name, char const *location_stack);
 void write_function_event_post_to_proof_trace(void *proof_writer);

--- a/lib/ast/definition.cpp
+++ b/lib/ast/definition.cpp
@@ -1,6 +1,7 @@
 #include <kllvm/ast/AST.h>
 
 #include <iostream>
+#include <stack>
 #include <string>
 #include <unordered_set>
 
@@ -285,12 +286,38 @@ void kore_definition::preprocess() {
     for (auto *symbol : entry.second) {
       if (symbol->is_concrete()) {
         for (auto const &sort : symbol->get_arguments()) {
+          // We use a work list to ensure that parametric sorts get ordinals
+          // that are greater than the ordinals of any of their parameters.
+          // This invariant is usefull for serialization purposes, and given
+          // that all parametric sorts are statically known, it is sound to
+          // assign ordinals to them in such a topological order.
+          std::stack<std::pair<kore_composite_sort *, bool>> worklist;
           auto *ctr = dynamic_cast<kore_composite_sort *>(sort.get());
-          if (!sorts.contains(*ctr)) {
-            sorts.emplace(*ctr, next_sort++);
-            all_sorts_.push_back(ctr);
+          worklist.push(std::make_pair(ctr, false));
+
+          while (!worklist.empty()) {
+            auto *sort_to_process = worklist.top().first;
+            bool params_processed = worklist.top().second;
+            worklist.pop();
+
+            if (!sorts.contains(*sort_to_process)) {
+              if (!params_processed) {
+                // Defer processing this sort until its parameter sorts have
+                // been processed.
+                worklist.push(std::make_pair(sort_to_process, true));
+                for (auto const &param_sort : sort_to_process->get_arguments()) {
+                  auto *param_ctr = dynamic_cast<kore_composite_sort *>(param_sort.get());
+                  worklist.push(std::make_pair(param_ctr, false));
+                }
+                continue;
+              }
+
+              sorts.emplace(*sort_to_process, next_sort++);
+              all_sorts_.push_back(sort_to_process);
+            }
+
+            sort_to_process->set_ordinal(sorts[*sort_to_process]);
           }
-          ctr->set_ordinal(sorts[*ctr]);
         }
         if (!instantiations.contains(*symbol)) {
           instantiations.emplace(*symbol, next_symbol++);

--- a/lib/ast/definition.cpp
+++ b/lib/ast/definition.cpp
@@ -305,8 +305,10 @@ void kore_definition::preprocess() {
                 // Defer processing this sort until its parameter sorts have
                 // been processed.
                 worklist.push(std::make_pair(sort_to_process, true));
-                for (auto const &param_sort : sort_to_process->get_arguments()) {
-                  auto *param_ctr = dynamic_cast<kore_composite_sort *>(param_sort.get());
+                for (auto const &param_sort :
+                     sort_to_process->get_arguments()) {
+                  auto *param_ctr
+                      = dynamic_cast<kore_composite_sort *>(param_sort.get());
                   worklist.push(std::make_pair(param_ctr, false));
                 }
                 continue;

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -183,8 +183,8 @@ void emit_kore_rich_header(std::ostream &os, kore_definition *definition) {
     uint8_t num_sort_params = sort->get_arguments().size();
     os.write(reinterpret_cast<char const *>(&num_sort_params), 1);
     for (uint8_t j = 0; j < num_sort_params; j++) {
-      auto *param_sort =
-        dynamic_cast<kore_composite_sort *>(sort->get_arguments()[j].get());
+      auto *param_sort
+          = dynamic_cast<kore_composite_sort *>(sort->get_arguments()[j].get());
       uint32_t param_ordinal = param_sort->get_ordinal();
       if (param_ordinal >= i) {
         throw std::runtime_error("found sort ordinal not in topological order");

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -25,7 +25,8 @@ llvm::Constant *create_global_sort_string_ptr(
 }
 
 template <typename IRBuilder>
-llvm::Value *get_llvm_value_for_kore_term(llvm::Value *val, uint64_t bits,  IRBuilder &b,  llvm::Module *mod) {
+llvm::Value *get_llvm_value_for_kore_term(
+    llvm::Value *val, uint64_t bits, IRBuilder &b, llvm::Module *mod) {
   if (bits <= 64) {
     return val;
   }
@@ -43,12 +44,9 @@ llvm::Value *get_llvm_value_for_kore_term(llvm::Value *val, uint64_t bits,  IRBu
 uint64_t proof_event::get_llvm_scalar_bits(kore_composite_sort &sort) {
   value_type sort_category = sort.get_category(definition_);
   switch (sort_category.cat) {
-  case sort_category::Bool:
-    return 1;
-  case sort_category::MInt:
-    return sort_category.bits;
-  default:
-    return 0;
+  case sort_category::Bool: return 1;
+  case sort_category::MInt: return sort_category.bits;
+  default: return 0;
   }
 }
 

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -649,15 +649,15 @@ void write_hook_event_pre_to_proof_trace(
 
 void write_hook_event_post_to_proof_trace(
     void *proof_writer, void *hook_result, uint64_t block_header,
-    bool indirect) {
+    uint64_t bits) {
   static_cast<proof_trace_writer *>(proof_writer)
-      ->hook_event_post(hook_result, block_header, indirect);
+      ->hook_event_post(hook_result, block_header, bits);
 }
 
 void write_argument_to_proof_trace(
-    void *proof_writer, void *arg, uint64_t block_header, bool indirect) {
+    void *proof_writer, void *arg, uint64_t block_header, uint64_t bits) {
   static_cast<proof_trace_writer *>(proof_writer)
-      ->argument(arg, block_header, indirect);
+      ->argument(arg, block_header, bits);
 }
 
 void write_rewrite_event_pre_to_proof_trace(
@@ -668,15 +668,15 @@ void write_rewrite_event_pre_to_proof_trace(
 
 void write_variable_to_proof_trace(
     void *proof_writer, char const *name, void *var, uint64_t block_header,
-    bool indirect) {
+    uint64_t bits) {
   static_cast<proof_trace_writer *>(proof_writer)
-      ->variable(name, var, block_header, indirect);
+      ->variable(name, var, block_header, bits);
 }
 
 void write_rewrite_event_post_to_proof_trace(
-    void *proof_writer, void *config, uint64_t block_header, bool indirect) {
+    void *proof_writer, void *config, uint64_t block_header, uint64_t bits) {
   static_cast<proof_trace_writer *>(proof_writer)
-      ->rewrite_event_post(config, block_header, indirect);
+      ->rewrite_event_post(config, block_header, bits);
 }
 
 void write_function_event_pre_to_proof_trace(
@@ -734,8 +734,13 @@ void serialize_term_to_file(
 }
 
 void serialize_term_to_proof_trace(
-    FILE *file, void *subject, uint64_t block_header, bool indirect) {
-  void *arg = indirect ? (void *)&subject : subject;
+    FILE *file, void *subject, uint64_t block_header, uint64_t bits) {
+  void *arg = nullptr;
+  if (bits == 0 || bits > 64) {
+    arg = subject;
+  } else {
+    arg = (void *)&subject;
+  }
   struct blockheader header_val {
     block_header
   };


### PR DESCRIPTION
This PR fixes two issues related with the serialization of MInts in the proof trace:
- We add support for parametric sorts in the KORE rich header generation algorithm, because MInt sorts are indeed parametric. To do that we need to have an invariant of topological sorting of the ordinals of sorts, i.e. every sort needs to have an ordinal greater than the ordinals of all its parameters. We can guarantee that by generating the sort ordinals in this way, since all parametric sorts are known statically at compile time.
- We fix a bug on how we pass arguments to the `emit_*_to_proof_trace` functions that emit various events to the proof trace. Previously, when these functions needed to emit a KORE term as part of an event, they would accept a pointer to said KORE term as argument, an in case the term was a boolean or machine integer, that pointer would be cast to the actual value. However for machine integers longer than 64 bits, the pointer data type (which is 64 bit long) is not enough to store the machine integer value. We fix this by passing an actual pointer to the machine integer value in the case where the machine integer is longer than 64 bits.