### PR TITLE
Fixes for MInt serialization into the proof trace

### DIFF
--- a/include/kllvm/codegen/ProofEvent.h
+++ b/include/kllvm/codegen/ProofEvent.h
@@ -84,6 +84,13 @@ private:
   llvm::LoadInst *emit_get_proof_chunk_size(llvm::BasicBlock *insert_at_end);
 
   /*
+   * Check if a value of the given `sort` corresponds to an llvm scalar and
+   * return the size in bits of that scalar. Returns 0 if the given `sort` does
+   * not correspond to an llvm scalar.
+   */
+  uint64_t get_llvm_scalar_bits(kore_composite_sort &sort);
+
+  /*
    * Get the block header value for the given `sort_name`.
    */
   uint64_t get_block_header(std::string const &sort_name);

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -346,7 +346,7 @@ void serialize_raw_term_to_file(
 void serialize_configuration_to_proof_trace(
     FILE *file, block *subject, uint32_t sort);
 void serialize_term_to_proof_trace(
-    FILE *file, void *subject, uint64_t block_header, bool indirect);
+    FILE *file, void *subject, uint64_t block_header, uint64_t bits);
 
 // The following functions are called by the generated code and runtime code to
 // ouput the proof trace data.
@@ -355,16 +355,16 @@ void write_hook_event_pre_to_proof_trace(
     char const *location_stack);
 void write_hook_event_post_to_proof_trace(
     void *proof_writer, void *hook_result, uint64_t block_header,
-    bool indirect);
+    uint64_t bits);
 void write_argument_to_proof_trace(
-    void *proof_writer, void *arg, uint64_t block_header, bool indirect);
+    void *proof_writer, void *arg, uint64_t block_header, uint64_t bits);
 void write_rewrite_event_pre_to_proof_trace(
     void *proof_writer, uint64_t ordinal, uint64_t arity);
 void write_variable_to_proof_trace(
     void *proof_writer, char const *name, void *var, uint64_t block_header,
-    bool indirect);
+    uint64_t bits);
 void write_rewrite_event_post_to_proof_trace(
-    void *proof_writer, void *config, uint64_t block_header, bool indirect);
+    void *proof_writer, void *config, uint64_t block_header, uint64_t bits);
 void write_function_event_pre_to_proof_trace(
     void *proof_writer, char const *name, char const *location_stack);
 void write_function_event_post_to_proof_trace(void *proof_writer);

--- a/lib/ast/definition.cpp
+++ b/lib/ast/definition.cpp
@@ -1,6 +1,7 @@
 #include <kllvm/ast/AST.h>
 
 #include <iostream>
+#include <stack>
 #include <string>
 #include <unordered_set>
 
@@ -285,12 +286,38 @@ void kore_definition::preprocess() {
     for (auto *symbol : entry.second) {
       if (symbol->is_concrete()) {
         for (auto const &sort : symbol->get_arguments()) {
+          // We use a work list to ensure that parametric sorts get ordinals
+          // that are greater than the ordinals of any of their parameters.
+          // This invariant is usefull for serialization purposes, and given
+          // that all parametric sorts are statically known, it is sound to
+          // assign ordinals to them in such a topological order.
+          std::stack<std::pair<kore_composite_sort *, bool>> worklist;
           auto *ctr = dynamic_cast<kore_composite_sort *>(sort.get());
-          if (!sorts.contains(*ctr)) {
-            sorts.emplace(*ctr, next_sort++);
-            all_sorts_.push_back(ctr);
+          worklist.push(std::make_pair(ctr, false));
+
+          while (!worklist.empty()) {
+            auto *sort_to_process = worklist.top().first;
+            bool params_processed = worklist.top().second;
+            worklist.pop();
+
+            if (!sorts.contains(*sort_to_process)) {
+              if (!params_processed) {
+                // Defer processing this sort until its parameter sorts have
+                // been processed.
+                worklist.push(std::make_pair(sort_to_process, true));
+                for (auto const &param_sort : sort_to_process->get_arguments()) {
+                  auto *param_ctr = dynamic_cast<kore_composite_sort *>(param_sort.get());
+                  worklist.push(std::make_pair(param_ctr, false));
+                }
+                continue;
+              }
+
+              sorts.emplace(*sort_to_process, next_sort++);
+              all_sorts_.push_back(sort_to_process);
+            }
+
+            sort_to_process->set_ordinal(sorts[*sort_to_process]);
           }
-          ctr->set_ordinal(sorts[*ctr]);
         }
         if (!instantiations.contains(*symbol)) {
           instantiations.emplace(*symbol, next_symbol++);

--- a/lib/ast/definition.cpp
+++ b/lib/ast/definition.cpp
@@ -305,8 +305,10 @@ void kore_definition::preprocess() {
                 // Defer processing this sort until its parameter sorts have
                 // been processed.
                 worklist.push(std::make_pair(sort_to_process, true));
-                for (auto const &param_sort : sort_to_process->get_arguments()) {
-                  auto *param_ctr = dynamic_cast<kore_composite_sort *>(param_sort.get());
+                for (auto const &param_sort :
+                     sort_to_process->get_arguments()) {
+                  auto *param_ctr
+                      = dynamic_cast<kore_composite_sort *>(param_sort.get());
                   worklist.push(std::make_pair(param_ctr, false));
                 }
                 continue;

--- a/lib/binary/serializer.cpp
+++ b/lib/binary/serializer.cpp
@@ -183,8 +183,8 @@ void emit_kore_rich_header(std::ostream &os, kore_definition *definition) {
     uint8_t num_sort_params = sort->get_arguments().size();
     os.write(reinterpret_cast<char const *>(&num_sort_params), 1);
     for (uint8_t j = 0; j < num_sort_params; j++) {
-      auto *param_sort =
-        dynamic_cast<kore_composite_sort *>(sort->get_arguments()[j].get());
+      auto *param_sort
+          = dynamic_cast<kore_composite_sort *>(sort->get_arguments()[j].get());
       uint32_t param_ordinal = param_sort->get_ordinal();
       if (param_ordinal >= i) {
         throw std::runtime_error("found sort ordinal not in topological order");

--- a/lib/codegen/ProofEvent.cpp
+++ b/lib/codegen/ProofEvent.cpp
@@ -25,7 +25,8 @@ llvm::Constant *create_global_sort_string_ptr(
 }
 
 template <typename IRBuilder>
-llvm::Value *get_llvm_value_for_kore_term(llvm::Value *val, uint64_t bits,  IRBuilder &b,  llvm::Module *mod) {
+llvm::Value *get_llvm_value_for_kore_term(
+    llvm::Value *val, uint64_t bits, IRBuilder &b, llvm::Module *mod) {
   if (bits <= 64) {
     return val;
   }
@@ -43,12 +44,9 @@ llvm::Value *get_llvm_value_for_kore_term(llvm::Value *val, uint64_t bits,  IRBu
 uint64_t proof_event::get_llvm_scalar_bits(kore_composite_sort &sort) {
   value_type sort_category = sort.get_category(definition_);
   switch (sort_category.cat) {
-  case sort_category::Bool:
-    return 1;
-  case sort_category::MInt:
-    return sort_category.bits;
-  default:
-    return 0;
+  case sort_category::Bool: return 1;
+  case sort_category::MInt: return sort_category.bits;
+  default: return 0;
   }
 }
 

--- a/runtime/util/ConfigurationSerializer.cpp
+++ b/runtime/util/ConfigurationSerializer.cpp
@@ -649,15 +649,15 @@ void write_hook_event_pre_to_proof_trace(
 
 void write_hook_event_post_to_proof_trace(
     void *proof_writer, void *hook_result, uint64_t block_header,
-    bool indirect) {
+    uint64_t bits) {
   static_cast<proof_trace_writer *>(proof_writer)
-      ->hook_event_post(hook_result, block_header, indirect);
+      ->hook_event_post(hook_result, block_header, bits);
 }
 
 void write_argument_to_proof_trace(
-    void *proof_writer, void *arg, uint64_t block_header, bool indirect) {
+    void *proof_writer, void *arg, uint64_t block_header, uint64_t bits) {
   static_cast<proof_trace_writer *>(proof_writer)
-      ->argument(arg, block_header, indirect);
+      ->argument(arg, block_header, bits);
 }
 
 void write_rewrite_event_pre_to_proof_trace(
@@ -668,15 +668,15 @@ void write_rewrite_event_pre_to_proof_trace(
 
 void write_variable_to_proof_trace(
     void *proof_writer, char const *name, void *var, uint64_t block_header,
-    bool indirect) {
+    uint64_t bits) {
   static_cast<proof_trace_writer *>(proof_writer)
-      ->variable(name, var, block_header, indirect);
+      ->variable(name, var, block_header, bits);
 }
 
 void write_rewrite_event_post_to_proof_trace(
-    void *proof_writer, void *config, uint64_t block_header, bool indirect) {
+    void *proof_writer, void *config, uint64_t block_header, uint64_t bits) {
   static_cast<proof_trace_writer *>(proof_writer)
-      ->rewrite_event_post(config, block_header, indirect);
+      ->rewrite_event_post(config, block_header, bits);
 }
 
 void write_function_event_pre_to_proof_trace(
@@ -734,8 +734,13 @@ void serialize_term_to_file(
 }
 
 void serialize_term_to_proof_trace(
-    FILE *file, void *subject, uint64_t block_header, bool indirect) {
-  void *arg = indirect ? (void *)&subject : subject;
+    FILE *file, void *subject, uint64_t block_header, uint64_t bits) {
+  void *arg = nullptr;
+  if (bits == 0 || bits > 64) {
+    arg = subject;
+  } else {
+    arg = (void *)&subject;
+  }
   struct blockheader header_val {
     block_header
   };

--- a/test/input/mint-arith/add160.in
+++ b/test/input/mint-arith/add160.in
@@ -1,0 +1,1 @@
+LblinitGeneratedTopCell{}(Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("3")),inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("4")),\dv{SortInt{}}("160")))))

--- a/test/input/mint-arith/add256.in
+++ b/test/input/mint-arith/add256.in
@@ -1,0 +1,1 @@
+LblinitGeneratedTopCell{}(Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("3")),inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("4")),\dv{SortInt{}}("256")))))

--- a/test/input/mint-arith/add32.in
+++ b/test/input/mint-arith/add32.in
@@ -1,0 +1,1 @@
+LblinitGeneratedTopCell{}(Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("3")),inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("4")),\dv{SortInt{}}("32")))))

--- a/test/input/mint-arith/add64.in
+++ b/test/input/mint-arith/add64.in
@@ -1,0 +1,1 @@
+LblinitGeneratedTopCell{}(Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("3")),inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("4")),\dv{SortInt{}}("64")))))

--- a/test/input/mint-arith/add8.in
+++ b/test/input/mint-arith/add8.in
@@ -1,0 +1,1 @@
+LblinitGeneratedTopCell{}(Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("3")),inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("4")),\dv{SortInt{}}("8")))))

--- a/test/output/mint-arith/add160.proof.out.diff
+++ b/test/output/mint-arith/add160.proof.out.diff
@@ -1,0 +1,180 @@
+version: 13
+hook: MAP.concat Lbl'Unds'Map'Unds'{} ()
+  arg: kore[Lbl'Stop'Map{}()]
+  arg: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("160")))]
+hook result: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("160")))]
+function: LblinitGeneratedTopCell{} ()
+rule: 2960 1
+  VarInit = kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("160")))]
+function: LblinitKCell{} (0)
+rule: 2961 1
+  VarInit = kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("160")))]
+hook: MAP.lookup LblMap'Coln'lookup{} (0:0:0:0)
+  arg: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("160")))]
+  arg: kore[\dv{SortKConfigVar{}}("$PGM")]
+hook result: kore[Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("160"))]
+function: Lblproject'Coln'KItem{} (0:0)
+rule: 3069 1
+  VarK = kore[Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("160"))]
+function: LblinitGeneratedCounterCell{} (1)
+rule: 2959 0
+config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("160")),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
+side condition entry: 2883 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("160")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("160")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3017 1
+  VarK = kore[kseq{}(\dv{SortInt{}}("4"),dotk{}())]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("true")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2883 true
+rule: 2883 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("3")]
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("160")]
+rule: 2900 3
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(kseq{}(\dv{SortInt{}}("160"),dotk{}()),kseq{}(\dv{SortInt{}}("3"),dotk{}())),dotk{}())]
+  VarI = kore[\dv{SortInt{}}("4")]
+hook: MINT.integer LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort160{}} (0:0:0:0)
+  arg: kore[\dv{SortInt{}}("4")]
+hook result: kore[\dv{SortMInt{Sort160{}}}("4p160")]
+side condition entry: 2899 1
+  VarHOLE = kore[\dv{SortMInt{Sort160{}}}("4p160")]
+function: LblisKResult{} (1)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort160{}}}("4p160")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2899 true
+rule: 2899 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("3")]
+  VarHOLE = kore[\dv{SortMInt{Sort160{}}}("4p160")]
+  VarW = kore[\dv{SortInt{}}("160")]
+side condition entry: 2883 2
+  VarHOLE = kore[\dv{SortMInt{Sort160{}}}("4p160")]
+  VarW = kore[\dv{SortInt{}}("160")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("160")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort160{}}}("4p160")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2883 false
+side condition entry: 2888 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("160")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("160")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3017 1
+  VarK = kore[kseq{}(\dv{SortInt{}}("3"),dotk{}())]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("true")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2888 true
+rule: 2888 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortMInt{Sort160{}}}("4p160")]
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("160")]
+rule: 2900 3
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(kseq{}(\dv{SortInt{}}("160"),dotk{}()),kseq{}(\dv{SortMInt{Sort160{}}}("4p160"),dotk{}())),dotk{}())]
+  VarI = kore[\dv{SortInt{}}("3")]
+hook: MINT.integer LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort160{}} (0:0:0:0)
+  arg: kore[\dv{SortInt{}}("3")]
+hook result: kore[\dv{SortMInt{Sort160{}}}("3p160")]
+side condition entry: 2898 1
+  VarHOLE = kore[\dv{SortMInt{Sort160{}}}("3p160")]
+function: LblisKResult{} (1)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort160{}}}("3p160")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2898 true
+rule: 2898 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortMInt{Sort160{}}}("4p160")]
+  VarHOLE = kore[\dv{SortMInt{Sort160{}}}("3p160")]
+  VarW = kore[\dv{SortInt{}}("160")]
+side condition entry: 2883 2
+  VarHOLE = kore[\dv{SortMInt{Sort160{}}}("4p160")]
+  VarW = kore[\dv{SortInt{}}("160")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("160")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort160{}}}("4p160")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2883 false
+side condition entry: 2888 2
+  VarHOLE = kore[\dv{SortMInt{Sort160{}}}("3p160")]
+  VarW = kore[\dv{SortInt{}}("160")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("160")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort160{}}}("3p160")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2888 false
+rule: 2893 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("160")]
+  VarA = kore[\dv{SortMInt{Sort160{}}}("3p160")]
+  VarB = kore[\dv{SortMInt{Sort160{}}}("4p160")]
+hook: MINT.add Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{Sort160{}} (0:0:0)
+  arg: kore[\dv{SortMInt{Sort160{}}}("3p160")]
+  arg: kore[\dv{SortMInt{Sort160{}}}("4p160")]
+hook result: kore[\dv{SortMInt{Sort160{}}}("7p160")]
+config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\dv{SortMInt{Sort160{}}}("7p160"),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]

--- a/test/output/mint-arith/add256.proof.out.diff
+++ b/test/output/mint-arith/add256.proof.out.diff
@@ -1,0 +1,202 @@
+version: 13
+hook: MAP.concat Lbl'Unds'Map'Unds'{} ()
+  arg: kore[Lbl'Stop'Map{}()]
+  arg: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("256")))]
+hook result: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("256")))]
+function: LblinitGeneratedTopCell{} ()
+rule: 2960 1
+  VarInit = kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("256")))]
+function: LblinitKCell{} (0)
+rule: 2961 1
+  VarInit = kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("256")))]
+hook: MAP.lookup LblMap'Coln'lookup{} (0:0:0:0)
+  arg: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("256")))]
+  arg: kore[\dv{SortKConfigVar{}}("$PGM")]
+hook result: kore[Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("256"))]
+function: Lblproject'Coln'KItem{} (0:0)
+rule: 3069 1
+  VarK = kore[Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("256"))]
+function: LblinitGeneratedCounterCell{} (1)
+rule: 2959 0
+config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("256")),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
+side condition entry: 2883 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("256")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("256")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2883 false
+side condition entry: 2884 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("256")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("256")]
+  arg: kore[\dv{SortInt{}}("256")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3017 1
+  VarK = kore[kseq{}(\dv{SortInt{}}("4"),dotk{}())]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("true")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2884 true
+rule: 2884 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("3")]
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("256")]
+rule: 2903 3
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(kseq{}(\dv{SortInt{}}("256"),dotk{}()),kseq{}(\dv{SortInt{}}("3"),dotk{}())),dotk{}())]
+  VarI = kore[\dv{SortInt{}}("4")]
+hook: MINT.integer LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort256{}} (0:0:0:0)
+  arg: kore[\dv{SortInt{}}("4")]
+hook result: kore[\dv{SortMInt{Sort256{}}}("4p256")]
+side condition entry: 2902 1
+  VarHOLE = kore[\dv{SortMInt{Sort256{}}}("4p256")]
+function: LblisKResult{} (1)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort256{}}}("4p256")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2902 true
+rule: 2902 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("3")]
+  VarHOLE = kore[\dv{SortMInt{Sort256{}}}("4p256")]
+  VarW = kore[\dv{SortInt{}}("256")]
+side condition entry: 2884 2
+  VarHOLE = kore[\dv{SortMInt{Sort256{}}}("4p256")]
+  VarW = kore[\dv{SortInt{}}("256")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("256")]
+  arg: kore[\dv{SortInt{}}("256")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort256{}}}("4p256")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2884 false
+side condition entry: 2888 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("256")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("256")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2888 false
+side condition entry: 2889 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("256")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("256")]
+  arg: kore[\dv{SortInt{}}("256")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3017 1
+  VarK = kore[kseq{}(\dv{SortInt{}}("3"),dotk{}())]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("true")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2889 true
+rule: 2889 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortMInt{Sort256{}}}("4p256")]
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("256")]
+rule: 2903 3
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(kseq{}(\dv{SortInt{}}("256"),dotk{}()),kseq{}(\dv{SortMInt{Sort256{}}}("4p256"),dotk{}())),dotk{}())]
+  VarI = kore[\dv{SortInt{}}("3")]
+hook: MINT.integer LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort256{}} (0:0:0:0)
+  arg: kore[\dv{SortInt{}}("3")]
+hook result: kore[\dv{SortMInt{Sort256{}}}("3p256")]
+side condition entry: 2901 1
+  VarHOLE = kore[\dv{SortMInt{Sort256{}}}("3p256")]
+function: LblisKResult{} (1)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort256{}}}("3p256")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2901 true
+rule: 2901 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortMInt{Sort256{}}}("4p256")]
+  VarHOLE = kore[\dv{SortMInt{Sort256{}}}("3p256")]
+  VarW = kore[\dv{SortInt{}}("256")]
+side condition entry: 2884 2
+  VarHOLE = kore[\dv{SortMInt{Sort256{}}}("4p256")]
+  VarW = kore[\dv{SortInt{}}("256")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("256")]
+  arg: kore[\dv{SortInt{}}("256")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort256{}}}("4p256")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2884 false
+side condition entry: 2889 2
+  VarHOLE = kore[\dv{SortMInt{Sort256{}}}("3p256")]
+  VarW = kore[\dv{SortInt{}}("256")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("256")]
+  arg: kore[\dv{SortInt{}}("256")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort256{}}}("3p256")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2889 false
+rule: 2894 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("256")]
+  VarA = kore[\dv{SortMInt{Sort256{}}}("3p256")]
+  VarB = kore[\dv{SortMInt{Sort256{}}}("4p256")]
+hook: MINT.add Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{Sort256{}} (0:0:0)
+  arg: kore[\dv{SortMInt{Sort256{}}}("3p256")]
+  arg: kore[\dv{SortMInt{Sort256{}}}("4p256")]
+hook result: kore[\dv{SortMInt{Sort256{}}}("7p256")]
+config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\dv{SortMInt{Sort256{}}}("7p256"),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]

--- a/test/output/mint-arith/add32.proof.out.diff
+++ b/test/output/mint-arith/add32.proof.out.diff
@@ -1,0 +1,224 @@
+version: 13
+hook: MAP.concat Lbl'Unds'Map'Unds'{} ()
+  arg: kore[Lbl'Stop'Map{}()]
+  arg: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("32")))]
+hook result: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("32")))]
+function: LblinitGeneratedTopCell{} ()
+rule: 2960 1
+  VarInit = kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("32")))]
+function: LblinitKCell{} (0)
+rule: 2961 1
+  VarInit = kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("32")))]
+hook: MAP.lookup LblMap'Coln'lookup{} (0:0:0:0)
+  arg: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("32")))]
+  arg: kore[\dv{SortKConfigVar{}}("$PGM")]
+hook result: kore[Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("32"))]
+function: Lblproject'Coln'KItem{} (0:0)
+rule: 3069 1
+  VarK = kore[Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("32"))]
+function: LblinitGeneratedCounterCell{} (1)
+rule: 2959 0
+config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("32")),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
+side condition entry: 2883 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("32")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("32")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2883 false
+side condition entry: 2884 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("32")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("32")]
+  arg: kore[\dv{SortInt{}}("256")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2884 false
+side condition entry: 2885 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("32")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("32")]
+  arg: kore[\dv{SortInt{}}("32")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3017 1
+  VarK = kore[kseq{}(\dv{SortInt{}}("4"),dotk{}())]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("true")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2885 true
+rule: 2885 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("3")]
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("32")]
+rule: 2906 3
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(kseq{}(\dv{SortInt{}}("32"),dotk{}()),kseq{}(\dv{SortInt{}}("3"),dotk{}())),dotk{}())]
+  VarI = kore[\dv{SortInt{}}("4")]
+hook: MINT.integer LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort32{}} (0:0:0:0)
+  arg: kore[\dv{SortInt{}}("4")]
+hook result: kore[\dv{SortMInt{Sort32{}}}("4p32")]
+side condition entry: 2905 1
+  VarHOLE = kore[\dv{SortMInt{Sort32{}}}("4p32")]
+function: LblisKResult{} (1)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort32{}}}("4p32")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2905 true
+rule: 2905 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("3")]
+  VarHOLE = kore[\dv{SortMInt{Sort32{}}}("4p32")]
+  VarW = kore[\dv{SortInt{}}("32")]
+side condition entry: 2885 2
+  VarHOLE = kore[\dv{SortMInt{Sort32{}}}("4p32")]
+  VarW = kore[\dv{SortInt{}}("32")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("32")]
+  arg: kore[\dv{SortInt{}}("32")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort32{}}}("4p32")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2885 false
+side condition entry: 2888 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("32")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("32")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2888 false
+side condition entry: 2889 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("32")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("32")]
+  arg: kore[\dv{SortInt{}}("256")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2889 false
+side condition entry: 2890 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("32")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("32")]
+  arg: kore[\dv{SortInt{}}("32")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3017 1
+  VarK = kore[kseq{}(\dv{SortInt{}}("3"),dotk{}())]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("true")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2890 true
+rule: 2890 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortMInt{Sort32{}}}("4p32")]
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("32")]
+rule: 2906 3
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(kseq{}(\dv{SortInt{}}("32"),dotk{}()),kseq{}(\dv{SortMInt{Sort32{}}}("4p32"),dotk{}())),dotk{}())]
+  VarI = kore[\dv{SortInt{}}("3")]
+hook: MINT.integer LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort32{}} (0:0:0:0)
+  arg: kore[\dv{SortInt{}}("3")]
+hook result: kore[\dv{SortMInt{Sort32{}}}("3p32")]
+side condition entry: 2904 1
+  VarHOLE = kore[\dv{SortMInt{Sort32{}}}("3p32")]
+function: LblisKResult{} (1)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort32{}}}("3p32")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2904 true
+rule: 2904 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortMInt{Sort32{}}}("4p32")]
+  VarHOLE = kore[\dv{SortMInt{Sort32{}}}("3p32")]
+  VarW = kore[\dv{SortInt{}}("32")]
+side condition entry: 2885 2
+  VarHOLE = kore[\dv{SortMInt{Sort32{}}}("4p32")]
+  VarW = kore[\dv{SortInt{}}("32")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("32")]
+  arg: kore[\dv{SortInt{}}("32")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort32{}}}("4p32")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2885 false
+side condition entry: 2890 2
+  VarHOLE = kore[\dv{SortMInt{Sort32{}}}("3p32")]
+  VarW = kore[\dv{SortInt{}}("32")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("32")]
+  arg: kore[\dv{SortInt{}}("32")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort32{}}}("3p32")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2890 false
+rule: 2895 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("32")]
+  VarA = kore[\dv{SortMInt{Sort32{}}}("3p32")]
+  VarB = kore[\dv{SortMInt{Sort32{}}}("4p32")]
+hook: MINT.add Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{Sort32{}} (0:0:0)
+  arg: kore[\dv{SortMInt{Sort32{}}}("3p32")]
+  arg: kore[\dv{SortMInt{Sort32{}}}("4p32")]
+hook result: kore[\dv{SortMInt{Sort32{}}}("7p32")]
+config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\dv{SortMInt{Sort32{}}}("7p32"),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]

--- a/test/output/mint-arith/add64.proof.out.diff
+++ b/test/output/mint-arith/add64.proof.out.diff
@@ -1,0 +1,246 @@
+version: 13
+hook: MAP.concat Lbl'Unds'Map'Unds'{} ()
+  arg: kore[Lbl'Stop'Map{}()]
+  arg: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("64")))]
+hook result: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("64")))]
+function: LblinitGeneratedTopCell{} ()
+rule: 2960 1
+  VarInit = kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("64")))]
+function: LblinitKCell{} (0)
+rule: 2961 1
+  VarInit = kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("64")))]
+hook: MAP.lookup LblMap'Coln'lookup{} (0:0:0:0)
+  arg: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("64")))]
+  arg: kore[\dv{SortKConfigVar{}}("$PGM")]
+hook result: kore[Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("64"))]
+function: Lblproject'Coln'KItem{} (0:0)
+rule: 3069 1
+  VarK = kore[Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("64"))]
+function: LblinitGeneratedCounterCell{} (1)
+rule: 2959 0
+config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("64")),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
+side condition entry: 2883 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("64")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("64")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2883 false
+side condition entry: 2884 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("64")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("64")]
+  arg: kore[\dv{SortInt{}}("256")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2884 false
+side condition entry: 2885 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("64")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("64")]
+  arg: kore[\dv{SortInt{}}("32")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2885 false
+side condition entry: 2886 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("64")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("64")]
+  arg: kore[\dv{SortInt{}}("64")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3017 1
+  VarK = kore[kseq{}(\dv{SortInt{}}("4"),dotk{}())]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("true")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2886 true
+rule: 2886 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("3")]
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("64")]
+rule: 2909 3
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(kseq{}(\dv{SortInt{}}("64"),dotk{}()),kseq{}(\dv{SortInt{}}("3"),dotk{}())),dotk{}())]
+  VarI = kore[\dv{SortInt{}}("4")]
+hook: MINT.integer LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort64{}} (0:0:0:0)
+  arg: kore[\dv{SortInt{}}("4")]
+hook result: kore[\dv{SortMInt{Sort64{}}}("4p64")]
+side condition entry: 2908 1
+  VarHOLE = kore[\dv{SortMInt{Sort64{}}}("4p64")]
+function: LblisKResult{} (1)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort64{}}}("4p64")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2908 true
+rule: 2908 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("3")]
+  VarHOLE = kore[\dv{SortMInt{Sort64{}}}("4p64")]
+  VarW = kore[\dv{SortInt{}}("64")]
+side condition entry: 2886 2
+  VarHOLE = kore[\dv{SortMInt{Sort64{}}}("4p64")]
+  VarW = kore[\dv{SortInt{}}("64")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("64")]
+  arg: kore[\dv{SortInt{}}("64")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort64{}}}("4p64")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2886 false
+side condition entry: 2888 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("64")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("64")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2888 false
+side condition entry: 2889 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("64")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("64")]
+  arg: kore[\dv{SortInt{}}("256")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2889 false
+side condition entry: 2890 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("64")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("64")]
+  arg: kore[\dv{SortInt{}}("32")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2890 false
+side condition entry: 2891 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("64")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("64")]
+  arg: kore[\dv{SortInt{}}("64")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3017 1
+  VarK = kore[kseq{}(\dv{SortInt{}}("3"),dotk{}())]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("true")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2891 true
+rule: 2891 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortMInt{Sort64{}}}("4p64")]
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("64")]
+rule: 2909 3
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(kseq{}(\dv{SortInt{}}("64"),dotk{}()),kseq{}(\dv{SortMInt{Sort64{}}}("4p64"),dotk{}())),dotk{}())]
+  VarI = kore[\dv{SortInt{}}("3")]
+hook: MINT.integer LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort64{}} (0:0:0:0)
+  arg: kore[\dv{SortInt{}}("3")]
+hook result: kore[\dv{SortMInt{Sort64{}}}("3p64")]
+side condition entry: 2907 1
+  VarHOLE = kore[\dv{SortMInt{Sort64{}}}("3p64")]
+function: LblisKResult{} (1)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort64{}}}("3p64")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2907 true
+rule: 2907 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortMInt{Sort64{}}}("4p64")]
+  VarHOLE = kore[\dv{SortMInt{Sort64{}}}("3p64")]
+  VarW = kore[\dv{SortInt{}}("64")]
+side condition entry: 2886 2
+  VarHOLE = kore[\dv{SortMInt{Sort64{}}}("4p64")]
+  VarW = kore[\dv{SortInt{}}("64")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("64")]
+  arg: kore[\dv{SortInt{}}("64")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort64{}}}("4p64")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2886 false
+side condition entry: 2891 2
+  VarHOLE = kore[\dv{SortMInt{Sort64{}}}("3p64")]
+  VarW = kore[\dv{SortInt{}}("64")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("64")]
+  arg: kore[\dv{SortInt{}}("64")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort64{}}}("3p64")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2891 false
+rule: 2896 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("64")]
+  VarA = kore[\dv{SortMInt{Sort64{}}}("3p64")]
+  VarB = kore[\dv{SortMInt{Sort64{}}}("4p64")]
+hook: MINT.add Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{Sort64{}} (0:0:0)
+  arg: kore[\dv{SortMInt{Sort64{}}}("3p64")]
+  arg: kore[\dv{SortMInt{Sort64{}}}("4p64")]
+hook result: kore[\dv{SortMInt{Sort64{}}}("7p64")]
+config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\dv{SortMInt{Sort64{}}}("7p64"),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]

--- a/test/output/mint-arith/add8.proof.out.diff
+++ b/test/output/mint-arith/add8.proof.out.diff
@@ -1,0 +1,268 @@
+version: 13
+hook: MAP.concat Lbl'Unds'Map'Unds'{} ()
+  arg: kore[Lbl'Stop'Map{}()]
+  arg: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("8")))]
+hook result: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("8")))]
+function: LblinitGeneratedTopCell{} ()
+rule: 2960 1
+  VarInit = kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("8")))]
+function: LblinitKCell{} (0)
+rule: 2961 1
+  VarInit = kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("8")))]
+hook: MAP.lookup LblMap'Coln'lookup{} (0:0:0:0)
+  arg: kore[Lbl'UndsPipe'-'-GT-Unds'{}(\dv{SortKConfigVar{}}("$PGM"),Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("8")))]
+  arg: kore[\dv{SortKConfigVar{}}("$PGM")]
+hook result: kore[Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("8"))]
+function: Lblproject'Coln'KItem{} (0:0)
+rule: 3069 1
+  VarK = kore[Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("8"))]
+function: LblinitGeneratedCounterCell{} (1)
+rule: 2959 0
+config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\dv{SortInt{}}("3"),\dv{SortInt{}}("4"),\dv{SortInt{}}("8")),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]
+side condition entry: 2883 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2883 false
+side condition entry: 2884 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("256")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2884 false
+side condition entry: 2885 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("32")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2885 false
+side condition entry: 2886 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("64")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2886 false
+side condition entry: 2887 2
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("8")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3017 1
+  VarK = kore[kseq{}(\dv{SortInt{}}("4"),dotk{}())]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("true")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2887 true
+rule: 2887 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("3")]
+  VarHOLE = kore[\dv{SortInt{}}("4")]
+  VarW = kore[\dv{SortInt{}}("8")]
+rule: 2912 3
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(kseq{}(\dv{SortInt{}}("8"),dotk{}()),kseq{}(\dv{SortInt{}}("3"),dotk{}())),dotk{}())]
+  VarI = kore[\dv{SortInt{}}("4")]
+hook: MINT.integer LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort8{}} (0:0:0:0)
+  arg: kore[\dv{SortInt{}}("4")]
+hook result: kore[\dv{SortMInt{Sort8{}}}("4p8")]
+side condition entry: 2911 1
+  VarHOLE = kore[\dv{SortMInt{Sort8{}}}("4p8")]
+function: LblisKResult{} (1)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort8{}}}("4p8")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2911 true
+rule: 2911 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("3")]
+  VarHOLE = kore[\dv{SortMInt{Sort8{}}}("4p8")]
+  VarW = kore[\dv{SortInt{}}("8")]
+side condition entry: 2887 2
+  VarHOLE = kore[\dv{SortMInt{Sort8{}}}("4p8")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("8")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort8{}}}("4p8")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2887 false
+side condition entry: 2888 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("160")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2888 false
+side condition entry: 2889 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("256")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2889 false
+side condition entry: 2890 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("32")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2890 false
+side condition entry: 2891 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("64")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2891 false
+side condition entry: 2892 2
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("8")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3017 1
+  VarK = kore[kseq{}(\dv{SortInt{}}("3"),dotk{}())]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("true")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2892 true
+rule: 2892 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortMInt{Sort8{}}}("4p8")]
+  VarHOLE = kore[\dv{SortInt{}}("3")]
+  VarW = kore[\dv{SortInt{}}("8")]
+rule: 2912 3
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(kseq{}(\dv{SortInt{}}("8"),dotk{}()),kseq{}(\dv{SortMInt{Sort8{}}}("4p8"),dotk{}())),dotk{}())]
+  VarI = kore[\dv{SortInt{}}("3")]
+hook: MINT.integer LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort8{}} (0:0:0:0)
+  arg: kore[\dv{SortInt{}}("3")]
+hook result: kore[\dv{SortMInt{Sort8{}}}("3p8")]
+side condition entry: 2910 1
+  VarHOLE = kore[\dv{SortMInt{Sort8{}}}("3p8")]
+function: LblisKResult{} (1)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort8{}}}("3p8")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("true")]
+side condition exit: 2910 true
+rule: 2910 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortMInt{Sort8{}}}("4p8")]
+  VarHOLE = kore[\dv{SortMInt{Sort8{}}}("3p8")]
+  VarW = kore[\dv{SortInt{}}("8")]
+side condition entry: 2887 2
+  VarHOLE = kore[\dv{SortMInt{Sort8{}}}("4p8")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("8")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort8{}}}("4p8")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2887 false
+side condition entry: 2892 2
+  VarHOLE = kore[\dv{SortMInt{Sort8{}}}("3p8")]
+  VarW = kore[\dv{SortInt{}}("8")]
+hook: INT.eq Lbl'UndsEqlsEqls'Int'Unds'{} (0)
+  arg: kore[\dv{SortInt{}}("8")]
+  arg: kore[\dv{SortInt{}}("8")]
+hook result: kore[\dv{SortBool{}}("true")]
+function: LblisKResult{} (1:0)
+rule: 3018 1
+  VarKResult = kore[\dv{SortMInt{Sort8{}}}("3p8")]
+hook: BOOL.not LblnotBool'Unds'{} (1)
+  arg: kore[\dv{SortBool{}}("true")]
+hook result: kore[\dv{SortBool{}}("false")]
+hook: BOOL.and Lbl'Unds'andBool'Unds'{} ()
+  arg: kore[\dv{SortBool{}}("true")]
+  arg: kore[\dv{SortBool{}}("false")]
+hook result: kore[\dv{SortBool{}}("false")]
+side condition exit: 2892 false
+rule: 2897 5
+  Var'Unds'DotVar0 = kore[Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))]
+  Var'Unds'DotVar1 = kore[dotk{}()]
+  Var'Unds'Gen0 = kore[\dv{SortInt{}}("8")]
+  VarA = kore[\dv{SortMInt{Sort8{}}}("3p8")]
+  VarB = kore[\dv{SortMInt{Sort8{}}}("4p8")]
+hook: MINT.add Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{Sort8{}} (0:0:0)
+  arg: kore[\dv{SortMInt{Sort8{}}}("3p8")]
+  arg: kore[\dv{SortMInt{Sort8{}}}("4p8")]
+hook result: kore[\dv{SortMInt{Sort8{}}}("7p8")]
+config: kore[Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\dv{SortMInt{Sort8{}}}("7p8"),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")))]

--- a/test/proof/k-files/mint-arith.k
+++ b/test/proof/k-files/mint-arith.k
@@ -1,0 +1,61 @@
+module MINT-ARITH-SYNTAX
+
+  imports DOMAINS
+  imports MINT-SYNTAX
+
+  syntax MInt{8}
+  syntax MInt{32}
+  syntax MInt{64}
+  syntax MInt{160}
+  syntax MInt{256}
+
+  syntax KItem ::= add(Exp, Exp, Int)
+  syntax Exp ::= Int | MInt{8} | MInt{32} | MInt{64} | MInt{160} | MInt{256}
+
+endmodule
+
+module MINT-ARITH
+
+  imports MINT-ARITH-SYNTAX
+  imports MINT
+
+  syntax KResult ::= MInt{8} | MInt{32} | MInt{64} | MInt{160} | MInt{256}
+
+  context add(HOLE => toMInt8(HOLE),   _,                       W) requires W ==Int 8
+  context add(_,                       HOLE => toMInt8(HOLE),   W) requires W ==Int 8
+  context add(HOLE => toMInt32(HOLE),  _,                       W) requires W ==Int 32
+  context add(_,                       HOLE => toMInt32(HOLE),  W) requires W ==Int 32
+  context add(HOLE => toMInt64(HOLE),  _,                       W) requires W ==Int 64
+  context add(_,                       HOLE => toMInt64(HOLE),  W) requires W ==Int 64
+  context add(HOLE => toMInt160(HOLE), _,                       W) requires W ==Int 160
+  context add(_,                       HOLE => toMInt160(HOLE), W) requires W ==Int 160
+  context add(HOLE => toMInt256(HOLE), _,                       W) requires W ==Int 256
+  context add(_,                       HOLE => toMInt256(HOLE), W) requires W ==Int 256
+
+  rule add(A:MInt{8},   B:MInt{8},   _) => A +MInt B
+  rule add(A:MInt{32},  B:MInt{32},  _) => A +MInt B
+  rule add(A:MInt{64},  B:MInt{64},  _) => A +MInt B
+  rule add(A:MInt{160}, B:MInt{160}, _) => A +MInt B
+  rule add(A:MInt{256}, B:MInt{256}, _) => A +MInt B
+
+  syntax Exp8 ::= Int | MInt{8}
+  syntax Exp ::= toMInt8(Exp8) | Exp8
+  rule toMInt8(I:Int => Int2MInt(I))
+
+  syntax Exp32 ::= Int | MInt{32}
+  syntax Exp ::= toMInt32(Exp32) | Exp32
+  rule toMInt32(I:Int => Int2MInt(I))
+
+  syntax Exp64 ::= Int | MInt{64}
+  syntax Exp ::= toMInt64(Exp64) | Exp64
+  rule toMInt64(I:Int => Int2MInt(I))
+
+  syntax Exp160 ::= Int | MInt{160}
+  syntax Exp ::= toMInt160(Exp160) | Exp160
+  rule toMInt160(I:Int => Int2MInt(I))
+
+  syntax Exp256 ::= Int | MInt{256}
+  syntax Exp ::= toMInt256(Exp256) | Exp256
+  rule toMInt256(I:Int => Int2MInt(I))
+
+endmodule

--- a/test/proof/mint-arith.kore
+++ b/test/proof/mint-arith.kore
@@ -1,0 +1,7886 @@
+// RUN: %proof-interpreter
+// RUN: %check-dir-proof-out
+[topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+module BASIC-K
+    sort SortK{} []
+    sort SortKItem{} []
+endmodule
+[]
+module KSEQ
+    import BASIC-K []
+    symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol dotk{}() : SortK{} [constructor{}(), functional{}(), injective{}()]
+    symbol append{}(SortK{}, SortK{}) : SortK{} [function{}(), functional{}()]
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, dotk{}()),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                TAIL:SortK{},
+                \top{SortK{}}()
+            )
+        )
+    ) []
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, kseq{}(K:SortKItem{}, KS:SortK{})),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \equals{SortK{}, R}(
+            append{}(X0:SortK{}, X1:SortK{}),
+            \and{SortK{}}(
+                kseq{}(K:SortKItem{}, append{}(KS:SortK{}, TAIL:SortK{})),
+                \top{SortK{}}()
+            )
+        )
+    ) []
+endmodule
+[]
+module INJ
+    symbol inj{From, To}(From) : To [sortInjection{}()]
+    axiom {S1, S2, S3, R} \equals{S3, R}(inj{S2, S3}(inj{S1, S2}(T:S1)), inj{S1, S3}(T:S1)) [simplification{}()]
+endmodule
+[]
+module K
+    import KSEQ []
+    import INJ []
+    alias weakExistsFinally{A}(A) : A where weakExistsFinally{A}(@X:A) := @X:A []
+    alias weakAlwaysFinally{A}(A) : A where weakAlwaysFinally{A}(@X:A) := @X:A []
+    alias allPathGlobally{A}(A) : A where allPathGlobally{A}(@X:A) := @X:A []
+endmodule
+[]
+
+module MINT-ARITH
+
+// imports
+  import K []
+
+// sorts
+  sort SortKCellOpt{} []
+  sort SortIOInt{} []
+  sort Sort32{} [nat{}("32")]
+  sort SortExp32{} []
+  hooked-sort SortFloat{} [hasDomainValues{}(), hook{}("FLOAT.Float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1483,3,1483,35)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  sort SortKConfigVar{} [hasDomainValues{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(40,3,40,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/kast.md)"), token{}()]
+  sort SortExp64{} []
+  sort SortIOError{} []
+  hooked-sort SortMInt{SortS0} [hasDomainValues{}(), hook{}("MINT.MInt")]
+  sort SortGeneratedTopCellFragment{} []
+  sort SortIOFile{} []
+  hooked-sort SortList{} [concat{}(Lbl'Unds'List'Unds'{}()), element{}(LblListItem{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(913,3,913,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'List{}()), update{}(LblList'Coln'set{}())]
+  sort SortExp160{} []
+  sort SortKCell{} []
+  sort SortGeneratedTopCell{} []
+  sort SortGeneratedCounterCell{} []
+  sort Sort64{} [nat{}("64")]
+  hooked-sort SortMap{} [concat{}(Lbl'Unds'Map'Unds'{}()), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(218,3,218,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Map{}())]
+  hooked-sort SortString{} [hasDomainValues{}(), hook{}("STRING.String"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1696,3,1696,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  sort Sort160{} [nat{}("160")]
+  sort SortIOString{} []
+  sort SortId{} [hasDomainValues{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2255,3,2255,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), token{}()]
+  sort SortGeneratedCounterCellOpt{} []
+  sort Sort256{} [nat{}("256")]
+  sort SortExp{} []
+  hooked-sort SortInt{} [hasDomainValues{}(), hook{}("INT.Int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1198,3,1198,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-sort SortSet{} [concat{}(Lbl'Unds'Set'Unds'{}()), element{}(LblSetItem{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(700,3,700,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), unit{}(Lbl'Stop'Set{}())]
+  sort SortExp256{} []
+  sort SortKResult{} []
+  sort SortExp8{} []
+  sort SortStream{} []
+  sort Sort8{} [nat{}("8")]
+  hooked-sort SortBool{} [hasDomainValues{}(), hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1077,3,1077,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// symbols
+  symbol Lbl'Hash'E2BIG{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2400,22,2400,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#E2BIG")]
+  symbol Lbl'Hash'EACCES{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2401,22,2401,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EACCES")]
+  symbol Lbl'Hash'EADDRINUSE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2450,22,2450,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EADDRINUSE")]
+  symbol Lbl'Hash'EADDRNOTAVAIL{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2451,22,2451,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EADDRNOTAVAIL")]
+  symbol Lbl'Hash'EAFNOSUPPORT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2449,22,2449,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EAFNOSUPPORT")]
+  symbol Lbl'Hash'EAGAIN{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2402,22,2402,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EAGAIN")]
+  symbol Lbl'Hash'EALREADY{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2439,22,2439,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EALREADY")]
+  symbol Lbl'Hash'EBADF{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2403,22,2403,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EBADF")]
+  symbol Lbl'Hash'EBUSY{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2404,22,2404,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EBUSY")]
+  symbol Lbl'Hash'ECHILD{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2405,22,2405,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ECHILD")]
+  symbol Lbl'Hash'ECONNABORTED{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2455,22,2455,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ECONNABORTED")]
+  symbol Lbl'Hash'ECONNREFUSED{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2463,22,2463,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ECONNREFUSED")]
+  symbol Lbl'Hash'ECONNRESET{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2456,22,2456,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ECONNRESET")]
+  symbol Lbl'Hash'EDEADLK{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2406,22,2406,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EDEADLK")]
+  symbol Lbl'Hash'EDESTADDRREQ{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2441,22,2441,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EDESTADDRREQ")]
+  symbol Lbl'Hash'EDOM{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2407,22,2407,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EDOM")]
+  symbol Lbl'Hash'EEXIST{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2408,22,2408,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EEXIST")]
+  symbol Lbl'Hash'EFAULT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2409,22,2409,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EFAULT")]
+  symbol Lbl'Hash'EFBIG{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2410,22,2410,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EFBIG")]
+  symbol Lbl'Hash'EHOSTDOWN{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2464,22,2464,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EHOSTDOWN")]
+  symbol Lbl'Hash'EHOSTUNREACH{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2465,22,2465,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EHOSTUNREACH")]
+  symbol Lbl'Hash'EINPROGRESS{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2438,22,2438,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EINPROGRESS")]
+  symbol Lbl'Hash'EINTR{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2411,22,2411,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EINTR")]
+  symbol Lbl'Hash'EINVAL{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2412,22,2412,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EINVAL")]
+  symbol Lbl'Hash'EIO{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2413,22,2413,43)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EIO")]
+  symbol Lbl'Hash'EISCONN{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2458,22,2458,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EISCONN")]
+  symbol Lbl'Hash'EISDIR{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2414,22,2414,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EISDIR")]
+  symbol Lbl'Hash'ELOOP{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2466,22,2466,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ELOOP")]
+  symbol Lbl'Hash'EMFILE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2415,22,2415,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EMFILE")]
+  symbol Lbl'Hash'EMLINK{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2416,22,2416,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EMLINK")]
+  symbol Lbl'Hash'EMSGSIZE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2442,22,2442,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EMSGSIZE")]
+  symbol Lbl'Hash'ENAMETOOLONG{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2417,22,2417,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENAMETOOLONG")]
+  symbol Lbl'Hash'ENETDOWN{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2452,22,2452,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENETDOWN")]
+  symbol Lbl'Hash'ENETRESET{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2454,22,2454,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENETRESET")]
+  symbol Lbl'Hash'ENETUNREACH{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2453,22,2453,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENETUNREACH")]
+  symbol Lbl'Hash'ENFILE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2418,22,2418,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENFILE")]
+  symbol Lbl'Hash'ENOBUFS{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2457,22,2457,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOBUFS")]
+  symbol Lbl'Hash'ENODEV{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2419,22,2419,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENODEV")]
+  symbol Lbl'Hash'ENOENT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2420,22,2420,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOENT")]
+  symbol Lbl'Hash'ENOEXEC{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2421,22,2421,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOEXEC")]
+  symbol Lbl'Hash'ENOLCK{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2422,22,2422,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOLCK")]
+  symbol Lbl'Hash'ENOMEM{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2423,22,2423,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOMEM")]
+  symbol Lbl'Hash'ENOPROTOOPT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2444,22,2444,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOPROTOOPT")]
+  symbol Lbl'Hash'ENOSPC{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2424,22,2424,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOSPC")]
+  symbol Lbl'Hash'ENOSYS{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2425,22,2425,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOSYS")]
+  symbol Lbl'Hash'ENOTCONN{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2459,22,2459,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOTCONN")]
+  symbol Lbl'Hash'ENOTDIR{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2426,22,2426,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOTDIR")]
+  symbol Lbl'Hash'ENOTEMPTY{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2427,22,2427,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOTEMPTY")]
+  symbol Lbl'Hash'ENOTSOCK{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2440,22,2440,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOTSOCK")]
+  symbol Lbl'Hash'ENOTTY{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2428,22,2428,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENOTTY")]
+  symbol Lbl'Hash'ENXIO{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2429,22,2429,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ENXIO")]
+  symbol Lbl'Hash'EOF{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2398,22,2398,43)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EOF")]
+  symbol Lbl'Hash'EOPNOTSUPP{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2447,22,2447,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EOPNOTSUPP")]
+  symbol Lbl'Hash'EOVERFLOW{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2467,22,2467,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EOVERFLOW")]
+  symbol Lbl'Hash'EPERM{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2430,22,2430,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EPERM")]
+  symbol Lbl'Hash'EPFNOSUPPORT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2448,22,2448,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EPFNOSUPPORT")]
+  symbol Lbl'Hash'EPIPE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2431,22,2431,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EPIPE")]
+  symbol Lbl'Hash'EPROTONOSUPPORT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2445,22,2445,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EPROTONOSUPPORT")]
+  symbol Lbl'Hash'EPROTOTYPE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2443,22,2443,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EPROTOTYPE")]
+  symbol Lbl'Hash'ERANGE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2432,22,2432,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ERANGE")]
+  symbol Lbl'Hash'EROFS{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2433,22,2433,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EROFS")]
+  symbol Lbl'Hash'ESHUTDOWN{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2460,22,2460,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ESHUTDOWN")]
+  symbol Lbl'Hash'ESOCKTNOSUPPORT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2446,22,2446,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ESOCKTNOSUPPORT")]
+  symbol Lbl'Hash'ESPIPE{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2434,22,2434,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ESPIPE")]
+  symbol Lbl'Hash'ESRCH{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2435,22,2435,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ESRCH")]
+  symbol Lbl'Hash'ETIMEDOUT{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2462,22,2462,55)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ETIMEDOUT")]
+  symbol Lbl'Hash'ETOOMANYREFS{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2461,22,2461,61)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#ETOOMANYREFS")]
+  symbol Lbl'Hash'EWOULDBLOCK{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2437,22,2437,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EWOULDBLOCK")]
+  symbol Lbl'Hash'EXDEV{}() : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2436,22,2436,47)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#EXDEV")]
+  hooked-symbol Lbl'Hash'accept'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [function{}(), hook{}("IO.accept"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2565,20,2565,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(SortK{}) : SortStream{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2669,21,2669,31)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'close'LParUndsRParUnds'K-IO'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [function{}(), hook{}("IO.close"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2539,16,2539,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(SortK{}, SortK{}) : SortKItem{} [constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(SortK{}, SortK{}) : SortKItem{} [constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(SortK{}, SortK{}) : SortKItem{} [constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(SortK{}, SortK{}) : SortKItem{} [constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(SortK{}, SortK{}) : SortKItem{} [constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(SortK{}, SortK{}) : SortKItem{} [constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(SortK{}, SortK{}) : SortKItem{} [constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(SortK{}, SortK{}) : SortKItem{} [constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(SortK{}, SortK{}) : SortKItem{} [constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(SortK{}, SortK{}) : SortKItem{} [constructor{}(), functional{}(), injective{}()]
+  hooked-symbol Lbl'Hash'getc'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [function{}(), hook{}("IO.getc"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2520,20,2520,89)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(SortInt{}) : SortStream{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2670,21,2670,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'lock'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [function{}(), hook{}("IO.lock"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2551,16,2551,91)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'log{}(SortString{}) : SortK{} [function{}(), functional{}(), hook{}("IO.logString"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2645,16,2645,108)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#log"), total{}()]
+  hooked-symbol Lbl'Hash'logToFile{}(SortString{}, SortString{}) : SortK{} [function{}(), functional{}(), hook{}("IO.log"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2636,16,2636,128)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#logToFile"), total{}()]
+  hooked-symbol Lbl'Hash'mkstemp'LParUndsRParUnds'K-IO'Unds'IOFile'Unds'String{}(SortString{}) : SortIOFile{} [function{}(), hook{}("IO.mkstemp"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2613,21,2613,84)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'open'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'String{}(SortString{}) : SortIOInt{} [function{}(), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2490,20,2490,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'Unds'IOInt'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortIOInt{} [function{}(), hook{}("IO.open"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2491,18,2491,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(SortInt{}) : SortStream{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2672,21,2672,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortStream{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2671,21,2671,48)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'putc'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [function{}(), hook{}("IO.putc"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2530,16,2530,93)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'read'LParUndsCommUndsRParUnds'K-IO'Unds'IOString'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortIOString{} [function{}(), hook{}("IO.read"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2521,23,2521,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'remove'LParUndsRParUnds'K-IO'Unds'K'Unds'String{}(SortString{}) : SortK{} [function{}(), functional{}(), hook{}("IO.remove"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2624,16,2624,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Hash'seek'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [function{}(), hook{}("IO.seek"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2506,16,2506,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'seekEnd'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [function{}(), hook{}("IO.seekEnd"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2507,16,2507,96)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'shutdownWrite'LParUndsRParUnds'K-IO'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [function{}(), hook{}("IO.shutdownWrite"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2566,16,2566,91)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}() : SortInt{} [function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2586,19,2586,46)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}() : SortInt{} [function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2584,18,2584,46)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}() : SortInt{} [function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2585,19,2585,46)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Hash'system'LParUndsRParUnds'K-IO'Unds'KItem'Unds'String{}(SortString{}) : SortKItem{} [function{}(), hook{}("IO.system"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2602,20,2602,74)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'systemResult{}(SortInt{}, SortString{}, SortString{}) : SortKItem{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2603,20,2603,135)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#systemResult")]
+  hooked-symbol Lbl'Hash'tell'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [function{}(), hook{}("IO.tell"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2505,20,2505,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lbl'Hash'tempFile{}(SortString{}, SortInt{}) : SortIOFile{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2615,21,2615,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#tempFile")]
+  hooked-symbol Lbl'Hash'time'LParRParUnds'K-IO'Unds'Int{}() : SortInt{} [function{}(), hook{}("IO.time"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2575,18,2575,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'trace{}(SortKItem{}) : SortK{} [function{}(), functional{}(), hook{}("IO.traceTerm"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2656,16,2656,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#trace"), total{}()]
+  hooked-symbol Lbl'Hash'traceK{}(SortK{}) : SortK{} [function{}(), functional{}(), hook{}("IO.traceTerm"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2657,16,2657,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#traceK"), total{}()]
+  symbol Lbl'Hash'unknownIOError{}(SortInt{}) : SortIOError{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2399,22,2399,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("#unknownIOError")]
+  hooked-symbol Lbl'Hash'unlock'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [function{}(), hook{}("IO.unlock"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2552,16,2552,95)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Hash'write'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'String{}(SortInt{}, SortString{}) : SortK{} [function{}(), hook{}("IO.write"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2531,16,2531,93)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl--MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.neg"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2957,34,2957,108)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvuminus"), total{}()]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [function{}(), functional{}(), hook{}("LIST.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(937,19,937,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("smt_seq_nil"), symbol'Kywd'{}(".List"), total{}()]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [function{}(), functional{}(), hook{}("MAP.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(248,18,248,96)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(".Map"), total{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [function{}(), functional{}(), hook{}("SET.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(729,18,729,90)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(".Set"), total{}()]
+  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [cell{}(), constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortKCell{}, SortGeneratedCounterCell{}) : SortGeneratedTopCell{} [cell{}(), constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortKCellOpt{}, SortGeneratedCounterCellOpt{}) : SortGeneratedTopCellFragment{} [constructor{}(), functional{}(), injective{}()]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [cell{}(), constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(527,17,527,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/kast.md)")]
+  hooked-symbol LblBase2String'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortString{} [function{}(), hook{}("STRING.base2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1825,21,1825,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(SortBool{}) : SortString{} [function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1775,21,1775,56)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblFloat2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float{}(SortFloat{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.float2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1802,21,1802,101)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblFloatFormat{}(SortFloat{}, SortString{}) : SortString{} [function{}(), hook{}("STRING.floatFormat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1803,21,1803,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("FloatFormat")]
+  hooked-symbol LblId2String'LParUndsRParUnds'ID-COMMON'Unds'String'Unds'Id{}(SortId{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.token2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2262,21,2262,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{SortWidth}(SortInt{}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.integer"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2892,34,2892,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("int2bv"), total{}()]
+  hooked-symbol LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(SortInt{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.int2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1824,21,1824,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [function{}(), hook{}("LIST.get"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(965,20,965,91)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("List:get")]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [function{}(), hook{}("LIST.range"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1012,19,1012,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("List:range")]
+  hooked-symbol LblList'Coln'set{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [function{}(), hook{}("LIST.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(974,19,974,108)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("List:set")]
+  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [function{}(), functional{}(), hook{}("LIST.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(945,19,945,124)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("smt_seq_elem"), symbol'Kywd'{}("ListItem"), total{}()]
+  hooked-symbol LblMInt2Signed'LParUndsRParUnds'MINT'Unds'Int'Unds'MInt{SortWidth}(SortMInt{SortWidth}) : SortInt{} [function{}(), functional{}(), hook{}("MINT.svalue"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2889,26,2889,91)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblMInt2Unsigned'LParUndsRParUnds'MINT'Unds'Int'Unds'MInt{SortWidth}(SortMInt{SortWidth}) : SortInt{} [function{}(), functional{}(), hook{}("MINT.uvalue"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2890,26,2890,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bv2int"), total{}()]
+  hooked-symbol LblMap'Coln'choice{}(SortMap{}) : SortKItem{} [function{}(), hook{}("MAP.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,20,393,101)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Map:choice")]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [function{}(), hook{}("MAP.lookup"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(271,20,271,105)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Map:lookup")]
+  hooked-symbol LblMap'Coln'lookupOrDefault{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [function{}(), functional{}(), hook{}("MAP.lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(281,20,281,134)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Map:lookupOrDefault"), total{}()]
+  hooked-symbol LblMap'Coln'update{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,18,290,132)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Map:update"), total{}()]
+  hooked-symbol LblSet'Coln'choice{}(SortSet{}) : SortKItem{} [function{}(), hook{}("SET.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(804,20,804,95)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Set:choice")]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [function{}(), functional{}(), hook{}("SET.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(769,18,769,106)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Set:difference"), total{}()]
+  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [function{}(), functional{}(), hook{}("SET.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(777,19,777,94)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("Set:in"), total{}()]
+  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [function{}(), functional{}(), hook{}("SET.element"), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(737,18,737,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("SetItem"), total{}()]
+  hooked-symbol LblString2Base'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'Int{}(SortString{}, SortInt{}) : SortInt{} [function{}(), hook{}("STRING.string2base"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1826,21,1826,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(SortString{}) : SortBool{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1781,19,1781,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblString2Float'LParUndsRParUnds'STRING-COMMON'Unds'Float'Unds'String{}(SortString{}) : SortFloat{} [function{}(), hook{}("STRING.string2float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1804,21,1804,94)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(SortString{}) : SortId{} [function{}(), functional{}(), hook{}("STRING.string2token"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2263,17,2263,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblString2Int'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [function{}(), hook{}("STRING.string2int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1823,21,1823,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'UndsPerc'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.tmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1248,18,1250,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (or (= 0 (mod #1 #2)) (>= #1 0)) (mod #1 #2) (ite (> #2 0) (- (mod #1 #2) #2) (+ (mod #1 #2) #2)))"), symbol'Kywd'{}("_%Int_")]
+  hooked-symbol Lbl'UndsPerc'sMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.srem"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2961,34,2961,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvsrem")]
+  hooked-symbol Lbl'UndsPerc'uMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.urem"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2963,34,2963,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvurem")]
+  hooked-symbol Lbl'UndsAnd-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1261,18,1261,125)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("andInt"), symbol'Kywd'{}("_&Int_"), total{}()]
+  hooked-symbol Lbl'UndsAnd-'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2972,34,2972,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvand"), total{}()]
+  hooked-symbol Lbl'UndsStar'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.mul"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1242,18,1242,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("*"), symbol'Kywd'{}("_*Int_"), total{}()]
+  hooked-symbol Lbl'UndsStar'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.mul"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2959,34,2959,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvmul"), total{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.add"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1255,18,1255,122)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("+"), symbol'Kywd'{}("_+Int_"), total{}()]
+  hooked-symbol Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.add"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2965,34,2965,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvadd"), total{}()]
+  hooked-symbol Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1714,21,1714,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds'-Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.sub"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1256,18,1256,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("-"), symbol'Kywd'{}("_-Int_"), total{}()]
+  hooked-symbol Lbl'Unds'-MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.sub"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2966,34,2966,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvsub"), total{}()]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,18,311,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'UndsSlsh'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.tdiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1245,18,1247,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (or (= 0 (mod #1 #2)) (>= #1 0)) (div #1 #2) (ite (> #2 0) (+ (div #1 #2) 1) (- (div #1 #2) 1)))"), symbol'Kywd'{}("_/Int_")]
+  hooked-symbol Lbl'UndsSlsh'sMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.sdiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2960,34,2960,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvsdiv")]
+  hooked-symbol Lbl'UndsSlsh'uMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.udiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2962,34,2962,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvudiv")]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.shl"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1259,18,1259,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("shlInt"), symbol'Kywd'{}("_<<Int_")]
+  hooked-symbol Lbl'Unds-LT--LT-'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.shl"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2968,34,2968,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvshl")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1317,19,1317,105)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("<="), symbol'Kywd'{}("_<=Int_"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [function{}(), functional{}(), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,19,383,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [function{}(), functional{}(), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(786,19,786,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [function{}(), functional{}(), hook{}("STRING.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1859,19,1859,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.sle"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2989,27,2989,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvsle"), total{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.ule"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2990,27,2990,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvule"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1318,19,1318,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("<"), symbol'Kywd'{}("_<Int_"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [function{}(), functional{}(), hook{}("STRING.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1858,19,1858,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.slt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2987,27,2987,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvslt"), total{}()]
+  hooked-symbol Lbl'Unds-LT-'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.ult"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2988,27,2988,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvult"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1118,19,1118,126)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("distinct"), symbol'Kywd'{}("_=/=Bool_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1322,19,1322,118)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("distinct"), symbol'Kywd'{}("_=/=Int_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [function{}(), functional{}(), hook{}("KEQUAL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2293,19,2293,138)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("distinct"), symbol'Kywd'{}("_=/=K_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'MInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2996,27,2996,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("distinct"), total{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [function{}(), functional{}(), hook{}("STRING.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1855,19,1855,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1117,19,1117,118)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("="), symbol'Kywd'{}("_==Bool_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1321,19,1321,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("="), symbol'Kywd'{}("_==Int_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [function{}(), functional{}(), hook{}("KEQUAL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2292,19,2292,127)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("="), symbol'Kywd'{}("_==K_"), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'MInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2995,27,2995,105)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("="), total{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [function{}(), functional{}(), hook{}("STRING.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1854,19,1854,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1319,19,1319,105)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}(">="), symbol'Kywd'{}("_>=Int_"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [function{}(), functional{}(), hook{}("STRING.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1861,19,1861,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.sge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2993,27,2993,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvsge"), total{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.uge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2994,27,2994,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvuge"), total{}()]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.shr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1258,18,1258,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("shrInt"), symbol'Kywd'{}("_>>Int_")]
+  hooked-symbol Lbl'Unds-GT--GT-'aMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.ashr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2969,34,2969,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvashr")]
+  hooked-symbol Lbl'Unds-GT--GT-'lMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), hook{}("MINT.lshr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2970,34,2970,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvlshr")]
+  hooked-symbol Lbl'Unds-GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), functional{}(), hook{}("INT.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1320,19,1320,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}(">"), symbol'Kywd'{}("_>Int_"), total{}()]
+  hooked-symbol Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [function{}(), functional{}(), hook{}("STRING.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1860,19,1860,78)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds-GT-'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.sgt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2991,27,2991,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvsgt"), total{}()]
+  hooked-symbol Lbl'Unds-GT-'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortBool{} [function{}(), functional{}(), hook{}("MINT.ugt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2992,27,2992,110)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvugt"), total{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [element{}(LblListItem{}()), function{}(), functional{}(), hook{}("LIST.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(929,19,929,198)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("smt_seq_concat"), symbol'Kywd'{}("_List_"), total{}(), unit{}(Lbl'Stop'List{}()), update{}(LblList'Coln'set{}())]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), function{}(), hook{}("MAP.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,18,240,165)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_Map_"), unit{}(Lbl'Stop'Map{}())]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [element{}(LblSetItem{}()), function{}(), hook{}("SET.concat"), idem{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(721,18,721,157)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_Set_"), unit{}(Lbl'Stop'Set{}())]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(299,18,299,109)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_[_<-undef]"), total{}()]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUnds'{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.powmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1240,18,1240,131)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(mod (^ #1 #2) #3)"), symbol'Kywd'{}("_^%Int__")]
+  hooked-symbol Lbl'UndsXor-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.pow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1239,18,1239,109)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("^"), symbol'Kywd'{}("_^Int_")]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1110,19,1110,138)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("and"), symbol'Kywd'{}("_andBool_"), total{}()]
+  hooked-symbol Lbl'Unds'andThenBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.andThen"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1111,19,1111,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("and"), symbol'Kywd'{}("_andThenBool_"), total{}()]
+  hooked-symbol Lbl'Unds'divInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.ediv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1252,18,1252,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("div"), symbol'Kywd'{}("_divInt_")]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1331,19,1331,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Unds'impliesBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.implies"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1115,19,1115,145)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("=>"), symbol'Kywd'{}("_impliesBool_"), total{}()]
+  hooked-symbol Lbl'Unds'inList'Unds'{}(SortKItem{}, SortList{}) : SortBool{} [function{}(), functional{}(), hook{}("LIST.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1021,19,1021,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_inList_"), total{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [function{}(), functional{}(), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(357,19,357,89)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbl'Unds'modInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.emod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1253,18,1253,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("mod"), symbol'Kywd'{}("_modInt_")]
+  hooked-symbol Lbl'Unds'orBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1113,19,1113,135)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("or"), symbol'Kywd'{}("_orBool_"), total{}()]
+  hooked-symbol Lbl'Unds'orElseBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.orElse"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1114,19,1114,143)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("or"), symbol'Kywd'{}("_orElseBool_"), total{}()]
+  hooked-symbol Lbl'Unds'xorBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1112,19,1112,138)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("xor"), symbol'Kywd'{}("_xorBool_"), total{}()]
+  hooked-symbol Lbl'Unds'xorInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1263,18,1263,127)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("xorInt"), symbol'Kywd'{}("_xorInt_"), total{}()]
+  hooked-symbol Lbl'Unds'xorMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2974,34,2974,118)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvxor"), total{}()]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.element"), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(257,18,257,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("_|->_"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1265,18,1265,123)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("orInt"), symbol'Kywd'{}("_|Int_"), total{}()]
+  hooked-symbol Lbl'UndsPipe'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2976,34,2976,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvor"), total{}()]
+  hooked-symbol Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [function{}(), functional{}(), hook{}("SET.union"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(748,18,748,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.abs"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1282,18,1282,119)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (< #1 0) (- 0 #1) #1)"), total{}()]
+  symbol Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(SortExp{}, SortExp{}, SortInt{}) : SortKItem{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,20,12,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.bitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1307,18,1307,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblbitwidthMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'MInt{SortWidth}(SortMInt{SortWidth}) : SortInt{} [function{}(), functional{}(), hook{}("MINT.bitwidth"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2872,26,2872,92)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblcategoryChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'String{}(SortString{}) : SortString{} [function{}(), hook{}("STRING.category"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1871,21,1871,81)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblchrChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(SortInt{}) : SortString{} [function{}(), hook{}("STRING.chr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1731,21,1731,70)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortInt{} [function{}(), functional{}(), hook{}("STRING.countAllOccurrences"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1844,18,1844,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LbldirectionalityChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'String{}(SortString{}) : SortString{} [function{}(), hook{}("STRING.directionality"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1872,21,1872,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [function{}(), hook{}("LIST.fill"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1002,19,1002,100)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [function{}(), hook{}("STRING.findChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1768,18,1768,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [function{}(), hook{}("STRING.find"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1757,18,1757,111)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(SortInt{}) : SortId{} [freshGenerator{}(), function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2264,17,2264,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [freshGenerator{}(), function{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1445,18,1445,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol LblgetGeneratedCounterCell{}(SortGeneratedTopCell{}) : SortGeneratedCounterCell{} [function{}()]
+  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [function{}(), functional{}(), total{}()]
+  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [function{}()]
+  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [function{}()]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [function{}(), functional{}(), hook{}("SET.intersection"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(759,18,759,90)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol Lblis160{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol Lblis256{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol Lblis32{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol Lblis64{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol Lblis8{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisBool{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisExp{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisExp160{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisExp256{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisExp32{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisExp64{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisExp8{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisFloat{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisIOError{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisIOFile{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisIOInt{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisIOString{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisId{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisInt{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisK{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisKResult{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisList{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisMInt'LBra'160'RBra'{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisMInt'LBra'256'RBra'{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisMInt'LBra'32'RBra'{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisMInt'LBra'64'RBra'{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisMInt'LBra'8'RBra'{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisMap{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisStream{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  symbol LblisString{}(SortK{}) : SortBool{} [function{}(), functional{}(), total{}()]
+  hooked-symbol Lblite{SortSort}(SortBool{}, SortSort, SortSort) : SortSort [function{}(), functional{}(), hook{}("KEQUAL.ite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2297,26,2297,132)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("ite"), symbol'Kywd'{}("ite"), total{}()]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(SortMap{}) : SortSet{} [function{}(), functional{}(), hook{}("MAP.keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,18,341,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [function{}(), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,19,349,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [function{}(), functional{}(), hook{}("STRING.length"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1722,18,1722,80)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), hook{}("INT.log2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1293,18,1293,75)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'Unds'List'Unds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [function{}(), hook{}("LIST.make"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(983,19,983,82)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.max"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1274,18,1274,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (< #1 #2) #2 #1)"), total{}()]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.min"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1273,18,1273,114)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (< #1 #2) #1 #2)"), total{}()]
+  hooked-symbol LblnewUUID'Unds'STRING-COMMON'Unds'String{}() : SortString{} [function{}(), hook{}("STRING.uuid"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1874,21,1874,68)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblnoGeneratedCounterCell{}() : SortGeneratedCounterCellOpt{} [constructor{}(), functional{}(), injective{}()]
+  symbol LblnoKCell{}() : SortKCellOpt{} [constructor{}(), functional{}(), injective{}()]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [function{}(), functional{}(), hook{}("BOOL.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1109,19,1109,131)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("not"), symbol'Kywd'{}("notBool_"), total{}()]
+  hooked-symbol LblordChar'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [function{}(), hook{}("STRING.ord"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1732,18,1732,70)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol Lblproject'ColnHash'tempFile'Coln'fd{}(SortIOFile{}) : SortInt{} [function{}()]
+  symbol Lblproject'ColnHash'tempFile'Coln'path{}(SortIOFile{}) : SortString{} [function{}()]
+  symbol Lblproject'ColnHash'unknownIOError'Coln'errno{}(SortIOError{}) : SortInt{} [function{}()]
+  symbol Lblproject'Coln'Bool{}(SortK{}) : SortBool{} [function{}()]
+  symbol Lblproject'Coln'Exp{}(SortK{}) : SortExp{} [function{}()]
+  symbol Lblproject'Coln'Exp160{}(SortK{}) : SortExp160{} [function{}()]
+  symbol Lblproject'Coln'Exp256{}(SortK{}) : SortExp256{} [function{}()]
+  symbol Lblproject'Coln'Exp32{}(SortK{}) : SortExp32{} [function{}()]
+  symbol Lblproject'Coln'Exp64{}(SortK{}) : SortExp64{} [function{}()]
+  symbol Lblproject'Coln'Exp8{}(SortK{}) : SortExp8{} [function{}()]
+  symbol Lblproject'Coln'Float{}(SortK{}) : SortFloat{} [function{}()]
+  symbol Lblproject'Coln'GeneratedCounterCell{}(SortK{}) : SortGeneratedCounterCell{} [function{}()]
+  symbol Lblproject'Coln'GeneratedCounterCellOpt{}(SortK{}) : SortGeneratedCounterCellOpt{} [function{}()]
+  symbol Lblproject'Coln'GeneratedTopCell{}(SortK{}) : SortGeneratedTopCell{} [function{}()]
+  symbol Lblproject'Coln'GeneratedTopCellFragment{}(SortK{}) : SortGeneratedTopCellFragment{} [function{}()]
+  symbol Lblproject'Coln'IOError{}(SortK{}) : SortIOError{} [function{}()]
+  symbol Lblproject'Coln'IOFile{}(SortK{}) : SortIOFile{} [function{}()]
+  symbol Lblproject'Coln'IOInt{}(SortK{}) : SortIOInt{} [function{}()]
+  symbol Lblproject'Coln'IOString{}(SortK{}) : SortIOString{} [function{}()]
+  symbol Lblproject'Coln'Id{}(SortK{}) : SortId{} [function{}()]
+  symbol Lblproject'Coln'Int{}(SortK{}) : SortInt{} [function{}()]
+  symbol Lblproject'Coln'K{}(SortK{}) : SortK{} [function{}()]
+  symbol Lblproject'Coln'KCell{}(SortK{}) : SortKCell{} [function{}()]
+  symbol Lblproject'Coln'KCellOpt{}(SortK{}) : SortKCellOpt{} [function{}()]
+  symbol Lblproject'Coln'KItem{}(SortK{}) : SortKItem{} [function{}()]
+  symbol Lblproject'Coln'KResult{}(SortK{}) : SortKResult{} [function{}()]
+  symbol Lblproject'Coln'List{}(SortK{}) : SortList{} [function{}()]
+  symbol Lblproject'Coln'MInt'LBra'160'RBra'{}(SortK{}) : SortMInt{Sort160{}} [function{}()]
+  symbol Lblproject'Coln'MInt'LBra'256'RBra'{}(SortK{}) : SortMInt{Sort256{}} [function{}()]
+  symbol Lblproject'Coln'MInt'LBra'32'RBra'{}(SortK{}) : SortMInt{Sort32{}} [function{}()]
+  symbol Lblproject'Coln'MInt'LBra'64'RBra'{}(SortK{}) : SortMInt{Sort64{}} [function{}()]
+  symbol Lblproject'Coln'MInt'LBra'8'RBra'{}(SortK{}) : SortMInt{Sort8{}} [function{}()]
+  symbol Lblproject'Coln'Map{}(SortK{}) : SortMap{} [function{}()]
+  symbol Lblproject'Coln'Set{}(SortK{}) : SortSet{} [function{}()]
+  symbol Lblproject'Coln'Stream{}(SortK{}) : SortStream{} [function{}()]
+  symbol Lblproject'Coln'String{}(SortK{}) : SortString{} [function{}()]
+  hooked-symbol LblpushList{}(SortKItem{}, SortList{}) : SortList{} [function{}(), functional{}(), hook{}("LIST.push"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(953,19,953,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("pushList"), total{}()]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), hook{}("INT.rand"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1341,18,1341,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.removeAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,18,333,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortString{}, SortInt{}) : SortString{} [function{}(), hook{}("STRING.replace"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1842,21,1842,146)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.replaceAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1841,21,1841,149)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.replaceFirst"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1843,21,1843,151)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [function{}(), hook{}("STRING.rfindChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1769,18,1769,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [function{}(), hook{}("STRING.rfind"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1758,18,1758,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblroundMInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'MInt{SortWidth1, SortWidth2}(SortMInt{SortWidth2}) : SortMInt{SortWidth1} [function{}(), functional{}(), hook{}("MINT.round"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3021,44,3021,103)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblsMaxMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.smax"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3006,34,3006,140)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (bvslt #1 #2) #2 #1)"), total{}()]
+  hooked-symbol LblsMinMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.smin"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3007,34,3007,140)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (bvslt #1 #2) #1 #2)"), total{}()]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [function{}(), hook{}("INT.signExtendBitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1308,18,1308,113)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblsignExtendMInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'MInt{SortWidth1, SortWidth2}(SortMInt{SortWidth2}) : SortMInt{SortWidth1} [function{}(), functional{}(), hook{}("MINT.sext"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3022,44,3022,107)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(SortSet{}) : SortInt{} [function{}(), functional{}(), hook{}("SET.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(794,18,794,76)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol LblsizeList{}(SortList{}) : SortInt{} [function{}(), functional{}(), hook{}("LIST.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1029,18,1029,116)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("smt_seq_len"), symbol'Kywd'{}("sizeList"), total{}()]
+  hooked-symbol LblsizeMap{}(SortMap{}) : SortInt{} [function{}(), functional{}(), hook{}("MAP.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(373,18,373,99)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}("sizeMap"), total{}()]
+  symbol LblsmaxMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2903,18,2903,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblsminMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2902,18,2902,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LblsoverflowMInt'LParUndsCommUndsRParUnds'MINT'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2919,19,2919,62)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT-COMMON'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [function{}(), hook{}("INT.srand"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1342,16,1342,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(SortString{}, SortInt{}, SortInt{}) : SortString{} [function{}(), functional{}(), hook{}("STRING.substr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1747,21,1747,117)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  symbol LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(SortExp160{}) : SortExp{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(54,18,54,35)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+  symbol LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(SortExp256{}) : SortExp{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(58,18,58,35)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+  symbol LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(SortExp32{}) : SortExp{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(46,18,46,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+  symbol LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(SortExp64{}) : SortExp{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(50,18,50,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+  symbol LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(SortExp8{}) : SortExp{} [constructor{}(), functional{}(), injective{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(42,18,42,31)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+  hooked-symbol LbluMaxMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.umax"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3008,34,3008,140)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (bvult #1 #2) #2 #1)"), total{}()]
+  hooked-symbol LbluMinMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}, SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.umin"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3009,34,3009,140)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("(ite (bvult #1 #2) #1 #2)"), total{}()]
+  symbol LblumaxMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2905,18,2905,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LbluminMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2904,18,2904,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  symbol LbluoverflowMInt'LParUndsCommUndsRParUnds'MINT'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2920,19,2920,62)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [function{}(), hook{}("LIST.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(993,19,993,97)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [function{}(), functional{}(), hook{}("MAP.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(324,18,324,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), total{}()]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [function{}(), hook{}("MAP.values"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(365,19,365,77)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+  hooked-symbol Lbl'Tild'Int'Unds'{}(SortInt{}) : SortInt{} [function{}(), functional{}(), hook{}("INT.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1237,18,1237,112)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smtlib{}("notInt"), symbol'Kywd'{}("~Int_"), total{}()]
+  hooked-symbol Lbl'Tild'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt{SortWidth}(SortMInt{SortWidth}) : SortMInt{SortWidth} [function{}(), functional{}(), hook{}("MINT.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2956,34,2956,104)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), smt-hook{}("bvnot"), total{}()]
+
+// generated axioms
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortExp32{}, SortKItem{}} (From:SortExp32{}))) [subsort{SortExp32{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, inj{SortKCell{}, SortKCellOpt{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCellOpt{}, SortKItem{}} (From:SortKCellOpt{}))) [subsort{SortKCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMap{}, SortKItem{}} (From:SortMap{}))) [subsort{SortMap{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCell{}, SortKItem{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSet{}, SortKItem{}} (From:SortSet{}))) [subsort{SortSet{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOError{}, SortKItem{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKResult{}, SortKItem{}} (From:SortKResult{}))) [subsort{SortKResult{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortId{}, SortKItem{}} (From:SortId{}))) [subsort{SortId{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (From:SortGeneratedCounterCellOpt{}))) [subsort{SortGeneratedCounterCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortList{}, SortKItem{}} (From:SortList{}))) [subsort{SortList{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCell{}, SortKItem{}} (From:SortGeneratedTopCell{}))) [subsort{SortGeneratedTopCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortExp256{}, SortKItem{}} (From:SortExp256{}))) [subsort{SortExp256{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStream{}, SortKItem{}} (From:SortStream{}))) [subsort{SortStream{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBool{}, SortKItem{}} (From:SortBool{}))) [subsort{SortBool{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMInt{Sort160{}}, SortKItem{}} (From:SortMInt{Sort160{}}))) [subsort{SortMInt{Sort160{}}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortExp160{}, SortKItem{}} (From:SortExp160{}))) [subsort{SortExp160{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOString{}, SortKItem{}} (From:SortIOString{}))) [subsort{SortIOString{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortExp{}, SortKItem{}} (From:SortExp{}))) [subsort{SortExp{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOFile{}, SortKItem{}} (From:SortIOFile{}))) [subsort{SortIOFile{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortExp8{}, SortKItem{}} (From:SortExp8{}))) [subsort{SortExp8{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMInt{Sort256{}}, SortKItem{}} (From:SortMInt{Sort256{}}))) [subsort{SortMInt{Sort256{}}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMInt{Sort32{}}, SortKItem{}} (From:SortMInt{Sort32{}}))) [subsort{SortMInt{Sort32{}}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortFloat{}, SortKItem{}} (From:SortFloat{}))) [subsort{SortFloat{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortString{}, SortKItem{}} (From:SortString{}))) [subsort{SortString{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (From:SortGeneratedTopCellFragment{}))) [subsort{SortGeneratedTopCellFragment{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOInt{}, SortKItem{}} (From:SortIOInt{}))) [subsort{SortIOInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortExp64{}, SortKItem{}} (From:SortExp64{}))) [subsort{SortExp64{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMInt{Sort8{}}, SortKItem{}} (From:SortMInt{Sort8{}}))) [subsort{SortMInt{Sort8{}}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMInt{Sort64{}}, SortKItem{}} (From:SortMInt{Sort64{}}))) [subsort{SortMInt{Sort64{}}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortInt{}, SortExp{}} (From:SortInt{}))) [subsort{SortInt{}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortMInt{Sort8{}}, SortExp{}} (From:SortMInt{Sort8{}}))) [subsort{SortMInt{Sort8{}}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortMInt{Sort32{}}, SortExp{}} (From:SortMInt{Sort32{}}))) [subsort{SortMInt{Sort32{}}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortMInt{Sort64{}}, SortExp{}} (From:SortMInt{Sort64{}}))) [subsort{SortMInt{Sort64{}}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortMInt{Sort160{}}, SortExp{}} (From:SortMInt{Sort160{}}))) [subsort{SortMInt{Sort160{}}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortMInt{Sort256{}}, SortExp{}} (From:SortMInt{Sort256{}}))) [subsort{SortMInt{Sort256{}}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKResult{}, \equals{SortKResult{}, R} (Val:SortKResult{}, inj{SortMInt{Sort8{}}, SortKResult{}} (From:SortMInt{Sort8{}}))) [subsort{SortMInt{Sort8{}}, SortKResult{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKResult{}, \equals{SortKResult{}, R} (Val:SortKResult{}, inj{SortMInt{Sort32{}}, SortKResult{}} (From:SortMInt{Sort32{}}))) [subsort{SortMInt{Sort32{}}, SortKResult{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKResult{}, \equals{SortKResult{}, R} (Val:SortKResult{}, inj{SortMInt{Sort64{}}, SortKResult{}} (From:SortMInt{Sort64{}}))) [subsort{SortMInt{Sort64{}}, SortKResult{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKResult{}, \equals{SortKResult{}, R} (Val:SortKResult{}, inj{SortMInt{Sort160{}}, SortKResult{}} (From:SortMInt{Sort160{}}))) [subsort{SortMInt{Sort160{}}, SortKResult{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKResult{}, \equals{SortKResult{}, R} (Val:SortKResult{}, inj{SortMInt{Sort256{}}, SortKResult{}} (From:SortMInt{Sort256{}}))) [subsort{SortMInt{Sort256{}}, SortKResult{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOInt{}, \equals{SortIOInt{}, R} (Val:SortIOInt{}, inj{SortInt{}, SortIOInt{}} (From:SortInt{}))) [subsort{SortInt{}, SortIOInt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOInt{}, \equals{SortIOInt{}, R} (Val:SortIOInt{}, inj{SortIOError{}, SortIOInt{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOInt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOString{}, \equals{SortIOString{}, R} (Val:SortIOString{}, inj{SortString{}, SortIOString{}} (From:SortString{}))) [subsort{SortString{}, SortIOString{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOString{}, \equals{SortIOString{}, R} (Val:SortIOString{}, inj{SortIOError{}, SortIOString{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOString{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOFile{}, \equals{SortIOFile{}, R} (Val:SortIOFile{}, inj{SortIOError{}, SortIOFile{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOFile{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp8{}, \equals{SortExp8{}, R} (Val:SortExp8{}, inj{SortInt{}, SortExp8{}} (From:SortInt{}))) [subsort{SortInt{}, SortExp8{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKConfigVar{}, SortKItem{}} (From:SortKConfigVar{}))) [subsort{SortKConfigVar{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp8{}, \equals{SortExp8{}, R} (Val:SortExp8{}, inj{SortMInt{Sort8{}}, SortExp8{}} (From:SortMInt{Sort8{}}))) [subsort{SortMInt{Sort8{}}, SortExp8{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortExp8{}, SortExp{}} (From:SortExp8{}))) [subsort{SortExp8{}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp32{}, \equals{SortExp32{}, R} (Val:SortExp32{}, inj{SortInt{}, SortExp32{}} (From:SortInt{}))) [subsort{SortInt{}, SortExp32{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp32{}, \equals{SortExp32{}, R} (Val:SortExp32{}, inj{SortMInt{Sort32{}}, SortExp32{}} (From:SortMInt{Sort32{}}))) [subsort{SortMInt{Sort32{}}, SortExp32{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortExp32{}, SortExp{}} (From:SortExp32{}))) [subsort{SortExp32{}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp64{}, \equals{SortExp64{}, R} (Val:SortExp64{}, inj{SortInt{}, SortExp64{}} (From:SortInt{}))) [subsort{SortInt{}, SortExp64{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp64{}, \equals{SortExp64{}, R} (Val:SortExp64{}, inj{SortMInt{Sort64{}}, SortExp64{}} (From:SortMInt{Sort64{}}))) [subsort{SortMInt{Sort64{}}, SortExp64{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortExp64{}, SortExp{}} (From:SortExp64{}))) [subsort{SortExp64{}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp160{}, \equals{SortExp160{}, R} (Val:SortExp160{}, inj{SortInt{}, SortExp160{}} (From:SortInt{}))) [subsort{SortInt{}, SortExp160{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp160{}, \equals{SortExp160{}, R} (Val:SortExp160{}, inj{SortMInt{Sort160{}}, SortExp160{}} (From:SortMInt{Sort160{}}))) [subsort{SortMInt{Sort160{}}, SortExp160{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortExp160{}, SortExp{}} (From:SortExp160{}))) [subsort{SortExp160{}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp256{}, \equals{SortExp256{}, R} (Val:SortExp256{}, inj{SortInt{}, SortExp256{}} (From:SortInt{}))) [subsort{SortInt{}, SortExp256{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp256{}, \equals{SortExp256{}, R} (Val:SortExp256{}, inj{SortMInt{Sort256{}}, SortExp256{}} (From:SortMInt{Sort256{}}))) [subsort{SortMInt{Sort256{}}, SortExp256{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortExp256{}, SortExp{}} (From:SortExp256{}))) [subsort{SortExp256{}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'E2BIG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EACCES{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EADDRINUSE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EADDRNOTAVAIL{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EAFNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EAGAIN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EALREADY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EBADF{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EBUSY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECHILD{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNABORTED{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNREFUSED{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNRESET{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDEADLK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDESTADDRREQ{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDOM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EEXIST{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EFAULT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EFBIG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EHOSTDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EHOSTUNREACH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINPROGRESS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINTR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINVAL{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EIO{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EISCONN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EISDIR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ELOOP{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMFILE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMLINK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMSGSIZE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENAMETOOLONG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETRESET{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETUNREACH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENFILE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOBUFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENODEV{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOENT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOEXEC{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOLCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOMEM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOPROTOOPT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOSPC{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOSYS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTCONN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTDIR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTEMPTY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTSOCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTTY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENXIO{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOF{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOPNOTSUPP{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOVERFLOW{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPERM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPFNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPIPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EPROTONOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPROTONOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPROTOTYPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ERANGE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EROFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESHUTDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESOCKTNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESPIPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESRCH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ETIMEDOUT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ETOOMANYREFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EWOULDBLOCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EXDEV{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(Y0:SortK{})), Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(Y0:SortK{}, Y1:SortK{})), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}), \and{SortK{}} (X1:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Y0:SortExp{}, Y1:SortExp{}, Y2:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(Y0:SortK{}, Y1:SortK{})), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}), \and{SortK{}} (X1:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Y0:SortExp{}, Y1:SortExp{}, Y2:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(Y0:SortK{}, Y1:SortK{})), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}), \and{SortK{}} (X1:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Y0:SortExp{}, Y1:SortExp{}, Y2:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(Y0:SortK{}, Y1:SortK{})), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}), \and{SortK{}} (X1:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Y0:SortExp{}, Y1:SortExp{}, Y2:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(Y0:SortK{}, Y1:SortK{})), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}), \and{SortK{}} (X1:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(X0:SortK{}, X1:SortK{}), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Y0:SortExp{}, Y1:SortExp{}, Y2:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(Y0:SortK{}, Y1:SortK{})), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}), \and{SortK{}} (X1:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Y0:SortExp{}, Y1:SortExp{}, Y2:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(Y0:SortK{}, Y1:SortK{})), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}), \and{SortK{}} (X1:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(X0:SortK{}, X1:SortK{}), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Y0:SortExp{}, Y1:SortExp{}, Y2:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(Y0:SortK{}, Y1:SortK{})), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}), \and{SortK{}} (X1:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(X0:SortK{}, X1:SortK{}), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Y0:SortExp{}, Y1:SortExp{}, Y2:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(Y0:SortK{}, Y1:SortK{})), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}), \and{SortK{}} (X1:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(X0:SortK{}, X1:SortK{}), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Y0:SortExp{}, Y1:SortExp{}, Y2:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(Y0:SortK{}, Y1:SortK{})), Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}), \and{SortK{}} (X1:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(X0:SortK{}, X1:SortK{}), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Y0:SortExp{}, Y1:SortExp{}, Y2:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{})), Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'log{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'logToFile{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(Y0:SortInt{})), Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStream{}} (\and{SortStream{}} (Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(X0:SortString{}, X1:SortString{}), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(Y0:SortString{}, Y1:SortString{})), Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(\and{SortString{}} (X0:SortString{}, Y0:SortString{}), \and{SortString{}} (X1:SortString{}, Y1:SortString{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'remove'LParUndsRParUnds'K-IO'Unds'K'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'systemResult{}(K0:SortInt{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'systemResult{}(X0:SortInt{}, X1:SortString{}, X2:SortString{}), Lbl'Hash'systemResult{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{})), Lbl'Hash'systemResult{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}), \and{SortString{}} (X1:SortString{}, Y1:SortString{}), \and{SortString{}} (X2:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'systemResult{}(X0:SortInt{}, X1:SortString{}, X2:SortString{}), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Y0:SortExp{}, Y1:SortExp{}, Y2:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOFile{}, \equals{SortIOFile{}, R} (Val:SortIOFile{}, Lbl'Hash'tempFile{}(K0:SortString{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortIOFile{}} (\and{SortIOFile{}} (Lbl'Hash'tempFile{}(X0:SortString{}, X1:SortInt{}), Lbl'Hash'tempFile{}(Y0:SortString{}, Y1:SortInt{})), Lbl'Hash'tempFile{}(\and{SortString{}} (X0:SortString{}, Y0:SortString{}), \and{SortInt{}} (X1:SortInt{}, Y1:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'trace{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'traceK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'unknownIOError{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'unknownIOError{}(Y0:SortInt{})), Lbl'Hash'unknownIOError{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl--MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Stop'Set{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, Lbl'-LT-'generatedCounter'-GT-'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedCounterCell{}} (\and{SortGeneratedCounterCell{}} (Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{}), Lbl'-LT-'generatedCounter'-GT-'{}(Y0:SortInt{})), Lbl'-LT-'generatedCounter'-GT-'{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCell{}, \equals{SortGeneratedTopCell{}, R} (Val:SortGeneratedTopCell{}, Lbl'-LT-'generatedTop'-GT-'{}(K0:SortKCell{}, K1:SortGeneratedCounterCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCell{}} (\and{SortGeneratedTopCell{}} (Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}), Lbl'-LT-'generatedTop'-GT-'{}(Y0:SortKCell{}, Y1:SortGeneratedCounterCell{})), Lbl'-LT-'generatedTop'-GT-'{}(\and{SortKCell{}} (X0:SortKCell{}, Y0:SortKCell{}), \and{SortGeneratedCounterCell{}} (X1:SortGeneratedCounterCell{}, Y1:SortGeneratedCounterCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCellFragment{}, \equals{SortGeneratedTopCellFragment{}, R} (Val:SortGeneratedTopCellFragment{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(K0:SortKCellOpt{}, K1:SortGeneratedCounterCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCellFragment{}} (\and{SortGeneratedTopCellFragment{}} (Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}), Lbl'-LT-'generatedTop'-GT-'-fragment{}(Y0:SortKCellOpt{}, Y1:SortGeneratedCounterCellOpt{})), Lbl'-LT-'generatedTop'-GT-'-fragment{}(\and{SortKCellOpt{}} (X0:SortKCellOpt{}, Y0:SortKCellOpt{}), \and{SortGeneratedCounterCellOpt{}} (X1:SortGeneratedCounterCellOpt{}, Y1:SortGeneratedCounterCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, Lbl'-LT-'k'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblFloat2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float{}(K0:SortFloat{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblId2String'LParUndsRParUnds'ID-COMMON'Unds'String'Unds'Id{}(K0:SortId{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{SortWidth}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblMInt2Signed'LParUndsRParUnds'MINT'Unds'Int'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblMInt2Unsigned'LParUndsRParUnds'MINT'Unds'Int'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, LblMap'Coln'lookupOrDefault{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblMap'Coln'update{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortKItem{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'UndsAnd-'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'UndsStar'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'Unds'-MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'MInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'MInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'sMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'uMInt'UndsUnds'MINT'Unds'Bool'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:SortList{},K2:SortList{}),K3:SortList{}),Lbl'Unds'List'Unds'{}(K1:SortList{},Lbl'Unds'List'Unds'{}(K2:SortList{},K3:SortList{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(K:SortList{},Lbl'Stop'List{}()),K:SortList{}) [unit{}()] // right unit
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Stop'List{}(),K:SortList{}),K:SortList{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K:SortMap{},Lbl'Stop'Map{}()),K:SortMap{}) [unit{}()] // right unit
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),K:SortMap{}),K:SortMap{}) [unit{}()] // left unit
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},Lbl'Stop'Set{}()),K:SortSet{}) [unit{}()] // right unit
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Stop'Set{}(),K:SortSet{}),K:SortSet{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'inList'Unds'{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(K0:SortKItem{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'Unds'xorMInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortKItem{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'UndsPipe'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(K0:SortExp{}, K1:SortExp{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(X0:SortExp{}, X1:SortExp{}, X2:SortInt{}), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Y0:SortExp{}, Y1:SortExp{}, Y2:SortInt{})), Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(\and{SortExp{}} (X0:SortExp{}, Y0:SortExp{}), \and{SortExp{}} (X1:SortExp{}, Y1:SortExp{}), \and{SortInt{}} (X2:SortInt{}, Y2:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R, SortWidth} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblbitwidthMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, LblinitGeneratedCounterCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lblis160{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lblis256{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lblis32{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lblis64{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lblis8{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBool{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisExp{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisExp160{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisExp256{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisExp32{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisExp64{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisExp8{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisFloat{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCellFragment{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOError{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOFile{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOString{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisId{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKConfigVar{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKResult{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisList{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMInt'LBra'160'RBra'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMInt'LBra'256'RBra'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMInt'LBra'32'RBra'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMInt'LBra'64'RBra'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMInt'LBra'8'RBra'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMap{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisSet{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisStream{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisString{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R, SortSort} \exists{R} (Val:SortSort, \equals{SortSort, R} (Val:SortSort, Lblite{SortSort}(K0:SortBool{}, K1:SortSort, K2:SortSort))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, LblnoGeneratedCounterCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, LblnoKCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblpushList{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R, SortWidth1, SortWidth2} \exists{R} (Val:SortMInt{SortWidth1}, \equals{SortMInt{SortWidth1}, R} (Val:SortMInt{SortWidth1}, LblroundMInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'MInt{SortWidth1, SortWidth2}(K0:SortMInt{SortWidth2}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, LblsMaxMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, LblsMinMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth1, SortWidth2} \exists{R} (Val:SortMInt{SortWidth1}, \equals{SortMInt{SortWidth1}, R} (Val:SortMInt{SortWidth1}, LblsignExtendMInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'MInt{SortWidth1, SortWidth2}(K0:SortMInt{SortWidth2}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblsizeList{}(K0:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblsizeMap{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(K0:SortString{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(K0:SortExp160{}))) [functional{}()] // functional
+  axiom{}\implies{SortExp{}} (\and{SortExp{}} (LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(X0:SortExp160{}), LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(Y0:SortExp160{})), LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(\and{SortExp160{}} (X0:SortExp160{}, Y0:SortExp160{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(X0:SortExp160{}), LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(Y0:SortExp256{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(X0:SortExp160{}), LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(Y0:SortExp32{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(X0:SortExp160{}), LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(Y0:SortExp64{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(X0:SortExp160{}), LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(Y0:SortExp8{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(K0:SortExp256{}))) [functional{}()] // functional
+  axiom{}\implies{SortExp{}} (\and{SortExp{}} (LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(X0:SortExp256{}), LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(Y0:SortExp256{})), LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(\and{SortExp256{}} (X0:SortExp256{}, Y0:SortExp256{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(X0:SortExp256{}), LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(Y0:SortExp32{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(X0:SortExp256{}), LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(Y0:SortExp64{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(X0:SortExp256{}), LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(Y0:SortExp8{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(K0:SortExp32{}))) [functional{}()] // functional
+  axiom{}\implies{SortExp{}} (\and{SortExp{}} (LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(X0:SortExp32{}), LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(Y0:SortExp32{})), LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(\and{SortExp32{}} (X0:SortExp32{}, Y0:SortExp32{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(X0:SortExp32{}), LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(Y0:SortExp64{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(X0:SortExp32{}), LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(Y0:SortExp8{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(K0:SortExp64{}))) [functional{}()] // functional
+  axiom{}\implies{SortExp{}} (\and{SortExp{}} (LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(X0:SortExp64{}), LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(Y0:SortExp64{})), LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(\and{SortExp64{}} (X0:SortExp64{}, Y0:SortExp64{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(X0:SortExp64{}), LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(Y0:SortExp8{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(K0:SortExp8{}))) [functional{}()] // functional
+  axiom{}\implies{SortExp{}} (\and{SortExp{}} (LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(X0:SortExp8{}), LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(Y0:SortExp8{})), LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(\and{SortExp8{}} (X0:SortExp8{}, Y0:SortExp8{}))) [constructor{}()] // no confusion same constructor
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, LbluMaxMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, LbluMinMInt'LParUndsCommUndsRParUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}, K1:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'Unds'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortWidth} \exists{R} (Val:SortMInt{SortWidth}, \equals{SortMInt{SortWidth}, R} (Val:SortMInt{SortWidth}, Lbl'Tild'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt{SortWidth}(K0:SortMInt{SortWidth}))) [functional{}()] // functional
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortExp{}} (\exists{SortExp{}} (X0:SortExp160{}, LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(X0:SortExp160{})), \exists{SortExp{}} (X0:SortExp256{}, LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(X0:SortExp256{})), \exists{SortExp{}} (X0:SortExp32{}, LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(X0:SortExp32{})), \exists{SortExp{}} (X0:SortExp64{}, LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(X0:SortExp64{})), \exists{SortExp{}} (X0:SortExp8{}, LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(X0:SortExp8{})), \exists{SortExp{}} (Val:SortExp160{}, inj{SortExp160{}, SortExp{}} (Val:SortExp160{})), \exists{SortExp{}} (Val:SortExp256{}, inj{SortExp256{}, SortExp{}} (Val:SortExp256{})), \exists{SortExp{}} (Val:SortExp32{}, inj{SortExp32{}, SortExp{}} (Val:SortExp32{})), \exists{SortExp{}} (Val:SortExp64{}, inj{SortExp64{}, SortExp{}} (Val:SortExp64{})), \exists{SortExp{}} (Val:SortExp8{}, inj{SortExp8{}, SortExp{}} (Val:SortExp8{})), \exists{SortExp{}} (Val:SortInt{}, inj{SortInt{}, SortExp{}} (Val:SortInt{})), \exists{SortExp{}} (Val:SortMInt{Sort160{}}, inj{SortMInt{Sort160{}}, SortExp{}} (Val:SortMInt{Sort160{}})), \exists{SortExp{}} (Val:SortMInt{Sort256{}}, inj{SortMInt{Sort256{}}, SortExp{}} (Val:SortMInt{Sort256{}})), \exists{SortExp{}} (Val:SortMInt{Sort32{}}, inj{SortMInt{Sort32{}}, SortExp{}} (Val:SortMInt{Sort32{}})), \exists{SortExp{}} (Val:SortMInt{Sort64{}}, inj{SortMInt{Sort64{}}, SortExp{}} (Val:SortMInt{Sort64{}})), \exists{SortExp{}} (Val:SortMInt{Sort8{}}, inj{SortMInt{Sort8{}}, SortExp{}} (Val:SortMInt{Sort8{}})), \bottom{SortExp{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortExp160{}} (\exists{SortExp160{}} (Val:SortInt{}, inj{SortInt{}, SortExp160{}} (Val:SortInt{})), \exists{SortExp160{}} (Val:SortMInt{Sort160{}}, inj{SortMInt{Sort160{}}, SortExp160{}} (Val:SortMInt{Sort160{}})), \bottom{SortExp160{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortExp256{}} (\exists{SortExp256{}} (Val:SortInt{}, inj{SortInt{}, SortExp256{}} (Val:SortInt{})), \exists{SortExp256{}} (Val:SortMInt{Sort256{}}, inj{SortMInt{Sort256{}}, SortExp256{}} (Val:SortMInt{Sort256{}})), \bottom{SortExp256{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortExp32{}} (\exists{SortExp32{}} (Val:SortInt{}, inj{SortInt{}, SortExp32{}} (Val:SortInt{})), \exists{SortExp32{}} (Val:SortMInt{Sort32{}}, inj{SortMInt{Sort32{}}, SortExp32{}} (Val:SortMInt{Sort32{}})), \bottom{SortExp32{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortExp64{}} (\exists{SortExp64{}} (Val:SortInt{}, inj{SortInt{}, SortExp64{}} (Val:SortInt{})), \exists{SortExp64{}} (Val:SortMInt{Sort64{}}, inj{SortMInt{Sort64{}}, SortExp64{}} (Val:SortMInt{Sort64{}})), \bottom{SortExp64{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortExp8{}} (\exists{SortExp8{}} (Val:SortInt{}, inj{SortInt{}, SortExp8{}} (Val:SortInt{})), \exists{SortExp8{}} (Val:SortMInt{Sort8{}}, inj{SortMInt{Sort8{}}, SortExp8{}} (Val:SortMInt{Sort8{}})), \bottom{SortExp8{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortFloat{}} (\top{SortFloat{}}(), \bottom{SortFloat{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCellOpt{}} (LblnoGeneratedCounterCell{}(), \exists{SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{})), \bottom{SortGeneratedCounterCellOpt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCell{}} (\exists{SortGeneratedTopCell{}} (X0:SortKCell{}, \exists{SortGeneratedTopCell{}} (X1:SortGeneratedCounterCell{}, Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}))), \bottom{SortGeneratedTopCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCellFragment{}} (\exists{SortGeneratedTopCellFragment{}} (X0:SortKCellOpt{}, \exists{SortGeneratedTopCellFragment{}} (X1:SortGeneratedCounterCellOpt{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortGeneratedCounterCellOpt{}))), \bottom{SortGeneratedTopCellFragment{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EACCES{}(), Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EAFNOSUPPORT{}(), Lbl'Hash'EAGAIN{}(), Lbl'Hash'EALREADY{}(), Lbl'Hash'EBADF{}(), Lbl'Hash'EBUSY{}(), Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDEADLK{}(), Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EDOM{}(), Lbl'Hash'EEXIST{}(), Lbl'Hash'EFAULT{}(), Lbl'Hash'EFBIG{}(), Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EINTR{}(), Lbl'Hash'EINVAL{}(), Lbl'Hash'EIO{}(), Lbl'Hash'EISCONN{}(), Lbl'Hash'EISDIR{}(), Lbl'Hash'ELOOP{}(), Lbl'Hash'EMFILE{}(), Lbl'Hash'EMLINK{}(), Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTCONN{}(), Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOTTY{}(), Lbl'Hash'ENXIO{}(), Lbl'Hash'EOF{}(), Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPERM{}(), Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPIPE{}(), Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ERANGE{}(), Lbl'Hash'EROFS{}(), Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESPIPE{}(), Lbl'Hash'ESRCH{}(), Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EXDEV{}(), \exists{SortIOError{}} (X0:SortInt{}, Lbl'Hash'unknownIOError{}(X0:SortInt{})), \bottom{SortIOError{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOFile{}} (\exists{SortIOFile{}} (X0:SortString{}, \exists{SortIOFile{}} (X1:SortInt{}, Lbl'Hash'tempFile{}(X0:SortString{}, X1:SortInt{}))), \exists{SortIOFile{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOFile{}} (Val:SortIOError{})), \bottom{SortIOFile{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOInt{}} (\exists{SortIOInt{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOInt{}} (Val:SortIOError{})), \exists{SortIOInt{}} (Val:SortInt{}, inj{SortInt{}, SortIOInt{}} (Val:SortInt{})), \bottom{SortIOInt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOString{}} (\exists{SortIOString{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOString{}} (Val:SortIOError{})), \exists{SortIOString{}} (Val:SortString{}, inj{SortString{}, SortIOString{}} (Val:SortString{})), \bottom{SortIOString{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortId{}} (\top{SortId{}}(), \bottom{SortId{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKCellOpt{}} (LblnoKCell{}(), \exists{SortKCellOpt{}} (Val:SortKCell{}, inj{SortKCell{}, SortKCellOpt{}} (Val:SortKCell{})), \bottom{SortKCellOpt{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(X0:SortK{}, X1:SortK{}))), \exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(X0:SortK{}, X1:SortK{}))), \exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(X0:SortK{}, X1:SortK{}))), \exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(X0:SortK{}, X1:SortK{}))), \exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(X0:SortK{}, X1:SortK{}))), \exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(X0:SortK{}, X1:SortK{}))), \exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(X0:SortK{}, X1:SortK{}))), \exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(X0:SortK{}, X1:SortK{}))), \exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(X0:SortK{}, X1:SortK{}))), \exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(X0:SortK{}, X1:SortK{}))), \exists{SortKItem{}} (X0:SortInt{}, \exists{SortKItem{}} (X1:SortString{}, \exists{SortKItem{}} (X2:SortString{}, Lbl'Hash'systemResult{}(X0:SortInt{}, X1:SortString{}, X2:SortString{})))), \exists{SortKItem{}} (X0:SortExp{}, \exists{SortKItem{}} (X1:SortExp{}, \exists{SortKItem{}} (X2:SortInt{}, Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(X0:SortExp{}, X1:SortExp{}, X2:SortInt{})))), \exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \exists{SortKItem{}} (Val:SortExp{}, inj{SortExp{}, SortKItem{}} (Val:SortExp{})), \exists{SortKItem{}} (Val:SortExp160{}, inj{SortExp160{}, SortKItem{}} (Val:SortExp160{})), \exists{SortKItem{}} (Val:SortExp256{}, inj{SortExp256{}, SortKItem{}} (Val:SortExp256{})), \exists{SortKItem{}} (Val:SortExp32{}, inj{SortExp32{}, SortKItem{}} (Val:SortExp32{})), \exists{SortKItem{}} (Val:SortExp64{}, inj{SortExp64{}, SortKItem{}} (Val:SortExp64{})), \exists{SortKItem{}} (Val:SortExp8{}, inj{SortExp8{}, SortKItem{}} (Val:SortExp8{})), \exists{SortKItem{}} (Val:SortFloat{}, inj{SortFloat{}, SortKItem{}} (Val:SortFloat{})), \exists{SortKItem{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (Val:SortGeneratedCounterCell{})), \exists{SortKItem{}} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (Val:SortGeneratedCounterCellOpt{})), \exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \exists{SortKItem{}} (Val:SortIOError{}, inj{SortIOError{}, SortKItem{}} (Val:SortIOError{})), \exists{SortKItem{}} (Val:SortIOFile{}, inj{SortIOFile{}, SortKItem{}} (Val:SortIOFile{})), \exists{SortKItem{}} (Val:SortIOInt{}, inj{SortIOInt{}, SortKItem{}} (Val:SortIOInt{})), \exists{SortKItem{}} (Val:SortIOString{}, inj{SortIOString{}, SortKItem{}} (Val:SortIOString{})), \exists{SortKItem{}} (Val:SortId{}, inj{SortId{}, SortKItem{}} (Val:SortId{})), \exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \exists{SortKItem{}} (Val:SortKConfigVar{}, inj{SortKConfigVar{}, SortKItem{}} (Val:SortKConfigVar{})), \exists{SortKItem{}} (Val:SortKResult{}, inj{SortKResult{}, SortKItem{}} (Val:SortKResult{})), \exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \exists{SortKItem{}} (Val:SortMInt{Sort160{}}, inj{SortMInt{Sort160{}}, SortKItem{}} (Val:SortMInt{Sort160{}})), \exists{SortKItem{}} (Val:SortMInt{Sort256{}}, inj{SortMInt{Sort256{}}, SortKItem{}} (Val:SortMInt{Sort256{}})), \exists{SortKItem{}} (Val:SortMInt{Sort32{}}, inj{SortMInt{Sort32{}}, SortKItem{}} (Val:SortMInt{Sort32{}})), \exists{SortKItem{}} (Val:SortMInt{Sort64{}}, inj{SortMInt{Sort64{}}, SortKItem{}} (Val:SortMInt{Sort64{}})), \exists{SortKItem{}} (Val:SortMInt{Sort8{}}, inj{SortMInt{Sort8{}}, SortKItem{}} (Val:SortMInt{Sort8{}})), \exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \exists{SortKItem{}} (Val:SortStream{}, inj{SortStream{}, SortKItem{}} (Val:SortStream{})), \exists{SortKItem{}} (Val:SortString{}, inj{SortString{}, SortKItem{}} (Val:SortString{})), \bottom{SortKItem{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKResult{}} (\exists{SortKResult{}} (Val:SortMInt{Sort160{}}, inj{SortMInt{Sort160{}}, SortKResult{}} (Val:SortMInt{Sort160{}})), \exists{SortKResult{}} (Val:SortMInt{Sort256{}}, inj{SortMInt{Sort256{}}, SortKResult{}} (Val:SortMInt{Sort256{}})), \exists{SortKResult{}} (Val:SortMInt{Sort32{}}, inj{SortMInt{Sort32{}}, SortKResult{}} (Val:SortMInt{Sort32{}})), \exists{SortKResult{}} (Val:SortMInt{Sort64{}}, inj{SortMInt{Sort64{}}, SortKResult{}} (Val:SortMInt{Sort64{}})), \exists{SortKResult{}} (Val:SortMInt{Sort8{}}, inj{SortMInt{Sort8{}}, SortKResult{}} (Val:SortMInt{Sort8{}})), \bottom{SortKResult{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortMInt{Sort160{}}} (\top{SortMInt{Sort160{}}}(), \bottom{SortMInt{Sort160{}}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortMInt{Sort256{}}} (\top{SortMInt{Sort256{}}}(), \bottom{SortMInt{Sort256{}}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortMInt{Sort32{}}} (\top{SortMInt{Sort32{}}}(), \bottom{SortMInt{Sort32{}}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortMInt{Sort64{}}} (\top{SortMInt{Sort64{}}}(), \bottom{SortMInt{Sort64{}}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortMInt{Sort8{}}} (\top{SortMInt{Sort8{}}}(), \bottom{SortMInt{Sort8{}}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortStream{}} (\exists{SortStream{}} (X0:SortK{}, Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{})), \exists{SortStream{}} (X0:SortInt{}, Lbl'Hash'istream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{})), \exists{SortStream{}} (X0:SortInt{}, Lbl'Hash'ostream'LParUndsRParUnds'K-IO'Unds'Stream'Unds'Int{}(X0:SortInt{})), \exists{SortStream{}} (X0:SortString{}, \exists{SortStream{}} (X1:SortString{}, Lbl'Hash'parseInput'LParUndsCommUndsRParUnds'K-IO'Unds'Stream'Unds'String'Unds'String{}(X0:SortString{}, X1:SortString{}))), \bottom{SortStream{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortString{}} (\top{SortString{}}(), \bottom{SortString{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+
+// rules
+// rule `#open(_)_K-IO_IOInt_String`(S)=>`#open(_,_)_K-IO_IOInt_String_String`(S,#token("\"r+\"","String")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7ad2779cd54b9009119458217cae5138026cc4ff244e54c28e64db21100f63d9), org.kframework.attributes.Location(Location(2493,8,2493,48)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS:SortString{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOInt{},R} (
+      Lbl'Hash'open'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'String{}(X0:SortString{}),
+     \and{SortIOInt{}} (
+       Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'Unds'IOInt'Unds'String'Unds'String{}(VarS:SortString{},\dv{SortString{}}("r+")),
+        \top{SortIOInt{}}())))
+  [UNIQUE'Unds'ID{}("7ad2779cd54b9009119458217cae5138026cc4ff244e54c28e64db21100f63d9"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2493,8,2493,48)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `#stderr_K-IO_Int`(.KList)=>#token("2","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(75e0a8082acda4cf1e29caa6aaafb7f9a421e16421a41f2006943d6fab17a162), org.kframework.attributes.Location(Location(2590,8,2590,20)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortInt{},R} (
+      Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}(),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("2"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("75e0a8082acda4cf1e29caa6aaafb7f9a421e16421a41f2006943d6fab17a162"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2590,8,2590,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `#stdin_K-IO_Int`(.KList)=>#token("0","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c7ffdc9908c28a954521816d680f4e5ec44a679c7231a8dd09d4700f50b6d8c3), org.kframework.attributes.Location(Location(2588,8,2588,19)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortInt{},R} (
+      Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}(),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("0"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("c7ffdc9908c28a954521816d680f4e5ec44a679c7231a8dd09d4700f50b6d8c3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2588,8,2588,19)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `#stdout_K-IO_Int`(.KList)=>#token("1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4ad4f379ff9db687ff9dfd1b15052edbcd3342a2ed262ecdd38c769e177a592c), org.kframework.attributes.Location(Location(2589,8,2589,20)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortInt{},R} (
+      Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}(),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("1"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("4ad4f379ff9db687ff9dfd1b15052edbcd3342a2ed262ecdd38c769e177a592c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2589,8,2589,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(_Gen0,inj{Exp160,Exp}(HOLE),W)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt160(_)_MINT-ARITH_Exp_Exp160`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int1_4`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(`_==Int_`(W,#token("160","Int")),`notBool_`(isKResult(inj{Exp160,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(09d25887da8a40d1dcaf93a632911615f2377ae52910bdfccce3bc9d51a675a2), heat, org.kframework.attributes.Location(Location(31,11,31,88)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Var'Unds'Gen0:SortExp{},inj{SortExp160{}, SortExp{}}(VarHOLE:SortExp160{}),VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarW:SortInt{},\dv{SortInt{}}("160")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp160{}, SortKItem{}}(VarHOLE:SortExp160{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(VarHOLE:SortExp160{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("09d25887da8a40d1dcaf93a632911615f2377ae52910bdfccce3bc9d51a675a2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,11,31,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(_Gen0,inj{Exp256,Exp}(HOLE),W)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt256(_)_MINT-ARITH_Exp_Exp256`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int1_3`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(`_==Int_`(W,#token("256","Int")),`notBool_`(isKResult(inj{Exp256,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(bce14073a40e5a5a315e6edf3ff66d1e4e982262ff40d01adaad6bc9fe548b2e), heat, org.kframework.attributes.Location(Location(33,11,33,88)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Var'Unds'Gen0:SortExp{},inj{SortExp256{}, SortExp{}}(VarHOLE:SortExp256{}),VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarW:SortInt{},\dv{SortInt{}}("256")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp256{}, SortKItem{}}(VarHOLE:SortExp256{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(VarHOLE:SortExp256{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("bce14073a40e5a5a315e6edf3ff66d1e4e982262ff40d01adaad6bc9fe548b2e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(33,11,33,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(_Gen0,inj{Exp32,Exp}(HOLE),W)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt32(_)_MINT-ARITH_Exp_Exp32`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int1_`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(`_==Int_`(W,#token("32","Int")),`notBool_`(isKResult(inj{Exp32,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(97fd7b2cc2186ef9b10cb36924d88810da0db533bddbd54d4c35120b73ffcf67), heat, org.kframework.attributes.Location(Location(27,11,27,87)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Var'Unds'Gen0:SortExp{},inj{SortExp32{}, SortExp{}}(VarHOLE:SortExp32{}),VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarW:SortInt{},\dv{SortInt{}}("32")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp32{}, SortKItem{}}(VarHOLE:SortExp32{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(VarHOLE:SortExp32{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("97fd7b2cc2186ef9b10cb36924d88810da0db533bddbd54d4c35120b73ffcf67"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(27,11,27,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(_Gen0,inj{Exp64,Exp}(HOLE),W)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt64(_)_MINT-ARITH_Exp_Exp64`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int1_5`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(`_==Int_`(W,#token("64","Int")),`notBool_`(isKResult(inj{Exp64,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(f736484d9315a814ebd05abb75e8934d4ad0eb385a5ce6507f009cca1f903224), heat, org.kframework.attributes.Location(Location(29,11,29,87)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Var'Unds'Gen0:SortExp{},inj{SortExp64{}, SortExp{}}(VarHOLE:SortExp64{}),VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarW:SortInt{},\dv{SortInt{}}("64")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp64{}, SortKItem{}}(VarHOLE:SortExp64{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(VarHOLE:SortExp64{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("f736484d9315a814ebd05abb75e8934d4ad0eb385a5ce6507f009cca1f903224"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(29,11,29,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(_Gen0,inj{Exp8,Exp}(HOLE),W)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt8(_)_MINT-ARITH_Exp_Exp8`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int1_2`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(`_==Int_`(W,#token("8","Int")),`notBool_`(isKResult(inj{Exp8,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(b534677ba5c4d945a6418b32492a92e7991ce36e8d828ad01ec7a57c43793270), heat, org.kframework.attributes.Location(Location(25,11,25,86)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Var'Unds'Gen0:SortExp{},inj{SortExp8{}, SortExp{}}(VarHOLE:SortExp8{}),VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarW:SortInt{},\dv{SortInt{}}("8")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp8{}, SortKItem{}}(VarHOLE:SortExp8{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(VarHOLE:SortExp8{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("b534677ba5c4d945a6418b32492a92e7991ce36e8d828ad01ec7a57c43793270"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(25,11,25,86)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{Exp160,Exp}(HOLE),_Gen0,W)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt160(_)_MINT-ARITH_Exp_Exp160`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int0_4`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(`_==Int_`(W,#token("160","Int")),`notBool_`(isKResult(inj{Exp160,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(f73cc04a07231377323b1dc4f24392640ab925dfa0676d4534c16b07eb1089ea), heat, org.kframework.attributes.Location(Location(30,11,30,88)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortExp160{}, SortExp{}}(VarHOLE:SortExp160{}),Var'Unds'Gen0:SortExp{},VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarW:SortInt{},\dv{SortInt{}}("160")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp160{}, SortKItem{}}(VarHOLE:SortExp160{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(VarHOLE:SortExp160{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("f73cc04a07231377323b1dc4f24392640ab925dfa0676d4534c16b07eb1089ea"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,11,30,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{Exp256,Exp}(HOLE),_Gen0,W)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt256(_)_MINT-ARITH_Exp_Exp256`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int0_2`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(`_==Int_`(W,#token("256","Int")),`notBool_`(isKResult(inj{Exp256,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(731d4e1af32ec6a298da063326050f2228767f69971e7abcf324d2e918a397cc), heat, org.kframework.attributes.Location(Location(32,11,32,88)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortExp256{}, SortExp{}}(VarHOLE:SortExp256{}),Var'Unds'Gen0:SortExp{},VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarW:SortInt{},\dv{SortInt{}}("256")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp256{}, SortKItem{}}(VarHOLE:SortExp256{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(VarHOLE:SortExp256{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("731d4e1af32ec6a298da063326050f2228767f69971e7abcf324d2e918a397cc"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(32,11,32,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{Exp32,Exp}(HOLE),_Gen0,W)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt32(_)_MINT-ARITH_Exp_Exp32`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int0_`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(`_==Int_`(W,#token("32","Int")),`notBool_`(isKResult(inj{Exp32,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(b1ea4488f18a465d281cecfe5b3e88a16a8c99f495d171c6e1e1a944ee6fc311), heat, org.kframework.attributes.Location(Location(26,11,26,87)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortExp32{}, SortExp{}}(VarHOLE:SortExp32{}),Var'Unds'Gen0:SortExp{},VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarW:SortInt{},\dv{SortInt{}}("32")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp32{}, SortKItem{}}(VarHOLE:SortExp32{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(VarHOLE:SortExp32{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("b1ea4488f18a465d281cecfe5b3e88a16a8c99f495d171c6e1e1a944ee6fc311"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(26,11,26,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{Exp64,Exp}(HOLE),_Gen0,W)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt64(_)_MINT-ARITH_Exp_Exp64`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int0_3`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(`_==Int_`(W,#token("64","Int")),`notBool_`(isKResult(inj{Exp64,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(714a3d8a6c9fae7cfd34870f2af00e4774897891708688dd8d4acbf63fd07b5b), heat, org.kframework.attributes.Location(Location(28,11,28,87)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortExp64{}, SortExp{}}(VarHOLE:SortExp64{}),Var'Unds'Gen0:SortExp{},VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarW:SortInt{},\dv{SortInt{}}("64")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp64{}, SortKItem{}}(VarHOLE:SortExp64{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(VarHOLE:SortExp64{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("714a3d8a6c9fae7cfd34870f2af00e4774897891708688dd8d4acbf63fd07b5b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(28,11,28,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{Exp8,Exp}(HOLE),_Gen0,W)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt8(_)_MINT-ARITH_Exp_Exp8`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int0_5`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0) requires `_andBool_`(`_==Int_`(W,#token("8","Int")),`notBool_`(isKResult(inj{Exp8,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(1cf98b0cf66682448c02bea900df02096258548a5423300a576ca594d0e517eb), heat, org.kframework.attributes.Location(Location(24,11,24,86)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortExp8{}, SortExp{}}(VarHOLE:SortExp8{}),Var'Unds'Gen0:SortExp{},VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarW:SortInt{},\dv{SortInt{}}("8")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp8{}, SortKItem{}}(VarHOLE:SortExp8{}),dotk{}())))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(VarHOLE:SortExp8{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("1cf98b0cf66682448c02bea900df02096258548a5423300a576ca594d0e517eb"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(24,11,24,86)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{MInt,Exp}(A),inj{MInt,Exp}(B),_Gen0)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{MInt,KItem}(`_+MInt__MINT_MInt_MInt_MInt`{160}(A,B))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ed3d5f22406dc6b525e2fffa289a5f4bfc3dcaed5063b833b29d1e3b3319e6f2), org.kframework.attributes.Location(Location(38,8,38,53)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortMInt{Sort160{}}, SortExp{}}(VarA:SortMInt{Sort160{}}),inj{SortMInt{Sort160{}}, SortExp{}}(VarB:SortMInt{Sort160{}}),Var'Unds'Gen0:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortMInt{Sort160{}}, SortKItem{}}(Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{Sort160{}}(VarA:SortMInt{Sort160{}},VarB:SortMInt{Sort160{}})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("ed3d5f22406dc6b525e2fffa289a5f4bfc3dcaed5063b833b29d1e3b3319e6f2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(38,8,38,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{MInt,Exp}(A),inj{MInt,Exp}(B),_Gen0)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{MInt,KItem}(`_+MInt__MINT_MInt_MInt_MInt`{256}(A,B))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e84c3b1a648168730b78b29c47c457924fc9a7ac40a00fbaa0f018f498b9e2d5), org.kframework.attributes.Location(Location(39,8,39,53)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortMInt{Sort256{}}, SortExp{}}(VarA:SortMInt{Sort256{}}),inj{SortMInt{Sort256{}}, SortExp{}}(VarB:SortMInt{Sort256{}}),Var'Unds'Gen0:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortMInt{Sort256{}}, SortKItem{}}(Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{Sort256{}}(VarA:SortMInt{Sort256{}},VarB:SortMInt{Sort256{}})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("e84c3b1a648168730b78b29c47c457924fc9a7ac40a00fbaa0f018f498b9e2d5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(39,8,39,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{MInt,Exp}(A),inj{MInt,Exp}(B),_Gen0)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{MInt,KItem}(`_+MInt__MINT_MInt_MInt_MInt`{32}(A,B))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(11f6293f4b0d1101575cf8d6f04b06f15ad1b5a00d12345101603f9659cb66c3), org.kframework.attributes.Location(Location(36,8,36,53)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortMInt{Sort32{}}, SortExp{}}(VarA:SortMInt{Sort32{}}),inj{SortMInt{Sort32{}}, SortExp{}}(VarB:SortMInt{Sort32{}}),Var'Unds'Gen0:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortMInt{Sort32{}}, SortKItem{}}(Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{Sort32{}}(VarA:SortMInt{Sort32{}},VarB:SortMInt{Sort32{}})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("11f6293f4b0d1101575cf8d6f04b06f15ad1b5a00d12345101603f9659cb66c3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(36,8,36,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{MInt,Exp}(A),inj{MInt,Exp}(B),_Gen0)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{MInt,KItem}(`_+MInt__MINT_MInt_MInt_MInt`{64}(A,B))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(da0c5b341d2c4fadba6a3468d14e6cb30b18b2ca51e96acf9e54552c9d2db06b), org.kframework.attributes.Location(Location(37,8,37,53)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortMInt{Sort64{}}, SortExp{}}(VarA:SortMInt{Sort64{}}),inj{SortMInt{Sort64{}}, SortExp{}}(VarB:SortMInt{Sort64{}}),Var'Unds'Gen0:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortMInt{Sort64{}}, SortKItem{}}(Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{Sort64{}}(VarA:SortMInt{Sort64{}},VarB:SortMInt{Sort64{}})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("da0c5b341d2c4fadba6a3468d14e6cb30b18b2ca51e96acf9e54552c9d2db06b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(37,8,37,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{MInt,Exp}(A),inj{MInt,Exp}(B),_Gen0)~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{MInt,KItem}(`_+MInt__MINT_MInt_MInt_MInt`{8}(A,B))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd4ea1933d366cf74b149d8e4a6700a264f495c1f1b98676c3d31d563030c972), org.kframework.attributes.Location(Location(35,8,35,53)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortMInt{Sort8{}}, SortExp{}}(VarA:SortMInt{Sort8{}}),inj{SortMInt{Sort8{}}, SortExp{}}(VarB:SortMInt{Sort8{}}),Var'Unds'Gen0:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortMInt{Sort8{}}, SortKItem{}}(Lbl'UndsPlus'MInt'UndsUnds'MINT'Unds'MInt'Unds'MInt'Unds'MInt{Sort8{}}(VarA:SortMInt{Sort8{}},VarB:SortMInt{Sort8{}})),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("fd4ea1933d366cf74b149d8e4a6700a264f495c1f1b98676c3d31d563030c972"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(35,8,35,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt160(_)_MINT-ARITH_Exp_Exp160`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int0_4`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{Exp160,Exp}(HOLE),_Gen0,W)~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(inj{Exp160,KItem}(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(87996af00dbebcf292d9d74e01cfce1b37b1f5ecc7549f43665e93e546a1263e), cool, org.kframework.attributes.Location(Location(30,11,30,88)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(VarHOLE:SortExp160{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'4{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(inj{SortExp160{}, SortKItem{}}(VarHOLE:SortExp160{}),dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortExp160{}, SortExp{}}(VarHOLE:SortExp160{}),Var'Unds'Gen0:SortExp{},VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("87996af00dbebcf292d9d74e01cfce1b37b1f5ecc7549f43665e93e546a1263e"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,11,30,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt160(_)_MINT-ARITH_Exp_Exp160`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int1_4`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(_Gen0,inj{Exp160,Exp}(HOLE),W)~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(inj{Exp160,KItem}(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(87e6c57a8ea10dc80b0165b332cd0eef7903871fb70c2192f08ede1b72e11eed), cool, org.kframework.attributes.Location(Location(31,11,31,88)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(VarHOLE:SortExp160{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'4{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(inj{SortExp160{}, SortKItem{}}(VarHOLE:SortExp160{}),dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Var'Unds'Gen0:SortExp{},inj{SortExp160{}, SortExp{}}(VarHOLE:SortExp160{}),VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("87e6c57a8ea10dc80b0165b332cd0eef7903871fb70c2192f08ede1b72e11eed"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,11,31,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt160(_)_MINT-ARITH_Exp_Exp160`(inj{Int,Exp160}(I)))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt160(_)_MINT-ARITH_Exp_Exp160`(inj{MInt,Exp160}(`Int2MInt(_)_MINT_MInt_Int`{160}(I))))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(6392d970768e3bba154ded3b14bd2ad89ed094efc20a116be8c3811c636d5f1c), org.kframework.attributes.Location(Location(55,8,55,39)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(inj{SortInt{}, SortExp160{}}(VarI:SortInt{}))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt160'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp160{}(inj{SortMInt{Sort160{}}, SortExp160{}}(LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort160{}}(VarI:SortInt{})))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("6392d970768e3bba154ded3b14bd2ad89ed094efc20a116be8c3811c636d5f1c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(55,8,55,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt256(_)_MINT-ARITH_Exp_Exp256`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int0_2`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{Exp256,Exp}(HOLE),_Gen0,W)~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(inj{Exp256,KItem}(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(bdebe6610b3d9b39c2c06aeafe17a1f156544a976197bdc2d9cee28d53d3000f), cool, org.kframework.attributes.Location(Location(32,11,32,88)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(VarHOLE:SortExp256{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'2{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(inj{SortExp256{}, SortKItem{}}(VarHOLE:SortExp256{}),dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortExp256{}, SortExp{}}(VarHOLE:SortExp256{}),Var'Unds'Gen0:SortExp{},VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("bdebe6610b3d9b39c2c06aeafe17a1f156544a976197bdc2d9cee28d53d3000f"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(32,11,32,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt256(_)_MINT-ARITH_Exp_Exp256`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int1_3`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(_Gen0,inj{Exp256,Exp}(HOLE),W)~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(inj{Exp256,KItem}(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(297cd6a5d7a54fcbf908b11e1f5f42df3668c37dd2b0028bc098ddbfaa4b663d), cool, org.kframework.attributes.Location(Location(33,11,33,88)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(VarHOLE:SortExp256{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'3{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(inj{SortExp256{}, SortKItem{}}(VarHOLE:SortExp256{}),dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Var'Unds'Gen0:SortExp{},inj{SortExp256{}, SortExp{}}(VarHOLE:SortExp256{}),VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("297cd6a5d7a54fcbf908b11e1f5f42df3668c37dd2b0028bc098ddbfaa4b663d"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(33,11,33,88)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt256(_)_MINT-ARITH_Exp_Exp256`(inj{Int,Exp256}(I)))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt256(_)_MINT-ARITH_Exp_Exp256`(inj{MInt,Exp256}(`Int2MInt(_)_MINT_MInt_Int`{256}(I))))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7876eb6579f71fb31a40d4f034e5020e8ff4fb49f7740aabaf487818e905923f), org.kframework.attributes.Location(Location(59,8,59,39)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(inj{SortInt{}, SortExp256{}}(VarI:SortInt{}))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt256'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp256{}(inj{SortMInt{Sort256{}}, SortExp256{}}(LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort256{}}(VarI:SortInt{})))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("7876eb6579f71fb31a40d4f034e5020e8ff4fb49f7740aabaf487818e905923f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(59,8,59,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt32(_)_MINT-ARITH_Exp_Exp32`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int0_`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{Exp32,Exp}(HOLE),_Gen0,W)~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(inj{Exp32,KItem}(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(7e7f995724a4d6e5368a95519176f501a8a60b05922107ad26c8bbb4a354c247), cool, org.kframework.attributes.Location(Location(26,11,26,87)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(VarHOLE:SortExp32{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(inj{SortExp32{}, SortKItem{}}(VarHOLE:SortExp32{}),dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortExp32{}, SortExp{}}(VarHOLE:SortExp32{}),Var'Unds'Gen0:SortExp{},VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("7e7f995724a4d6e5368a95519176f501a8a60b05922107ad26c8bbb4a354c247"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(26,11,26,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt32(_)_MINT-ARITH_Exp_Exp32`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int1_`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(_Gen0,inj{Exp32,Exp}(HOLE),W)~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(inj{Exp32,KItem}(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(29eb8fed02ebb8fd4c7e7b34188f78869c2d155145cf6401785342305e255a7f), cool, org.kframework.attributes.Location(Location(27,11,27,87)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(VarHOLE:SortExp32{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(inj{SortExp32{}, SortKItem{}}(VarHOLE:SortExp32{}),dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Var'Unds'Gen0:SortExp{},inj{SortExp32{}, SortExp{}}(VarHOLE:SortExp32{}),VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("29eb8fed02ebb8fd4c7e7b34188f78869c2d155145cf6401785342305e255a7f"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(27,11,27,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt32(_)_MINT-ARITH_Exp_Exp32`(inj{Int,Exp32}(I)))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt32(_)_MINT-ARITH_Exp_Exp32`(inj{MInt,Exp32}(`Int2MInt(_)_MINT_MInt_Int`{32}(I))))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c7a3f972b1b0a81c4edbc3417167beff8bc0757d4c96e3d2413191cc6c77d53e), org.kframework.attributes.Location(Location(47,8,47,38)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(inj{SortInt{}, SortExp32{}}(VarI:SortInt{}))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt32'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp32{}(inj{SortMInt{Sort32{}}, SortExp32{}}(LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort32{}}(VarI:SortInt{})))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("c7a3f972b1b0a81c4edbc3417167beff8bc0757d4c96e3d2413191cc6c77d53e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(47,8,47,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt64(_)_MINT-ARITH_Exp_Exp64`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int0_3`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{Exp64,Exp}(HOLE),_Gen0,W)~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(inj{Exp64,KItem}(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(0a65a285d1a044f7495726b08df82bd8d71c618824c1465f6a5fe3024a340268), cool, org.kframework.attributes.Location(Location(28,11,28,87)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(VarHOLE:SortExp64{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'3{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(inj{SortExp64{}, SortKItem{}}(VarHOLE:SortExp64{}),dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortExp64{}, SortExp{}}(VarHOLE:SortExp64{}),Var'Unds'Gen0:SortExp{},VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("0a65a285d1a044f7495726b08df82bd8d71c618824c1465f6a5fe3024a340268"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(28,11,28,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt64(_)_MINT-ARITH_Exp_Exp64`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int1_5`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(_Gen0,inj{Exp64,Exp}(HOLE),W)~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(inj{Exp64,KItem}(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(40163f833eff8afbd5358875bde0bc40644642d3022b8272b9c659fdf11d7ada), cool, org.kframework.attributes.Location(Location(29,11,29,87)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(VarHOLE:SortExp64{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'5{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(inj{SortExp64{}, SortKItem{}}(VarHOLE:SortExp64{}),dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Var'Unds'Gen0:SortExp{},inj{SortExp64{}, SortExp{}}(VarHOLE:SortExp64{}),VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("40163f833eff8afbd5358875bde0bc40644642d3022b8272b9c659fdf11d7ada"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(29,11,29,87)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt64(_)_MINT-ARITH_Exp_Exp64`(inj{Int,Exp64}(I)))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt64(_)_MINT-ARITH_Exp_Exp64`(inj{MInt,Exp64}(`Int2MInt(_)_MINT_MInt_Int`{64}(I))))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c7c7d987103f1ab7cae1ed9eac15ba33266f2247aab4e02a37239cd5f240ecea), org.kframework.attributes.Location(Location(51,8,51,38)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(inj{SortInt{}, SortExp64{}}(VarI:SortInt{}))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt64'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp64{}(inj{SortMInt{Sort64{}}, SortExp64{}}(LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort64{}}(VarI:SortInt{})))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("c7c7d987103f1ab7cae1ed9eac15ba33266f2247aab4e02a37239cd5f240ecea"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(51,8,51,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt8(_)_MINT-ARITH_Exp_Exp8`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int0_5`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(inj{Exp8,Exp}(HOLE),_Gen0,W)~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(inj{Exp8,KItem}(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(d1569d3715240375ecdcfaa6c2752c1daeb999de0da4e1a3b2f5712bba61c734), cool, org.kframework.attributes.Location(Location(24,11,24,86)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(VarHOLE:SortExp8{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int0'Unds'5{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(inj{SortExp8{}, SortKItem{}}(VarHOLE:SortExp8{}),dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(inj{SortExp8{}, SortExp{}}(VarHOLE:SortExp8{}),Var'Unds'Gen0:SortExp{},VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("d1569d3715240375ecdcfaa6c2752c1daeb999de0da4e1a3b2f5712bba61c734"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(24,11,24,86)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt8(_)_MINT-ARITH_Exp_Exp8`(HOLE))~>`#freezeradd(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int1_2`(inj{Int,KItem}(W),inj{Exp,KItem}(_Gen0))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(`add(_,_,_)_MINT-ARITH-SYNTAX_KItem_Exp_Exp_Int`(_Gen0,inj{Exp8,Exp}(HOLE),W)~>_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(inj{Exp8,KItem}(HOLE))) ensures #token("true","Bool") [UNIQUE_ID(ed84576c68217cbf04218cb6f585c05267b95790c1cfebe338daa5478deed206), cool, org.kframework.attributes.Location(Location(25,11,25,86)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(VarHOLE:SortExp8{})),kseq{}(Lbl'Hash'freezeradd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int1'Unds'2{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarW:SortInt{}),dotk{}()),kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen0:SortExp{}),dotk{}())),Var'Unds'DotVar1:SortK{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(inj{SortExp8{}, SortKItem{}}(VarHOLE:SortExp8{}),dotk{}()))),
+        \dv{SortBool{}}("true"))),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbladd'LParUndsCommUndsCommUndsRParUnds'MINT-ARITH-SYNTAX'Unds'KItem'Unds'Exp'Unds'Exp'Unds'Int{}(Var'Unds'Gen0:SortExp{},inj{SortExp8{}, SortExp{}}(VarHOLE:SortExp8{}),VarW:SortInt{}),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("ed84576c68217cbf04218cb6f585c05267b95790c1cfebe338daa5478deed206"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(25,11,25,86)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt8(_)_MINT-ARITH_Exp_Exp8`(inj{Int,Exp8}(I)))~>_DotVar1),_DotVar0)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`toMInt8(_)_MINT-ARITH_Exp_Exp8`(inj{MInt,Exp8}(`Int2MInt(_)_MINT_MInt_Int`{8}(I))))~>_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3a0732cf05a09096af5344c795ba074d3733132f81c863d3e7992f4262d31bcf), org.kframework.attributes.Location(Location(43,8,43,37)), org.kframework.attributes.Source(Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+        Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(inj{SortInt{}, SortExp8{}}(VarI:SortInt{}))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}),
+        \top{SortGeneratedTopCell{}}()),
+      \and{SortGeneratedTopCell{}} (
+      Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(LbltoMInt8'LParUndsRParUnds'MINT-ARITH'Unds'Exp'Unds'Exp8{}(inj{SortMInt{Sort8{}}, SortExp8{}}(LblInt2MInt'LParUndsRParUnds'MINT'Unds'MInt'Unds'Int{Sort8{}}(VarI:SortInt{})))),Var'Unds'DotVar1:SortK{})),Var'Unds'DotVar0:SortGeneratedCounterCell{}), \top{SortGeneratedTopCell{}}()))
+  [UNIQUE'Unds'ID{}("3a0732cf05a09096af5344c795ba074d3733132f81c863d3e7992f4262d31bcf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(43,8,43,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
+
+// rule `Bool2String(_)_STRING-COMMON_String_Bool`(#token("false","Bool"))=>#token("\"false\"","String") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cca4780e4e7660055f781b9643f3125234a0f4f08ba76cacf8e5a18fe7fc999f), org.kframework.attributes.Location(Location(1777,8,1777,37)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(X0:SortBool{}),
+     \and{SortString{}} (
+       \dv{SortString{}}("false"),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("cca4780e4e7660055f781b9643f3125234a0f4f08ba76cacf8e5a18fe7fc999f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1777,8,1777,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `Bool2String(_)_STRING-COMMON_String_Bool`(#token("true","Bool"))=>#token("\"true\"","String") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(365df37345a5a44ac061f8741369c7bd74a49f0f6e7b716be0374806dd1add3d), org.kframework.attributes.Location(Location(1776,8,1776,36)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(X0:SortBool{}),
+     \and{SortString{}} (
+       \dv{SortString{}}("true"),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("365df37345a5a44ac061f8741369c7bd74a49f0f6e7b716be0374806dd1add3d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1776,8,1776,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `String2Bool(_)_STRING-COMMON_Bool_String`(#token("\"false\"","String"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b73b5c8e0ae45020f2b9b8170d366691fee01a63763b79653a2075703ec4e835), org.kframework.attributes.Location(Location(1783,8,1783,37)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            \dv{SortString{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(X0:SortString{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b73b5c8e0ae45020f2b9b8170d366691fee01a63763b79653a2075703ec4e835"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1783,8,1783,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `String2Bool(_)_STRING-COMMON_Bool_String`(#token("\"true\"","String"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(27a5d1d7872d61f82556a4e44bda13846dde7dc2d9c54304d7858de9a8b9d6b8), org.kframework.attributes.Location(Location(1782,8,1782,36)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            \dv{SortString{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(X0:SortString{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("27a5d1d7872d61f82556a4e44bda13846dde7dc2d9c54304d7858de9a8b9d6b8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1782,8,1782,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_<=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_<String__STRING-COMMON_Bool_String_String`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9e50fb4dcba1212ee863c170298cb8b555f39fb3b4bcb649f3d1d8e321accc80), org.kframework.attributes.Location(Location(1876,8,1876,63)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9e50fb4dcba1212ee863c170298cb8b555f39fb3b4bcb649f3d1d8e321accc80"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1876,8,1876,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_=/=Bool_`(B1,B2)=>`notBool_`(`_==Bool_`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f), org.kframework.attributes.Location(Location(1159,8,1159,57)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB1:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB2:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(VarB1:SortBool{},VarB2:SortBool{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1159,8,1159,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_=/=Int_`(I1,I2)=>`notBool_`(`_==Int_`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3), org.kframework.attributes.Location(Location(1442,8,1442,53)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Int'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1442,8,1442,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c), org.kframework.attributes.Location(Location(2322,8,2322,45)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarK2:SortK{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2322,8,2322,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_=/=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_==String__STRING-COMMON_Bool_String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f390a9b650f3de0e3a93773a46e65aae3decdeb2a10906058f204f031681c9b7), org.kframework.attributes.Location(Location(1856,8,1856,65)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f390a9b650f3de0e3a93773a46e65aae3decdeb2a10906058f204f031681c9b7"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1856,8,1856,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_>=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_<String__STRING-COMMON_Bool_String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b376ffb0925555ed27696d73fc8fe43306e2005e4cf6ad819e860958992f9f17), org.kframework.attributes.Location(Location(1878,8,1878,63)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{})),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b376ffb0925555ed27696d73fc8fe43306e2005e4cf6ad819e860958992f9f17"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1878,8,1878,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_>String__STRING-COMMON_Bool_String_String`(S1,S2)=>`_<String__STRING-COMMON_Bool_String_String`(S2,S1) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8e5353c0a58491f8613ad7a35d0833206c342df0c91773e42485e52f4dad0cd0), org.kframework.attributes.Location(Location(1877,8,1877,52)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortBool{}} (
+       Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{}),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("8e5353c0a58491f8613ad7a35d0833206c342df0c91773e42485e52f4dad0cd0"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1877,8,1877,52)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_andBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497), org.kframework.attributes.Location(Location(1132,8,1132,37)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1132,8,1132,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(72139ee1f2b9362a47514de6503329ccf3c27e74e3ebfa0c0fe26321ec13f281), org.kframework.attributes.Location(Location(1131,8,1131,37)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("72139ee1f2b9362a47514de6503329ccf3c27e74e3ebfa0c0fe26321ec13f281"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1131,8,1131,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_andBool_`(_Gen0,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd61c826168aab115cd7f528702e8187ca16195bdcf29f42f33a32c83afebb12), org.kframework.attributes.Location(Location(1133,8,1133,37)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fd61c826168aab115cd7f528702e8187ca16195bdcf29f42f33a32c83afebb12"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1133,8,1133,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f), org.kframework.attributes.Location(Location(1130,8,1130,37)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1130,8,1130,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_andThenBool_`(#token("false","Bool") #as _Gen1,_Gen0)=>_Gen1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d), org.kframework.attributes.Location(Location(1137,8,1137,36)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'Gen1:SortBool{})
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       Var'Unds'Gen1:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1137,8,1137,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_andThenBool_`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2cfb33affb9c668d39a4a7267156085e1dbd3584fc7925b1aa9a1672bb9eab9f), org.kframework.attributes.Location(Location(1136,8,1136,37)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(VarK:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2cfb33affb9c668d39a4a7267156085e1dbd3584fc7925b1aa9a1672bb9eab9f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1136,8,1136,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_andThenBool_`(_Gen0,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(198861009d03d8f5220000f16342962720be289ca0d49b12953fb2693e2fea01), org.kframework.attributes.Location(Location(1138,8,1138,36)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("198861009d03d8f5220000f16342962720be289ca0d49b12953fb2693e2fea01"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1138,8,1138,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_andThenBool_`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689), org.kframework.attributes.Location(Location(1135,8,1135,37)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1135,8,1135,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_divInt_`(I1,I2)=>`_/Int_`(`_-Int_`(I1,`_modInt_`(I1,I2)),I2) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4), org.kframework.attributes.Location(Location(1431,8,1432,23)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      Lbl'Unds'divInt'Unds'{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsSlsh'Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{}),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1431,8,1432,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_dividesInt__INT-COMMON_Bool_Int_Int`(I1,I2)=>`_==Int_`(`_%Int_`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5), org.kframework.attributes.Location(Location(1443,8,1443,58)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       Lbl'UndsEqlsEqls'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0")),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1443,8,1443,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_impliesBool_`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(93b8d798abd6d9999e0e733384ad161e9a0bd2f074623a742afdc63964380aba), org.kframework.attributes.Location(Location(1157,8,1157,45)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       LblnotBool'Unds'{}(VarB:SortBool{}),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("93b8d798abd6d9999e0e733384ad161e9a0bd2f074623a742afdc63964380aba"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1157,8,1157,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_impliesBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b4994db7b40b72dc09ac8d5d036263b215c37d45f45d764251d8b607a7592ba), org.kframework.attributes.Location(Location(1156,8,1156,39)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2b4994db7b40b72dc09ac8d5d036263b215c37d45f45d764251d8b607a7592ba"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1156,8,1156,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_impliesBool_`(#token("false","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e), org.kframework.attributes.Location(Location(1155,8,1155,40)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1155,8,1155,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_impliesBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d), org.kframework.attributes.Location(Location(1154,8,1154,36)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1154,8,1154,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_modInt_`(I1,I2)=>`_%Int_`(`_+Int_`(`_%Int_`(I1,`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(44257f63a99a0583c2d10058edbff90118966e30914b3a637b8315212c681bc4), concrete, org.kframework.attributes.Location(Location(1434,5,1437,23)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)]), simplification]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \equals{SortInt{},R} (
+      Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'UndsPerc'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("44257f63a99a0583c2d10058edbff90118966e30914b3a637b8315212c681bc4"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1434,5,1437,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a5bb27ab54700cb845d17b12e0b0a4cbd5c8944272bcbe0d15ccc0b44d0049ff), org.kframework.attributes.Location(Location(1147,8,1147,32)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a5bb27ab54700cb845d17b12e0b0a4cbd5c8944272bcbe0d15ccc0b44d0049ff"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1147,8,1147,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(942af273100b5a3c1fb3d0c8cc92b0bf845a7b34444c5a6c35b7d3fe72bef48e), org.kframework.attributes.Location(Location(1145,8,1145,34)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("942af273100b5a3c1fb3d0c8cc92b0bf845a7b34444c5a6c35b7d3fe72bef48e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1145,8,1145,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b), org.kframework.attributes.Location(Location(1146,8,1146,32)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1146,8,1146,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_orBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2), org.kframework.attributes.Location(Location(1144,8,1144,34)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1144,8,1144,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_orElseBool_`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(13cf42d440f9a7a360a8136ee4b35ae7b99501f515322d214c3b866691f4713b), org.kframework.attributes.Location(Location(1152,8,1152,37)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(VarK:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("13cf42d440f9a7a360a8136ee4b35ae7b99501f515322d214c3b866691f4713b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1152,8,1152,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orElseBool_`(_Gen0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2459cad4fbb946a5c7f71565601afeeec79f05f41497b1f7ef547578c88f3158), org.kframework.attributes.Location(Location(1150,8,1150,33)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(Var'Unds'Gen0:SortBool{},\dv{SortBool{}}("true")),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2459cad4fbb946a5c7f71565601afeeec79f05f41497b1f7ef547578c88f3158"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1150,8,1150,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_orElseBool_`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf), org.kframework.attributes.Location(Location(1151,8,1151,37)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1151,8,1151,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_orElseBool_`(#token("true","Bool"),_Gen0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6), org.kframework.attributes.Location(Location(1149,8,1149,33)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'Gen0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1149,8,1149,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_xorBool_`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f), org.kframework.attributes.Location(Location(1142,8,1142,38)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarB:SortBool{}
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1142,8,1142,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_xorBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(69f518203376930fb76ce51df5dd0c6c81d19f71eba3a1852afa5301d02eb4fa), org.kframework.attributes.Location(Location(1141,8,1141,38)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)]), simplification]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("69f518203376930fb76ce51df5dd0c6c81d19f71eba3a1852afa5301d02eb4fa"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1141,8,1141,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), simplification{}()]
+
+// rule `_xorBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf), org.kframework.attributes.Location(Location(1140,8,1140,38)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+     \and{SortBool{}} (
+       VarB:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1140,8,1140,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `_|Set__SET_Set_Set_Set`(S1,S2)=>`_Set_`(S1,`Set:difference`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c384edb8f3875244a593dda6163c3dee1bce5485e4e1848892aebc2bab67d2e9), concrete, org.kframework.attributes.Location(Location(749,8,749,45)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortSet{}, R} (
+            X0:SortSet{},
+            VarS1:SortSet{}
+          ),\and{R} (
+          \in{SortSet{}, R} (
+            X1:SortSet{},
+            VarS2:SortSet{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortSet{},R} (
+      Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(X0:SortSet{},X1:SortSet{}),
+     \and{SortSet{}} (
+       Lbl'Unds'Set'Unds'{}(VarS1:SortSet{},LblSet'Coln'difference{}(VarS2:SortSet{},VarS1:SortSet{})),
+        \top{SortSet{}}())))
+  [UNIQUE'Unds'ID{}("c384edb8f3875244a593dda6163c3dee1bce5485e4e1848892aebc2bab67d2e9"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(749,8,749,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_modInt_`(`_>>Int_`(I,IDX),`_<<Int_`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119), org.kframework.attributes.Location(Location(1427,8,1427,85)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'modInt'Unds'{}(Lbl'Unds-GT--GT-'Int'Unds'{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1427,8,1427,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToCount)=>`_+Int_`(#token("1","Int"),`countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToCount)),`lengthString(_)_STRING-COMMON_Int_String`(Source)),ToCount)) requires `_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(628cff029a6d79e4c99999c0309f91ab8cb12f0ba549bb3faa850f96304c970e), org.kframework.attributes.Location(Location(1887,8,1888,60)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToCount:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortInt{}} (
+       Lbl'UndsPlus'Int'Unds'{}(\dv{SortInt{}}("1"),LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToCount:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})),VarToCount:SortString{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("628cff029a6d79e4c99999c0309f91ab8cb12f0ba549bb3faa850f96304c970e"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1887,8,1888,60)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToCount)=>#token("0","Int") requires `_<Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(1c726cd81629c2e5f411539a7f9b4d297e8600e5d71a5d235d287e3001f3ec84), org.kframework.attributes.Location(Location(1885,8,1886,59)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToCount:SortString{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("0"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("1c726cd81629c2e5f411539a7f9b4d297e8600e5d71a5d235d287e3001f3ec84"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1885,8,1886,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,S2,I)=>ite{Int}(`_==Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),#token("-1","Int")),`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I),ite{Int}(`_==Int_`(`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I),#token("-1","Int")),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`minInt(_,_)_INT-COMMON_Int_Int_Int`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I)))) requires `_=/=String__STRING-COMMON_Bool_String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [UNIQUE_ID(5b5d41706ad496a8165f1ea9c2109ce502796cbe90047732b173b3ad015058e3), org.kframework.attributes.Location(Location(1880,8,1880,431)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lblite{SortInt{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}),Lblite{SortInt{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{})))),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("5b5d41706ad496a8165f1ea9c2109ce502796cbe90047732b173b3ad015058e3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1880,8,1880,431)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(_Gen0,#token("\"\"","String"),_Gen1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5a6cf981f0ec2494854cd3e517b0cf645a1c9762c92a14849adfca9a6a553117), org.kframework.attributes.Location(Location(1881,8,1881,32)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            \dv{SortString{}}("")
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            Var'Unds'Gen1:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("-1"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("5a6cf981f0ec2494854cd3e517b0cf645a1c9762c92a14849adfca9a6a553117"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1881,8,1881,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `freshId(_)_ID-COMMON_Id_Int`(I)=>`String2Id(_)_ID-COMMON_Id_String`(`_+String__STRING-COMMON_String_String_String`(#token("\"_\"","String"),`Int2String(_)_STRING-COMMON_String_Int`(I))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3965c8e65257ebae926d601fa8ac672d34e4c211d73ba594c571c6bc5960f3de), org.kframework.attributes.Location(Location(2266,8,2266,62)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortId{},R} (
+      LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(X0:SortInt{}),
+     \and{SortId{}} (
+       LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(\dv{SortString{}}("_"),LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(VarI:SortInt{}))),
+        \top{SortId{}}())))
+  [UNIQUE'Unds'ID{}("3965c8e65257ebae926d601fa8ac672d34e4c211d73ba594c571c6bc5960f3de"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2266,8,2266,62)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `freshInt(_)_INT_Int_Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b), org.kframework.attributes.Location(Location(1446,8,1446,28)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       VarI:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1446,8,1446,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule getGeneratedCounterCell(`<generatedTop>`(_DotVar0,Cell))=>Cell requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortGeneratedTopCell{}, R} (
+            X0:SortGeneratedTopCell{},
+            Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'DotVar0:SortKCell{},VarCell:SortGeneratedCounterCell{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblgetGeneratedCounterCell{}(X0:SortGeneratedTopCell{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarCell:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("9ef5eb9b9e6bbd7436911fad20615821f61e06e742dd27773001ab0664bd1de3")]
+
+// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      
+          \top{R} ()
+        ),
+    \equals{SortGeneratedCounterCell{},R} (
+      LblinitGeneratedCounterCell{}(),
+     \and{SortGeneratedCounterCell{}} (
+       Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")),
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("5de11f6b50c4684c0e05b773f809d756f4ce9c03a4f24e23a9cddaf3fa31f553")]
+
+// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initKCell(Init),initGeneratedCounterCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4cbc9d1da6e6bfe3605113d64379a38394b46b474e41d7bf884f8912546543b1), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      LblinitGeneratedTopCell{}(X0:SortMap{}),
+     \and{SortGeneratedTopCell{}} (
+       Lbl'-LT-'generatedTop'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}()),
+        \top{SortGeneratedTopCell{}}())))
+  [UNIQUE'Unds'ID{}("4cbc9d1da6e6bfe3605113d64379a38394b46b474e41d7bf884f8912546543b1")]
+
+// rule initKCell(Init)=>`<k>`(`project:KItem`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar"))))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(888ac40929773fd17d5b9fd1e9d0be94791665a663f07907d894c31dccc871a5), initializer]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortMap{}, R} (
+            X0:SortMap{},
+            VarInit:SortMap{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCell{},R} (
+      LblinitKCell{}(X0:SortMap{}),
+     \and{SortKCell{}} (
+       Lbl'-LT-'k'-GT-'{}(kseq{}(Lblproject'Coln'KItem{}(kseq{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))),dotk{}())),dotk{}())),
+        \top{SortKCell{}}())))
+  [UNIQUE'Unds'ID{}("888ac40929773fd17d5b9fd1e9d0be94791665a663f07907d894c31dccc871a5")]
+
+// rule is160(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(aa3f00cb9a02ba98f022164716991c7b0359fee8a7542d52899563654190f19d), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:Sort160{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{Sort160{}, SortKItem{}}(Var'Unds'Gen0:Sort160{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      Lblis160{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("aa3f00cb9a02ba98f022164716991c7b0359fee8a7542d52899563654190f19d"), owise{}()]
+
+// rule is160(inj{160,KItem}(160))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b28711332e9eb28f59bae10021d7f6d6e64b35b96883241eca055a2b9c3d6c9)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{Sort160{}, SortKItem{}}(Var160:Sort160{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblis160{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("3b28711332e9eb28f59bae10021d7f6d6e64b35b96883241eca055a2b9c3d6c9")]
+
+// rule is256(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c6da5840c23335637724a83bef49234faebb665bd58c491def325f022f90cdf1), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:Sort256{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{Sort256{}, SortKItem{}}(Var'Unds'Gen1:Sort256{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      Lblis256{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("c6da5840c23335637724a83bef49234faebb665bd58c491def325f022f90cdf1"), owise{}()]
+
+// rule is256(inj{256,KItem}(256))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9e66a950a2af5a36978f9caa042e3ae3be6a3e98bb4161322ea178128aeec2dc)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{Sort256{}, SortKItem{}}(Var256:Sort256{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblis256{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9e66a950a2af5a36978f9caa042e3ae3be6a3e98bb4161322ea178128aeec2dc")]
+
+// rule is32(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b6c7003f49587e95f0164c9ae9b680b0a9d11acf104c290a80f71528ed55d131), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:Sort32{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{Sort32{}, SortKItem{}}(Var'Unds'Gen1:Sort32{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      Lblis32{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b6c7003f49587e95f0164c9ae9b680b0a9d11acf104c290a80f71528ed55d131"), owise{}()]
+
+// rule is32(inj{32,KItem}(32))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e547145cb81e2b210057c88cbe98f55fca55926d7aac87779aa38e44d1517d3d)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{Sort32{}, SortKItem{}}(Var32:Sort32{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblis32{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e547145cb81e2b210057c88cbe98f55fca55926d7aac87779aa38e44d1517d3d")]
+
+// rule is64(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(309d69e30e85e46cd3add95f1586a34f6ffee4e05119b363eba7aefa4798bd0f), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:Sort64{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{Sort64{}, SortKItem{}}(Var'Unds'Gen0:Sort64{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      Lblis64{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("309d69e30e85e46cd3add95f1586a34f6ffee4e05119b363eba7aefa4798bd0f"), owise{}()]
+
+// rule is64(inj{64,KItem}(64))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a5ccaf5af9a65df630230e540092eb2765cb936a3b6be9e3ae0b84f1998ee1b0)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{Sort64{}, SortKItem{}}(Var64:Sort64{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblis64{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a5ccaf5af9a65df630230e540092eb2765cb936a3b6be9e3ae0b84f1998ee1b0")]
+
+// rule is8(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2693b34deac73e1411d745533a5673c7108f2ffdf2d1de825a8f339042505087), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:Sort8{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{Sort8{}, SortKItem{}}(Var'Unds'Gen0:Sort8{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      Lblis8{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2693b34deac73e1411d745533a5673c7108f2ffdf2d1de825a8f339042505087"), owise{}()]
+
+// rule is8(inj{8,KItem}(8))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(42dbfef0cc222566717dc14d605a28a13cd4f1ae758af6b7068bd1b5a4b7af24)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{Sort8{}, SortKItem{}}(Var8:Sort8{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblis8{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("42dbfef0cc222566717dc14d605a28a13cd4f1ae758af6b7068bd1b5a4b7af24")]
+
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(495da551d13b205c8648618471ccfca028707f98eff21e6b11d591515ed6f29a), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortBool{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'Gen0:SortBool{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("495da551d13b205c8648618471ccfca028707f98eff21e6b11d591515ed6f29a"), owise{}()]
+
+// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarBool:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("dadad716b2f6a82fa4b2cc8f903a1b8f1f6e8cfa63f18b72a7cb35110bdcff77")]
+
+// rule isExp(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9e2a259ff2d6434bfe264d9e99ba0f82d9109ec7c26ae247655c5599fc9ef8b1), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortExp{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'Gen1:SortExp{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisExp{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9e2a259ff2d6434bfe264d9e99ba0f82d9109ec7c26ae247655c5599fc9ef8b1"), owise{}()]
+
+// rule isExp(inj{Exp,KItem}(Exp))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5113a02f7660a72f8eec77fb75db8556ae809f64d13e8478319e14b277319d5c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp{}, SortKItem{}}(VarExp:SortExp{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisExp{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5113a02f7660a72f8eec77fb75db8556ae809f64d13e8478319e14b277319d5c")]
+
+// rule isExp160(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d54f79338898ab9d00bae52a0bde798ded7fdcc1dd06c84b4f453281164a745d), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortExp160{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortExp160{}, SortKItem{}}(Var'Unds'Gen0:SortExp160{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisExp160{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d54f79338898ab9d00bae52a0bde798ded7fdcc1dd06c84b4f453281164a745d"), owise{}()]
+
+// rule isExp160(inj{Exp160,KItem}(Exp160))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4939cbdfbf08d4da978ac04dc2a9b8aab05f9c54fa61904d163d95068bbdfb4c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp160{}, SortKItem{}}(VarExp160:SortExp160{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisExp160{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4939cbdfbf08d4da978ac04dc2a9b8aab05f9c54fa61904d163d95068bbdfb4c")]
+
+// rule isExp256(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8dc9657a4add3f42ed5b988c77a8b6f682a4498dbb519b848de20b04da2de4aa), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortExp256{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortExp256{}, SortKItem{}}(Var'Unds'Gen1:SortExp256{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisExp256{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("8dc9657a4add3f42ed5b988c77a8b6f682a4498dbb519b848de20b04da2de4aa"), owise{}()]
+
+// rule isExp256(inj{Exp256,KItem}(Exp256))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(41d71927b147968d3607c6b5578cf52c746ce244d1f0619b0ed0c7612b0c7437)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp256{}, SortKItem{}}(VarExp256:SortExp256{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisExp256{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("41d71927b147968d3607c6b5578cf52c746ce244d1f0619b0ed0c7612b0c7437")]
+
+// rule isExp32(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4f19f059553c2874f85453e6f01c43d06177cc979150a5b11fc2a6cf5d875794), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortExp32{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortExp32{}, SortKItem{}}(Var'Unds'Gen1:SortExp32{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisExp32{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4f19f059553c2874f85453e6f01c43d06177cc979150a5b11fc2a6cf5d875794"), owise{}()]
+
+// rule isExp32(inj{Exp32,KItem}(Exp32))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5e37f4e60a868b6da36785b192c7849a56997cb7901f28b8fd7195fba1ab7cce)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp32{}, SortKItem{}}(VarExp32:SortExp32{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisExp32{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5e37f4e60a868b6da36785b192c7849a56997cb7901f28b8fd7195fba1ab7cce")]
+
+// rule isExp64(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d1b04b771e2666047a91edb0f107954b1d2a4f4d3c29c0dd0329fe6fb5d4b44d), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortExp64{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortExp64{}, SortKItem{}}(Var'Unds'Gen0:SortExp64{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisExp64{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d1b04b771e2666047a91edb0f107954b1d2a4f4d3c29c0dd0329fe6fb5d4b44d"), owise{}()]
+
+// rule isExp64(inj{Exp64,KItem}(Exp64))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e2d0f88ecdf89aca55b71dddc1a27435298bc7c0f0519fbaee1fb2934b687f01)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp64{}, SortKItem{}}(VarExp64:SortExp64{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisExp64{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e2d0f88ecdf89aca55b71dddc1a27435298bc7c0f0519fbaee1fb2934b687f01")]
+
+// rule isExp8(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(329df24958078a2844b7a92b865b7f3db86bac98c63be9365ddcb6df35681413), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortExp8{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortExp8{}, SortKItem{}}(Var'Unds'Gen0:SortExp8{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisExp8{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("329df24958078a2844b7a92b865b7f3db86bac98c63be9365ddcb6df35681413"), owise{}()]
+
+// rule isExp8(inj{Exp8,KItem}(Exp8))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ee04798b39082c936a455a328e5de00a6769d08fd3ee77e7a7631553f19ff080)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp8{}, SortKItem{}}(VarExp8:SortExp8{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisExp8{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ee04798b39082c936a455a328e5de00a6769d08fd3ee77e7a7631553f19ff080")]
+
+// rule isFloat(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(613283edb3d0af0dfe3d5c3626073b1904f0e254fc0797cd7a4f620cfeb7de62), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortFloat{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortFloat{}, SortKItem{}}(Var'Unds'Gen1:SortFloat{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisFloat{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("613283edb3d0af0dfe3d5c3626073b1904f0e254fc0797cd7a4f620cfeb7de62"), owise{}()]
+
+// rule isFloat(inj{Float,KItem}(Float))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d74a36c34f45e0bf74d89fdd362f124478ab18934b5786ff4aabfe527643c5f0)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortFloat{}, SortKItem{}}(VarFloat:SortFloat{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisFloat{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d74a36c34f45e0bf74d89fdd362f124478ab18934b5786ff4aabfe527643c5f0")]
+
+// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b0c8eb86594a387398bf96f2dbf773cff29d14b8a45c5f6701f205bf3d2f33ba), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedCounterCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedCounterCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("b0c8eb86594a387398bf96f2dbf773cff29d14b8a45c5f6701f205bf3d2f33ba"), owise{}()]
+
+// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarGeneratedCounterCell:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f7b6a3dbee5a80d5eeba727f40009876995660d4052a45fc50c55f88c5fc1a7c")]
+
+// rule isGeneratedCounterCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(84cfc8e964ec28b1912ffec4e6f5fccfcbad2256a1cba113622d99b11c13afd6), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortGeneratedCounterCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'Gen0:SortGeneratedCounterCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("84cfc8e964ec28b1912ffec4e6f5fccfcbad2256a1cba113622d99b11c13afd6"), owise{}()]
+
+// rule isGeneratedCounterCellOpt(inj{GeneratedCounterCellOpt,KItem}(GeneratedCounterCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarGeneratedCounterCellOpt:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a4ff3e170677e099d4b28085658942cb10fcf871aa99abcdf73927596c180f12")]
+
+// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ccb9226d9e6c0e476485f098ef162c6c2206ed3af1d8336ea3ae859b86bc4a8b), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedTopCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedTopCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ccb9226d9e6c0e476485f098ef162c6c2206ed3af1d8336ea3ae859b86bc4a8b"), owise{}()]
+
+// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarGeneratedTopCell:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("3bcf423225700e329d0533cfd806eb9bab91f9d8de0979c8d8e381fe5d076bb2")]
+
+// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(98049f5819962c7ee2b01436957b6cf8460b106979fa2c24f4c606bbf6cb1592), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortGeneratedTopCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(Var'Unds'Gen1:SortGeneratedTopCellFragment{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("98049f5819962c7ee2b01436957b6cf8460b106979fa2c24f4c606bbf6cb1592"), owise{}()]
+
+// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("559f2cdc0ab425bb065cc3174f4a1af4d9ca834f762a814cf3dfbf9a9d7f8271")]
+
+// rule isIOError(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c96fa3a271ec5957293f6ff8436703651f7e219c4364d65286dc134a6a6e7dda), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortIOError{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOError{}, SortKItem{}}(Var'Unds'Gen1:SortIOError{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOError{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("c96fa3a271ec5957293f6ff8436703651f7e219c4364d65286dc134a6a6e7dda"), owise{}()]
+
+// rule isIOError(inj{IOError,KItem}(IOError))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(af1461e241b050082a392e02da8a0d27eb78de77d591d7b2a949770399eea7d0)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOError{}, SortKItem{}}(VarIOError:SortIOError{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOError{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("af1461e241b050082a392e02da8a0d27eb78de77d591d7b2a949770399eea7d0")]
+
+// rule isIOFile(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bb21a59193df5500799f91683023dc97bc08ffce188c0fae38f4920cab8a0f5e), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortIOFile{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOFile{}, SortKItem{}}(Var'Unds'Gen0:SortIOFile{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOFile{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("bb21a59193df5500799f91683023dc97bc08ffce188c0fae38f4920cab8a0f5e"), owise{}()]
+
+// rule isIOFile(inj{IOFile,KItem}(IOFile))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e265f4f40b46b033479ce783a161791d2f3390b848921b8d137e83f3f513fc0a)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOFile{}, SortKItem{}}(VarIOFile:SortIOFile{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOFile{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e265f4f40b46b033479ce783a161791d2f3390b848921b8d137e83f3f513fc0a")]
+
+// rule isIOInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c0297d42abd0eb84ecc87316430c6a6e2961b3bc806b64f68256522680f8b19c), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortIOInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOInt{}, SortKItem{}}(Var'Unds'Gen1:SortIOInt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("c0297d42abd0eb84ecc87316430c6a6e2961b3bc806b64f68256522680f8b19c"), owise{}()]
+
+// rule isIOInt(inj{IOInt,KItem}(IOInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e744736c885f38e99587884080e17e1ddd231da39bcbdcb445d10f52b6675232)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOInt{}, SortKItem{}}(VarIOInt:SortIOInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("e744736c885f38e99587884080e17e1ddd231da39bcbdcb445d10f52b6675232")]
+
+// rule isIOString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f878d7ff3c358cb31e185d67585786837797c18b9599b202e2f399e4dc91f178), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortIOString{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortIOString{}, SortKItem{}}(Var'Unds'Gen1:SortIOString{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisIOString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f878d7ff3c358cb31e185d67585786837797c18b9599b202e2f399e4dc91f178"), owise{}()]
+
+// rule isIOString(inj{IOString,KItem}(IOString))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(febfbad427936ffed4a4f974d1061ec9b65a4d6751c5a4e0e31661905c3f9e1e)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOString{}, SortKItem{}}(VarIOString:SortIOString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisIOString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("febfbad427936ffed4a4f974d1061ec9b65a4d6751c5a4e0e31661905c3f9e1e")]
+
+// rule isId(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f37abe49c9a4ee52b56a492679d7aab25802b3c05860fee32a4a09d72b2a322f), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortId{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortId{}, SortKItem{}}(Var'Unds'Gen1:SortId{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisId{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f37abe49c9a4ee52b56a492679d7aab25802b3c05860fee32a4a09d72b2a322f"), owise{}()]
+
+// rule isId(inj{Id,KItem}(Id))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f024b5fa3f428dab8c832862d8a13219a64369be25641326400611b32ae8843d)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortId{}, SortKItem{}}(VarId:SortId{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisId{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f024b5fa3f428dab8c832862d8a13219a64369be25641326400611b32ae8843d")]
+
+// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(105572a4ac107eeb518b37c4d6ed3e28732b83afb0ba085d02d339c4fc2140a0), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortInt{}, SortKItem{}}(Var'Unds'Gen1:SortInt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("105572a4ac107eeb518b37c4d6ed3e28732b83afb0ba085d02d339c4fc2140a0"), owise{}()]
+
+// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarInt:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("92664aa821c8898ff16b4e72ad0bdf363f755c7660d28dcb69c129a2c94bc6b5")]
+
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisK{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("16ff77cff0ef50026a8b3f4614b87bda465701918596b7ad2280baffff56f847")]
+
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d30be57718b4b3745eaf2e99f875cfec7d5be2ff76bacde8a89bd4ab659d857f), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKCell{}, SortKItem{}}(Var'Unds'Gen1:SortKCell{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("d30be57718b4b3745eaf2e99f875cfec7d5be2ff76bacde8a89bd4ab659d857f"), owise{}()]
+
+// rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2695222b1238f711f8a356c0a1bc0ac418d7bd78fd3282e7c60882e2631a46df)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCell{}, SortKItem{}}(VarKCell:SortKCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2695222b1238f711f8a356c0a1bc0ac418d7bd78fd3282e7c60882e2631a46df")]
+
+// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a3f84195242c98b432c7c63a4189f4276cc3189445c5cf37ce08d9a6547b1f7), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'Gen1:SortKCellOpt{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9a3f84195242c98b432c7c63a4189f4276cc3189445c5cf37ce08d9a6547b1f7"), owise{}()]
+
+// rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1516473b1e153a368c273997543a4378ad451e5e828db8e289f4447f7e5228a5)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarKCellOpt:SortKCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("1516473b1e153a368c273997543a4378ad451e5e828db8e289f4447f7e5228a5")]
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f68a616e301c35586f68e97b729ae274278c3ef8fe6634711cfd3e1746bc0bc2), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortKConfigVar{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKConfigVar{}, SortKItem{}}(Var'Unds'Gen0:SortKConfigVar{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f68a616e301c35586f68e97b729ae274278c3ef8fe6634711cfd3e1746bc0bc2"), owise{}()]
+
+// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKConfigVar{}, SortKItem{}}(VarKConfigVar:SortKConfigVar{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("0ef0a00bb321f2c2a62a3239327de70ecb8e907a950cd20034c46b84e040ebcd")]
+
+// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(83812b6b9e31a764d66d89fd1c7e65b9b162d52c5aebfe99b1536e200a9590c2), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortKItem{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(Var'Unds'Gen1:SortKItem{},dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("83812b6b9e31a764d66d89fd1c7e65b9b162d52c5aebfe99b1536e200a9590c2"), owise{}()]
+
+// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarKItem:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("ed3c25a7dab5e5fbc101589e2fa74ac91aa107f051d22a01378222d08643373c")]
+
+// rule isKResult(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(afefecb36598372bc1ba6e5d0b24a00b91796244dc3bd7435e40ca6e9ab33d4b), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortKResult{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortKResult{}, SortKItem{}}(Var'Unds'Gen0:SortKResult{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisKResult{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("afefecb36598372bc1ba6e5d0b24a00b91796244dc3bd7435e40ca6e9ab33d4b"), owise{}()]
+
+// rule isKResult(inj{KResult,KItem}(KResult))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f4c2469bcff9527515b6d36f16040307917bda61067d10b85fb531e142483bee)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKResult{}, SortKItem{}}(VarKResult:SortKResult{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisKResult{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f4c2469bcff9527515b6d36f16040307917bda61067d10b85fb531e142483bee")]
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a9489adcf0279eca74c012bb1130bb9d30372cfbebc8e4ab4b173656c4d6613), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortList{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortList{}, SortKItem{}}(Var'Unds'Gen1:SortList{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("9a9489adcf0279eca74c012bb1130bb9d30372cfbebc8e4ab4b173656c4d6613"), owise{}()]
+
+// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarList:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("7d4dddf5bbdb61cfd11fb9be1071be7bd551cf186607cf6f493cfade3221c446")]
+
+// rule `isMInt{160}`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(42372f41a4d487dbdae4c035e45ef87b517a47c8260ec37573301b50e64a4b1a), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortMInt{Sort160{}},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMInt{Sort160{}}, SortKItem{}}(Var'Unds'Gen0:SortMInt{Sort160{}}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'160'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("42372f41a4d487dbdae4c035e45ef87b517a47c8260ec37573301b50e64a4b1a"), owise{}()]
+
+// rule `isMInt{160}`(inj{MInt,KItem}(MInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(95369e50c127b9472669affb3bfab3e3ac2ba9bc2bb50889c3e528c9d4b7c35c)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort160{}}, SortKItem{}}(VarMInt:SortMInt{Sort160{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'160'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("95369e50c127b9472669affb3bfab3e3ac2ba9bc2bb50889c3e528c9d4b7c35c")]
+
+// rule `isMInt{256}`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fa5ac8212f0d864ac8aa1d2bfdacedb25f1b466491918a14bfb1a2a657c849d9), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortMInt{Sort256{}},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMInt{Sort256{}}, SortKItem{}}(Var'Unds'Gen1:SortMInt{Sort256{}}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'256'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fa5ac8212f0d864ac8aa1d2bfdacedb25f1b466491918a14bfb1a2a657c849d9"), owise{}()]
+
+// rule `isMInt{256}`(inj{MInt,KItem}(MInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a523eecf5341d4be513fc22dd552f38ec2888b339226c218d35997cf017a45f3)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort256{}}, SortKItem{}}(VarMInt:SortMInt{Sort256{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'256'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("a523eecf5341d4be513fc22dd552f38ec2888b339226c218d35997cf017a45f3")]
+
+// rule `isMInt{32}`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5ad5ec67f05c4eba78ea6a7e38a5f63918bac62891c41b9c9965d5e7a2c1af24), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortMInt{Sort32{}},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMInt{Sort32{}}, SortKItem{}}(Var'Unds'Gen0:SortMInt{Sort32{}}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'32'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5ad5ec67f05c4eba78ea6a7e38a5f63918bac62891c41b9c9965d5e7a2c1af24"), owise{}()]
+
+// rule `isMInt{32}`(inj{MInt,KItem}(MInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bd6d624dbb3664bd095d9e098bf283ae682fbbf3212ddb36c60430d3b3a52f50)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort32{}}, SortKItem{}}(VarMInt:SortMInt{Sort32{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'32'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("bd6d624dbb3664bd095d9e098bf283ae682fbbf3212ddb36c60430d3b3a52f50")]
+
+// rule `isMInt{64}`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cb62dfeb7ce13fecc41740092599566cb2fcc11688f0571c23cf42732b214656), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortMInt{Sort64{}},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMInt{Sort64{}}, SortKItem{}}(Var'Unds'Gen0:SortMInt{Sort64{}}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'64'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("cb62dfeb7ce13fecc41740092599566cb2fcc11688f0571c23cf42732b214656"), owise{}()]
+
+// rule `isMInt{64}`(inj{MInt,KItem}(MInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(63035413b949c0bac193564937cd502a2c3aa53182ed2de338fa33c703cbf28f)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort64{}}, SortKItem{}}(VarMInt:SortMInt{Sort64{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'64'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("63035413b949c0bac193564937cd502a2c3aa53182ed2de338fa33c703cbf28f")]
+
+// rule `isMInt{8}`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c524ef7af377d50f6e353d4405ff96ab03c5f8bf1a73f9de692ab8bce7eb8172), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortMInt{Sort8{}},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMInt{Sort8{}}, SortKItem{}}(Var'Unds'Gen1:SortMInt{Sort8{}}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'8'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("c524ef7af377d50f6e353d4405ff96ab03c5f8bf1a73f9de692ab8bce7eb8172"), owise{}()]
+
+// rule `isMInt{8}`(inj{MInt,KItem}(MInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(023f885d6950498760bc9a5ab8b2d471d0ce16dacec268c553169b40e375df70)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort8{}}, SortKItem{}}(VarMInt:SortMInt{Sort8{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMInt'LBra'8'RBra'{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("023f885d6950498760bc9a5ab8b2d471d0ce16dacec268c553169b40e375df70")]
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(6f30a2087d0b19640df005437bc3f4665f41282666a72821b17b16c99ed5afee), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortMap{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortMap{}, SortKItem{}}(Var'Unds'Gen0:SortMap{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("6f30a2087d0b19640df005437bc3f4665f41282666a72821b17b16c99ed5afee"), owise{}()]
+
+// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarMap:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("4879c0fcf6b7d7f3d6b751e4f460f8dced005a44ae5ff600cffcea784cf58795")]
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b5aadccd9b89faba72816867187d48d279d8c27c8bda1a1b3b0658bd82bb783), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortSet{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'Gen1:SortSet{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("2b5aadccd9b89faba72816867187d48d279d8c27c8bda1a1b3b0658bd82bb783"), owise{}()]
+
+// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarSet:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("f205bc460bdb728b4c3458643699be30d519db4d8b13e80e2c27082b9e846e80")]
+
+// rule isStream(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(15e2e66b02746a7c3106ff32539631d15c0b184068a2767cfe37a26680aa442d), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen0:SortStream{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortStream{}, SortKItem{}}(Var'Unds'Gen0:SortStream{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisStream{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("15e2e66b02746a7c3106ff32539631d15c0b184068a2767cfe37a26680aa442d"), owise{}()]
+
+// rule isStream(inj{Stream,KItem}(Stream))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(27e703343d82a904ab8f74cc74fe8c6870a94fa1f4df39e1c0230ae06e4783cc)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortStream{}, SortKItem{}}(VarStream:SortStream{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisStream{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("27e703343d82a904ab8f74cc74fe8c6870a94fa1f4df39e1c0230ae06e4783cc")]
+
+// rule isString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fbe29b27977283e8cb5b35f1b17a6b7b2abc92a7fca608d496b346f7b6918961), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen1:SortString{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \in{SortK{}, R} (
+                  X0:SortK{},
+                  kseq{}(inj{SortString{}, SortKItem{}}(Var'Unds'Gen1:SortString{}),dotk{}())
+                ),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \top{R}(),
+        \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )
+    )),
+    \equals{SortBool{},R} (
+      LblisString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("fbe29b27977283e8cb5b35f1b17a6b7b2abc92a7fca608d496b346f7b6918961"), owise{}()]
+
+// rule isString(inj{String,KItem}(String))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(109ced650ead4a5092ddba090e1b8e181633ed0aa5c5f93bce9f88be215668ef)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortString{}, SortKItem{}}(VarString:SortString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblisString{}(X0:SortK{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("109ced650ead4a5092ddba090e1b8e181633ed0aa5c5f93bce9f88be215668ef")]
+
+// rule ite{K}(C,B1,_Gen0)=>B1 requires C ensures #token("true","Bool") [UNIQUE_ID(1ff8f4d71e4c13084eed473b08740da83c4cc7f1875d340d86dc72124c48b4a0), org.kframework.attributes.Location(Location(2324,8,2324,59)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        VarC:SortBool{},
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            VarB1:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lblite{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB1:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("1ff8f4d71e4c13084eed473b08740da83c4cc7f1875d340d86dc72124c48b4a0"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2324,8,2324,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule ite{K}(C,_Gen0,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [UNIQUE_ID(2f3f58a93926913fc5ca147dfd8d3d612508bc8ff67412ef10935df7c09554d5), org.kframework.attributes.Location(Location(2325,8,2325,67)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        LblnotBool'Unds'{}(VarC:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            VarC:SortBool{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X1:SortK{},
+            Var'Unds'Gen0:SortK{}
+          ),\and{R} (
+          \in{SortK{}, R} (
+            X2:SortK{},
+            VarB2:SortK{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortK{},R} (
+      Lblite{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+     \and{SortK{}} (
+       VarB2:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("2f3f58a93926913fc5ca147dfd8d3d612508bc8ff67412ef10935df7c09554d5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2325,8,2325,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I1 requires `_<Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(5615d5587c51d94a62fc99ae2458c06428585265e750fdc249083647f9d3d4c1), org.kframework.attributes.Location(Location(1439,8,1439,57)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI1:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("5615d5587c51d94a62fc99ae2458c06428585265e750fdc249083647f9d3d4c1"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1439,8,1439,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I2 requires `_>=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3), org.kframework.attributes.Location(Location(1440,8,1440,57)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI1:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI2:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortInt{}} (
+       VarI2:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1440,8,1440,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415), org.kframework.attributes.Location(Location(1128,8,1128,29)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("true"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1128,8,1128,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c), org.kframework.attributes.Location(Location(1127,8,1127,29)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+     \and{SortBool{}} (
+       \dv{SortBool{}}("false"),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1127,8,1127,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `project:#tempFile:fd`(#tempFile(K0,K1))=>K1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(adb3a6d90d2e5267333e61f4e4be032bebb5f7a513450887a845c863a2adf95d)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortIOFile{}, R} (
+            X0:SortIOFile{},
+            Lbl'Hash'tempFile{}(VarK0:SortString{},VarK1:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'ColnHash'tempFile'Coln'fd{}(X0:SortIOFile{}),
+     \and{SortInt{}} (
+       VarK1:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("adb3a6d90d2e5267333e61f4e4be032bebb5f7a513450887a845c863a2adf95d")]
+
+// rule `project:#tempFile:path`(#tempFile(K0,K1))=>K0 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0020b2718cda89e9c9f4d05915593ca66761a24dffb111c697ccc162278da8ea)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortIOFile{}, R} (
+            X0:SortIOFile{},
+            Lbl'Hash'tempFile{}(VarK0:SortString{},VarK1:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      Lblproject'ColnHash'tempFile'Coln'path{}(X0:SortIOFile{}),
+     \and{SortString{}} (
+       VarK0:SortString{},
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("0020b2718cda89e9c9f4d05915593ca66761a24dffb111c697ccc162278da8ea")]
+
+// rule `project:#unknownIOError:errno`(#unknownIOError(K0))=>K0 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a36cde36a6581696f3d54614cc0d2d0864c2da35c6c8dc8d56daaf8b24199241)]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortIOError{}, R} (
+            X0:SortIOError{},
+            Lbl'Hash'unknownIOError{}(VarK0:SortInt{})
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'ColnHash'unknownIOError'Coln'errno{}(X0:SortIOError{}),
+     \and{SortInt{}} (
+       VarK0:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("a36cde36a6581696f3d54614cc0d2d0864c2da35c6c8dc8d56daaf8b24199241")]
+
+// rule `project:Bool`(inj{Bool,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortBool{}, SortKItem{}}(VarK:SortBool{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      Lblproject'Coln'Bool{}(X0:SortK{}),
+     \and{SortBool{}} (
+       VarK:SortBool{},
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("5872f0d5b8131216db7bc41e2c3a423e55f4b8581589fcbd1bf93b2ca6862d54")]
+
+// rule `project:Exp`(inj{Exp,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9cd2bc2f2919e88b7c91858d910ebc06ec69505e24015e7346a27913f6b3d0c7), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp{}, SortKItem{}}(VarK:SortExp{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortExp{},R} (
+      Lblproject'Coln'Exp{}(X0:SortK{}),
+     \and{SortExp{}} (
+       VarK:SortExp{},
+        \top{SortExp{}}())))
+  [UNIQUE'Unds'ID{}("9cd2bc2f2919e88b7c91858d910ebc06ec69505e24015e7346a27913f6b3d0c7")]
+
+// rule `project:Exp160`(inj{Exp160,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d0200909a9ecb31f5650923500b9e916c293bc61f2f5b0edd02ff42338ab319a), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp160{}, SortKItem{}}(VarK:SortExp160{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortExp160{},R} (
+      Lblproject'Coln'Exp160{}(X0:SortK{}),
+     \and{SortExp160{}} (
+       VarK:SortExp160{},
+        \top{SortExp160{}}())))
+  [UNIQUE'Unds'ID{}("d0200909a9ecb31f5650923500b9e916c293bc61f2f5b0edd02ff42338ab319a")]
+
+// rule `project:Exp256`(inj{Exp256,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5547215c84980b727a83cb9dfd7570940d5d47ee0e9e66d78aa4f301fd13f001), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp256{}, SortKItem{}}(VarK:SortExp256{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortExp256{},R} (
+      Lblproject'Coln'Exp256{}(X0:SortK{}),
+     \and{SortExp256{}} (
+       VarK:SortExp256{},
+        \top{SortExp256{}}())))
+  [UNIQUE'Unds'ID{}("5547215c84980b727a83cb9dfd7570940d5d47ee0e9e66d78aa4f301fd13f001")]
+
+// rule `project:Exp32`(inj{Exp32,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9d1fde860be057fbc6048599efc9828cd82cf8b3a4e89556bd7c742b62916de4), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp32{}, SortKItem{}}(VarK:SortExp32{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortExp32{},R} (
+      Lblproject'Coln'Exp32{}(X0:SortK{}),
+     \and{SortExp32{}} (
+       VarK:SortExp32{},
+        \top{SortExp32{}}())))
+  [UNIQUE'Unds'ID{}("9d1fde860be057fbc6048599efc9828cd82cf8b3a4e89556bd7c742b62916de4")]
+
+// rule `project:Exp64`(inj{Exp64,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0e0c26cf892f3904058df271fd99bfa7c38ebac66157befeb576d74069073027), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp64{}, SortKItem{}}(VarK:SortExp64{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortExp64{},R} (
+      Lblproject'Coln'Exp64{}(X0:SortK{}),
+     \and{SortExp64{}} (
+       VarK:SortExp64{},
+        \top{SortExp64{}}())))
+  [UNIQUE'Unds'ID{}("0e0c26cf892f3904058df271fd99bfa7c38ebac66157befeb576d74069073027")]
+
+// rule `project:Exp8`(inj{Exp8,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(86108d7aa17d78db956c9f907f470e0748ee651cf1febd0c49950e92a942b6c1), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortExp8{}, SortKItem{}}(VarK:SortExp8{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortExp8{},R} (
+      Lblproject'Coln'Exp8{}(X0:SortK{}),
+     \and{SortExp8{}} (
+       VarK:SortExp8{},
+        \top{SortExp8{}}())))
+  [UNIQUE'Unds'ID{}("86108d7aa17d78db956c9f907f470e0748ee651cf1febd0c49950e92a942b6c1")]
+
+// rule `project:Float`(inj{Float,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(ef206f477d884c0b6413273ff35b1206769cdb5a5ceba7b97d9e8e0a7b14e399), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortFloat{}, SortKItem{}}(VarK:SortFloat{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortFloat{},R} (
+      Lblproject'Coln'Float{}(X0:SortK{}),
+     \and{SortFloat{}} (
+       VarK:SortFloat{},
+        \top{SortFloat{}}())))
+  [UNIQUE'Unds'ID{}("ef206f477d884c0b6413273ff35b1206769cdb5a5ceba7b97d9e8e0a7b14e399")]
+
+// rule `project:GeneratedCounterCell`(inj{GeneratedCounterCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarK:SortGeneratedCounterCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCell{},R} (
+      Lblproject'Coln'GeneratedCounterCell{}(X0:SortK{}),
+     \and{SortGeneratedCounterCell{}} (
+       VarK:SortGeneratedCounterCell{},
+        \top{SortGeneratedCounterCell{}}())))
+  [UNIQUE'Unds'ID{}("63453db9d9aa121b63bb877e2fa4998d399ef82d2a1e4b90f87a32ba55401217")]
+
+// rule `project:GeneratedCounterCellOpt`(inj{GeneratedCounterCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarK:SortGeneratedCounterCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedCounterCellOpt{},R} (
+      Lblproject'Coln'GeneratedCounterCellOpt{}(X0:SortK{}),
+     \and{SortGeneratedCounterCellOpt{}} (
+       VarK:SortGeneratedCounterCellOpt{},
+        \top{SortGeneratedCounterCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("9325a900267ae528f7cd09f3b44b825dd9ff344c38d38383c08fa697cc67efca")]
+
+// rule `project:GeneratedTopCell`(inj{GeneratedTopCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarK:SortGeneratedTopCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCell{},R} (
+      Lblproject'Coln'GeneratedTopCell{}(X0:SortK{}),
+     \and{SortGeneratedTopCell{}} (
+       VarK:SortGeneratedTopCell{},
+        \top{SortGeneratedTopCell{}}())))
+  [UNIQUE'Unds'ID{}("b0fabd8c7c81fe08ebd569aff59747d357e441ae1fcd05d9d594d57e38e3d55e")]
+
+// rule `project:GeneratedTopCellFragment`(inj{GeneratedTopCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarK:SortGeneratedTopCellFragment{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortGeneratedTopCellFragment{},R} (
+      Lblproject'Coln'GeneratedTopCellFragment{}(X0:SortK{}),
+     \and{SortGeneratedTopCellFragment{}} (
+       VarK:SortGeneratedTopCellFragment{},
+        \top{SortGeneratedTopCellFragment{}}())))
+  [UNIQUE'Unds'ID{}("2084fac322aa142a07f881814b8a286bf62d5c6d05777b7aa715ccc534cf9a42")]
+
+// rule `project:IOError`(inj{IOError,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7ffe32516a0c3941ee4ba99c0f779b50c13a06e7eeb613f97334efb61b50c3aa), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOError{}, SortKItem{}}(VarK:SortIOError{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOError{},R} (
+      Lblproject'Coln'IOError{}(X0:SortK{}),
+     \and{SortIOError{}} (
+       VarK:SortIOError{},
+        \top{SortIOError{}}())))
+  [UNIQUE'Unds'ID{}("7ffe32516a0c3941ee4ba99c0f779b50c13a06e7eeb613f97334efb61b50c3aa")]
+
+// rule `project:IOFile`(inj{IOFile,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(09adbf7f680517f1f89e4e8c71d5bd247c4a2ea5d62e7c4aeb3153ab97239841), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOFile{}, SortKItem{}}(VarK:SortIOFile{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOFile{},R} (
+      Lblproject'Coln'IOFile{}(X0:SortK{}),
+     \and{SortIOFile{}} (
+       VarK:SortIOFile{},
+        \top{SortIOFile{}}())))
+  [UNIQUE'Unds'ID{}("09adbf7f680517f1f89e4e8c71d5bd247c4a2ea5d62e7c4aeb3153ab97239841")]
+
+// rule `project:IOInt`(inj{IOInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e39565377db8be1e421a86f0a0c31d0782a9af4aed7031245771fcb2a0152e06), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOInt{}, SortKItem{}}(VarK:SortIOInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOInt{},R} (
+      Lblproject'Coln'IOInt{}(X0:SortK{}),
+     \and{SortIOInt{}} (
+       VarK:SortIOInt{},
+        \top{SortIOInt{}}())))
+  [UNIQUE'Unds'ID{}("e39565377db8be1e421a86f0a0c31d0782a9af4aed7031245771fcb2a0152e06")]
+
+// rule `project:IOString`(inj{IOString,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(76a39386f0abf23155a1642ec64113306ae7c384a59c2e7f562d3c564efcc9a4), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortIOString{}, SortKItem{}}(VarK:SortIOString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortIOString{},R} (
+      Lblproject'Coln'IOString{}(X0:SortK{}),
+     \and{SortIOString{}} (
+       VarK:SortIOString{},
+        \top{SortIOString{}}())))
+  [UNIQUE'Unds'ID{}("76a39386f0abf23155a1642ec64113306ae7c384a59c2e7f562d3c564efcc9a4")]
+
+// rule `project:Id`(inj{Id,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(afcb3941b7c18d4b91d6ed8981582d58e0dc006425e9889e9891c2a7c2b93554), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortId{}, SortKItem{}}(VarK:SortId{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortId{},R} (
+      Lblproject'Coln'Id{}(X0:SortK{}),
+     \and{SortId{}} (
+       VarK:SortId{},
+        \top{SortId{}}())))
+  [UNIQUE'Unds'ID{}("afcb3941b7c18d4b91d6ed8981582d58e0dc006425e9889e9891c2a7c2b93554")]
+
+// rule `project:Int`(inj{Int,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortInt{}, SortKItem{}}(VarK:SortInt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      Lblproject'Coln'Int{}(X0:SortK{}),
+     \and{SortInt{}} (
+       VarK:SortInt{},
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("f316b871091516c401f1d2382cc5f66322602b782c7b01e1aeb6c2ddab50e24b")]
+
+// rule `project:K`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            VarK:SortK{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortK{},R} (
+      Lblproject'Coln'K{}(X0:SortK{}),
+     \and{SortK{}} (
+       VarK:SortK{},
+        \top{SortK{}}())))
+  [UNIQUE'Unds'ID{}("25b529ddcefd25ef63f99a62040145ef27638e7679ea9202218fe14be98dff3a")]
+
+// rule `project:KCell`(inj{KCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(894c13c4c410f11e35bc3781505aeddde4ff400ddda1daf8b35259dbf0de9a24), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCell{}, SortKItem{}}(VarK:SortKCell{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCell{},R} (
+      Lblproject'Coln'KCell{}(X0:SortK{}),
+     \and{SortKCell{}} (
+       VarK:SortKCell{},
+        \top{SortKCell{}}())))
+  [UNIQUE'Unds'ID{}("894c13c4c410f11e35bc3781505aeddde4ff400ddda1daf8b35259dbf0de9a24")]
+
+// rule `project:KCellOpt`(inj{KCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f684dd78d97feadf0cbcb3cbb8892e0842f137c7b29a904cb2f3fc9755b29b30), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarK:SortKCellOpt{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKCellOpt{},R} (
+      Lblproject'Coln'KCellOpt{}(X0:SortK{}),
+     \and{SortKCellOpt{}} (
+       VarK:SortKCellOpt{},
+        \top{SortKCellOpt{}}())))
+  [UNIQUE'Unds'ID{}("f684dd78d97feadf0cbcb3cbb8892e0842f137c7b29a904cb2f3fc9755b29b30")]
+
+// rule `project:KItem`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(VarK:SortKItem{},dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKItem{},R} (
+      Lblproject'Coln'KItem{}(X0:SortK{}),
+     \and{SortKItem{}} (
+       VarK:SortKItem{},
+        \top{SortKItem{}}())))
+  [UNIQUE'Unds'ID{}("1242e49c17638c9a66a35e3bb8c237288f7e9aa9a6499101e8cdc55be320cd29")]
+
+// rule `project:KResult`(inj{KResult,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(07a916f84d6294528a6d07f273fb778b316d52b4ef8204a1817b105750b2b734), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortKResult{}, SortKItem{}}(VarK:SortKResult{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortKResult{},R} (
+      Lblproject'Coln'KResult{}(X0:SortK{}),
+     \and{SortKResult{}} (
+       VarK:SortKResult{},
+        \top{SortKResult{}}())))
+  [UNIQUE'Unds'ID{}("07a916f84d6294528a6d07f273fb778b316d52b4ef8204a1817b105750b2b734")]
+
+// rule `project:List`(inj{List,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortList{}, SortKItem{}}(VarK:SortList{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortList{},R} (
+      Lblproject'Coln'List{}(X0:SortK{}),
+     \and{SortList{}} (
+       VarK:SortList{},
+        \top{SortList{}}())))
+  [UNIQUE'Unds'ID{}("2b75eac5a59779d336e6cf9632bf9ba7d67286f322e753108b34e62f2443efe5")]
+
+// rule `project:MInt{160}`(inj{MInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e7ba7fd34b4205d4632fc16d50d52a48d062fd4bcdf0eac660ea7f27d2d43213), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort160{}}, SortKItem{}}(VarK:SortMInt{Sort160{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMInt{Sort160{}},R} (
+      Lblproject'Coln'MInt'LBra'160'RBra'{}(X0:SortK{}),
+     \and{SortMInt{Sort160{}}} (
+       VarK:SortMInt{Sort160{}},
+        \top{SortMInt{Sort160{}}}())))
+  [UNIQUE'Unds'ID{}("e7ba7fd34b4205d4632fc16d50d52a48d062fd4bcdf0eac660ea7f27d2d43213")]
+
+// rule `project:MInt{256}`(inj{MInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9c890bf8e4d883bf56e6048f639a5e23f3ff9998f6b0d9ac16ea23778956ab6f), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort256{}}, SortKItem{}}(VarK:SortMInt{Sort256{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMInt{Sort256{}},R} (
+      Lblproject'Coln'MInt'LBra'256'RBra'{}(X0:SortK{}),
+     \and{SortMInt{Sort256{}}} (
+       VarK:SortMInt{Sort256{}},
+        \top{SortMInt{Sort256{}}}())))
+  [UNIQUE'Unds'ID{}("9c890bf8e4d883bf56e6048f639a5e23f3ff9998f6b0d9ac16ea23778956ab6f")]
+
+// rule `project:MInt{32}`(inj{MInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(542fe8154fa5338c2822d5982ca06611b86b8538d65e319e80e29737e0bdd467), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort32{}}, SortKItem{}}(VarK:SortMInt{Sort32{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMInt{Sort32{}},R} (
+      Lblproject'Coln'MInt'LBra'32'RBra'{}(X0:SortK{}),
+     \and{SortMInt{Sort32{}}} (
+       VarK:SortMInt{Sort32{}},
+        \top{SortMInt{Sort32{}}}())))
+  [UNIQUE'Unds'ID{}("542fe8154fa5338c2822d5982ca06611b86b8538d65e319e80e29737e0bdd467")]
+
+// rule `project:MInt{64}`(inj{MInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7f14eb6497f756642828728a6f83c13ac9c7e3c39e956f4ccebb2a5169359142), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort64{}}, SortKItem{}}(VarK:SortMInt{Sort64{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMInt{Sort64{}},R} (
+      Lblproject'Coln'MInt'LBra'64'RBra'{}(X0:SortK{}),
+     \and{SortMInt{Sort64{}}} (
+       VarK:SortMInt{Sort64{}},
+        \top{SortMInt{Sort64{}}}())))
+  [UNIQUE'Unds'ID{}("7f14eb6497f756642828728a6f83c13ac9c7e3c39e956f4ccebb2a5169359142")]
+
+// rule `project:MInt{8}`(inj{MInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(1a08906672ed661e62b7898cc2e6c229203893f6e04c898ae5e5517f2cd0451a), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMInt{Sort8{}}, SortKItem{}}(VarK:SortMInt{Sort8{}}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMInt{Sort8{}},R} (
+      Lblproject'Coln'MInt'LBra'8'RBra'{}(X0:SortK{}),
+     \and{SortMInt{Sort8{}}} (
+       VarK:SortMInt{Sort8{}},
+        \top{SortMInt{Sort8{}}}())))
+  [UNIQUE'Unds'ID{}("1a08906672ed661e62b7898cc2e6c229203893f6e04c898ae5e5517f2cd0451a")]
+
+// rule `project:Map`(inj{Map,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortMap{}, SortKItem{}}(VarK:SortMap{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortMap{},R} (
+      Lblproject'Coln'Map{}(X0:SortK{}),
+     \and{SortMap{}} (
+       VarK:SortMap{},
+        \top{SortMap{}}())))
+  [UNIQUE'Unds'ID{}("031237d4aae58d86914d6370d37ccd15f4738378ed780333c59cc81b4f7bc598")]
+
+// rule `project:Set`(inj{Set,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortSet{}, SortKItem{}}(VarK:SortSet{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortSet{},R} (
+      Lblproject'Coln'Set{}(X0:SortK{}),
+     \and{SortSet{}} (
+       VarK:SortSet{},
+        \top{SortSet{}}())))
+  [UNIQUE'Unds'ID{}("0e7f5070c993161786e314f7199d985afebac9e07b5c784f6f623780c60ce9d0")]
+
+// rule `project:Stream`(inj{Stream,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bb30b432f6a3a9b73f42f0d3a54e07645be55c26bdee9d5c513f06e8009d0a77), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortStream{}, SortKItem{}}(VarK:SortStream{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortStream{},R} (
+      Lblproject'Coln'Stream{}(X0:SortK{}),
+     \and{SortStream{}} (
+       VarK:SortStream{},
+        \top{SortStream{}}())))
+  [UNIQUE'Unds'ID{}("bb30b432f6a3a9b73f42f0d3a54e07645be55c26bdee9d5c513f06e8009d0a77")]
+
+// rule `project:String`(inj{String,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e491dad8f644d2344f08cb72af01ade1e6ce9f564010a2de7909b3b6c7e2ae85), projection]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortK{}, R} (
+            X0:SortK{},
+            kseq{}(inj{SortString{}, SortKItem{}}(VarK:SortString{}),dotk{}())
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      Lblproject'Coln'String{}(X0:SortK{}),
+     \and{SortString{}} (
+       VarK:SortString{},
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("e491dad8f644d2344f08cb72af01ade1e6ce9f564010a2de7909b3b6c7e2ae85")]
+
+// rule pushList(K,L1)=>`_List_`(`ListItem`(K),L1) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f6967050cc4ec32c2d34d52f5577e09120f730420d2c5dc838cba81d04c57adf), org.kframework.attributes.Location(Location(954,8,954,54)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortKItem{}, R} (
+            X0:SortKItem{},
+            VarK:SortKItem{}
+          ),\and{R} (
+          \in{SortList{}, R} (
+            X1:SortList{},
+            VarL1:SortList{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortList{},R} (
+      LblpushList{}(X0:SortKItem{},X1:SortList{}),
+     \and{SortList{}} (
+       Lbl'Unds'List'Unds'{}(LblListItem{}(VarK:SortKItem{}),VarL1:SortList{}),
+        \top{SortList{}}())))
+  [UNIQUE'Unds'ID{}("f6967050cc4ec32c2d34d52f5577e09120f730420d2c5dc838cba81d04c57adf"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(954,8,954,54)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,ToReplace,Replacement,Count)=>`_+String__STRING-COMMON_String_String_String`(`_+String__STRING-COMMON_String_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToReplace)),`lengthString(_)_STRING-COMMON_Int_String`(Source)),ToReplace,Replacement,`_-Int_`(Count,#token("1","Int")))) requires `_andBool_`(`_>Int_`(Count,#token("0","Int")),`_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int"))) ensures #token("true","Bool") [UNIQUE_ID(4d80f4d63262761f305ff16a13c7b187891f796dbdb8f8bc0c2387a37c01cd6d), org.kframework.attributes.Location(Location(1900,8,1903,79)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'Unds-GT-'Int'Unds'{}(VarCount:SortInt{},\dv{SortInt{}}("0")),Lbl'Unds-GT-Eqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0"))),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            VarReplacement:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X3:SortInt{},
+            VarCount:SortInt{}
+          ),
+          \top{R} ()
+        ))))),
+    \equals{SortString{},R} (
+      Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortString{},X3:SortInt{}),
+     \and{SortString{}} (
+       Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})),VarToReplace:SortString{},VarReplacement:SortString{},Lbl'Unds'-Int'Unds'{}(VarCount:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("4d80f4d63262761f305ff16a13c7b187891f796dbdb8f8bc0c2387a37c01cd6d"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1900,8,1903,79)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,_Gen0,_Gen1,Count)=>Source requires `_>=Int_`(Count,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(8baee90bc16d350bd96511a574002886bac6fd9d5017c31b773c5064b69c5f79), org.kframework.attributes.Location(Location(1904,8,1905,31)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)]), owise]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'Gen5:SortInt{},
+          \exists{R} (Var'Unds'Gen2:SortString{},
+          \exists{R} (Var'Unds'Gen3:SortString{},
+          \exists{R} (Var'Unds'Gen4:SortString{},
+            \and{R} (
+              \equals{SortBool{},R}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'Unds-GT-'Int'Unds'{}(Var'Unds'Gen5:SortInt{},\dv{SortInt{}}("0")),Lbl'Unds-GT-Eqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(Var'Unds'Gen2:SortString{},Var'Unds'Gen3:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0"))),
+        \dv{SortBool{}}("true")),
+              \and{R} (
+                \in{SortString{}, R} (
+                  X0:SortString{},
+                  Var'Unds'Gen2:SortString{}
+                ),\and{R} (
+                \in{SortString{}, R} (
+                  X1:SortString{},
+                  Var'Unds'Gen3:SortString{}
+                ),\and{R} (
+                \in{SortString{}, R} (
+                  X2:SortString{},
+                  Var'Unds'Gen4:SortString{}
+                ),\and{R} (
+                \in{SortInt{}, R} (
+                  X3:SortInt{},
+                  Var'Unds'Gen5:SortInt{}
+                ),
+                \top{R} ()
+              ))))
+          ))))),
+          \bottom{R}()
+        )
+      ),
+      \and{R}(
+        \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(VarCount:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+        \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            Var'Unds'Gen1:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X3:SortInt{},
+            VarCount:SortInt{}
+          ),
+          \top{R} ()
+        ))))
+    )),
+    \equals{SortString{},R} (
+      Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortString{},X3:SortInt{}),
+     \and{SortString{}} (
+       VarSource:SortString{},
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("8baee90bc16d350bd96511a574002886bac6fd9d5017c31b773c5064b69c5f79"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1904,8,1905,31)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), owise{}()]
+
+// rule `replaceAll(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,Replacement)=>`replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,ToReplace,Replacement,`countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToReplace)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(262167183c3ec2e214d12bac6e639d7ac1a9f973582e16eca6c1af1da7ecc0a5), org.kframework.attributes.Location(Location(1906,8,1906,154)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            VarReplacement:SortString{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortString{},R} (
+      LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+     \and{SortString{}} (
+       Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{})),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("262167183c3ec2e214d12bac6e639d7ac1a9f973582e16eca6c1af1da7ecc0a5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1906,8,1906,154)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `replaceFirst(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,Replacement)=>`_+String__STRING-COMMON_String_String_String`(`_+String__STRING-COMMON_String_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToReplace)),`lengthString(_)_STRING-COMMON_Int_String`(Source))) requires `_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(e290042e5b5b2f620c0ca1871e708c3713c62b63b283e317bb7568e13968fe0c), org.kframework.attributes.Location(Location(1890,8,1892,66)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            VarReplacement:SortString{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortString{},R} (
+      LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+     \and{SortString{}} (
+       Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{}))),
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("e290042e5b5b2f620c0ca1871e708c3713c62b63b283e317bb7568e13968fe0c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1890,8,1892,66)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `replaceFirst(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,_Gen0)=>Source requires `_<Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(8fbd1c8efb9988236eddc95fc2af4a3e74f6ec94d696ee47209543fd0826dd34), org.kframework.attributes.Location(Location(1893,8,1894,57)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarSource:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarToReplace:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X2:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortString{},R} (
+      LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+     \and{SortString{}} (
+       VarSource:SortString{},
+        \top{SortString{}}())))
+  [UNIQUE'Unds'ID{}("8fbd1c8efb9988236eddc95fc2af4a3e74f6ec94d696ee47209543fd0826dd34"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1893,8,1894,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,S2,I)=>`maxInt(_,_)_INT-COMMON_Int_Int_Int`(`rfindString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I)) requires `_=/=String__STRING-COMMON_Bool_String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [UNIQUE_ID(b7f740050d72a847424b022a9c8217325aba8a154a42831aa3c7a3b0727f3205), org.kframework.attributes.Location(Location(1882,8,1882,182)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [symbol(#ruleRequires)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            VarS1:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            VarS2:SortString{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{})),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("b7f740050d72a847424b022a9c8217325aba8a154a42831aa3c7a3b0727f3205"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1882,8,1882,182)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(_Gen0,#token("\"\"","String"),_Gen1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(23b9fa88124c547d94aed32124d1ccd1069732b059f4c8b430ab4617979690f6), org.kframework.attributes.Location(Location(1883,8,1883,33)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            Var'Unds'Gen0:SortString{}
+          ),\and{R} (
+          \in{SortString{}, R} (
+            X1:SortString{},
+            \dv{SortString{}}("")
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            Var'Unds'Gen1:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("-1"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("23b9fa88124c547d94aed32124d1ccd1069732b059f4c8b430ab4617979690f6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1883,8,1883,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_-Int_`(`_modInt_`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))),`_<<Int_`(#token("1","Int"),LEN)),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f), org.kframework.attributes.Location(Location(1429,8,1429,164)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarI:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarIDX:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X2:SortInt{},
+            VarLEN:SortInt{}
+          ),
+          \top{R} ()
+        )))),
+    \equals{SortInt{},R} (
+      LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds'modInt'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1429,8,1429,164)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `smaxMInt(_)_MINT_Int_Int`(N)=>`_-Int_`(`_<<Int_`(#token("1","Int"),`_-Int_`(N,#token("1","Int"))),#token("1","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(885169667c6f8fea57b7fcc52120cbef83f7a6ce4b963cfd1964a8f45e16e376), org.kframework.attributes.Location(Location(2907,8,2907,54)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarN:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblsmaxMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarN:SortInt{},\dv{SortInt{}}("1"))),\dv{SortInt{}}("1")),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("885169667c6f8fea57b7fcc52120cbef83f7a6ce4b963cfd1964a8f45e16e376"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2907,8,2907,54)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `sminMInt(_)_MINT_Int_Int`(N)=>`_-Int_`(#token("0","Int"),`_<<Int_`(#token("1","Int"),`_-Int_`(N,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(905e85b657a586ca9a0fce05831454ca4a80fc7b87b06f13eeb3d4af7821b66c), org.kframework.attributes.Location(Location(2906,8,2906,54)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarN:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblsminMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(\dv{SortInt{}}("0"),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarN:SortInt{},\dv{SortInt{}}("1")))),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("905e85b657a586ca9a0fce05831454ca4a80fc7b87b06f13eeb3d4af7821b66c"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2906,8,2906,54)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `soverflowMInt(_,_)_MINT_Bool_Int_Int`(N,I)=>`_orBool_`(`_<Int_`(I,`sminMInt(_)_MINT_Int_Int`(N)),`_>Int_`(I,`smaxMInt(_)_MINT_Int_Int`(N))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(451ca26671f46f6bc7874beade344389ec2cd222fb83b97a9eedd324b8353629), org.kframework.attributes.Location(Location(2922,5,2924,49)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarN:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      LblsoverflowMInt'LParUndsCommUndsRParUnds'MINT'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       Lbl'Unds'orBool'Unds'{}(Lbl'Unds-LT-'Int'Unds'{}(VarI:SortInt{},LblsminMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(VarN:SortInt{})),Lbl'Unds-GT-'Int'Unds'{}(VarI:SortInt{},LblsmaxMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(VarN:SortInt{}))),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("451ca26671f46f6bc7874beade344389ec2cd222fb83b97a9eedd324b8353629"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2922,5,2924,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `umaxMInt(_)_MINT_Int_Int`(N)=>`_-Int_`(`_<<Int_`(#token("1","Int"),N),#token("1","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(112d01b7daf97f02c4b31925b2c46bfbbc1378e204996ff203543d4c44ccd5e5), org.kframework.attributes.Location(Location(2909,8,2909,45)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarN:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LblumaxMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       Lbl'Unds'-Int'Unds'{}(Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarN:SortInt{}),\dv{SortInt{}}("1")),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("112d01b7daf97f02c4b31925b2c46bfbbc1378e204996ff203543d4c44ccd5e5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2909,8,2909,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `uminMInt(_)_MINT_Int_Int`(_Gen0)=>#token("0","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(340a658083b6c1ac8b55d4c7c643de32cf560bb8b733ed8f9b139aee7c8c838b), org.kframework.attributes.Location(Location(2908,8,2908,28)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            Var'Unds'Gen0:SortInt{}
+          ),
+          \top{R} ()
+        )),
+    \equals{SortInt{},R} (
+      LbluminMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+     \and{SortInt{}} (
+       \dv{SortInt{}}("0"),
+        \top{SortInt{}}())))
+  [UNIQUE'Unds'ID{}("340a658083b6c1ac8b55d4c7c643de32cf560bb8b733ed8f9b139aee7c8c838b"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2908,8,2908,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+// rule `uoverflowMInt(_,_)_MINT_Bool_Int_Int`(N,I)=>`_orBool_`(`_<Int_`(I,`uminMInt(_)_MINT_Int_Int`(N)),`_>Int_`(I,`umaxMInt(_)_MINT_Int_Int`(N))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(669772aa6f72077d244868ca7dc07771189bb331b0347f2384101ba036d78ab2), org.kframework.attributes.Location(Location(2926,5,2928,49)), org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [symbol(#ruleNoConditions)])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortInt{}, R} (
+            X0:SortInt{},
+            VarN:SortInt{}
+          ),\and{R} (
+          \in{SortInt{}, R} (
+            X1:SortInt{},
+            VarI:SortInt{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      LbluoverflowMInt'LParUndsCommUndsRParUnds'MINT'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+     \and{SortBool{}} (
+       Lbl'Unds'orBool'Unds'{}(Lbl'Unds-LT-'Int'Unds'{}(VarI:SortInt{},LbluminMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(VarN:SortInt{})),Lbl'Unds-GT-'Int'Unds'{}(VarI:SortInt{},LblumaxMInt'LParUndsRParUnds'MINT'Unds'Int'Unds'Int{}(VarN:SortInt{}))),
+        \top{SortBool{}}())))
+  [UNIQUE'Unds'ID{}("669772aa6f72077d244868ca7dc07771189bb331b0347f2384101ba036d78ab2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2926,5,2928,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)")]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(17,1,61,10)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]

--- a/test/proof/mint-arith.kore
+++ b/test/proof/mint-arith.kore
@@ -1,5 +1,5 @@
 // RUN: %proof-interpreter
-// RUN: %check-dir-proof-out
+// RUN: %check-except-x86-llvm18-dir-proof-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/theo/builds/llvm-backend/test/proof/k-files/mint-arith.k)")]
 
 module BASIC-K


### PR DESCRIPTION
This PR fixes two issues related with the serialization of MInts in the proof trace:
- We add support for parametric sorts in the KORE rich header generation algorithm, because MInt sorts are indeed parametric. To do that we need to have an invariant of topological sorting of the ordinals of sorts, i.e. every sort needs to have an ordinal greater than the ordinals of all its parameters. We can guarantee that by generating the sort ordinals in this way, since all parametric sorts are known statically at compile time.
- We fix a bug on how we pass arguments to the `emit_*_to_proof_trace` functions that emit various events to the proof trace. Previously, when these functions needed to emit a KORE term as part of an event, they would accept a pointer to said KORE term as argument, an in case the term was a boolean or machine integer, that pointer would be cast to the actual value. However for machine integers longer than 64 bits, the pointer data type (which is 64 bit long) is not enough to store the machine integer value. We fix this by passing an actual pointer to the machine integer value in the case where the machine integer is longer than 64 bits.