### PR TITLE
try to delete some probably unneeded bitcasts

### DIFF
--- a/lib/codegen/CreateStaticTerm.cpp
+++ b/lib/codegen/CreateStaticTerm.cpp
@@ -83,10 +83,8 @@ llvm::Constant *create_static_term::not_injection_case(
 
   std::vector<llvm::Constant *> idxs
       = {llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx_), 0)};
-  return llvm::ConstantExpr::getBitCast(
-      llvm::ConstantExpr::getInBoundsGetElementPtr(
-          block_type, global_var, idxs),
-      llvm::PointerType::getUnqual(module_->getContext()));
+  return llvm::ConstantExpr::getInBoundsGetElementPtr(
+      block_type, global_var, idxs);
 }
 
 std::pair<llvm::Constant *, bool>

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -974,15 +974,14 @@ llvm::Value *create_term::not_injection_case(
   }
 
   auto *block_ptr = llvm::PointerType::getUnqual(module_->getContext());
-  auto *bitcast = new llvm::BitCastInst(block, block_ptr, "", current_block_);
   if (symbol_decl->attributes().contains(attribute_set::key::Binder)) {
     auto *call = llvm::CallInst::Create(
         get_or_insert_function(module_, "debruijnize", block_ptr, block_ptr),
-        bitcast, "withIndices", current_block_);
+        block, "withIndices", current_block_);
     set_debug_loc(call);
     return call;
   }
-  return bitcast;
+  return block;
 }
 
 // returns a value and a boolean indicating whether that value could be an


### PR DESCRIPTION
When we updated to the version of the llvm backend with opaque pointers, all pointer types become the same type in llvm bitcode. As such, we no longer need bitcast instructions to cast from one pointer type to another. These now redundant instructions can be removed.