### PR TITLE
further refactoring allocation code

### DIFF
--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -73,7 +73,7 @@ public:
   // Return value: the address allocated in the arena after size bytes from the
   //               starting pointer, or 0 if this is equal to the 3rd argument.
   static char *move_ptr(char *ptr, size_t size, char const *arena_end_ptr);
-  
+
   // Returns the ID of the semispace where the given address was allocated.
   // The behavior is undefined if called with an address that has not been
   // allocated within an arena.
@@ -91,14 +91,14 @@ private:
   // helper function for `kore_arena_alloc`. Do not call directly.
   void *do_alloc_slow(size_t requested);
 
-  char *first_block;  // beginning of first block
-  char *block;  // where allocations are being made in current block
-  char *block_start;  // start of current block
-  char *block_end;  // 1 past end of current block
-  char *first_collection_block;  // beginning of other semispace
-  size_t num_blocks;  // number of blocks in current semispace
-  size_t num_collection_blocks;  // number of blocks in other semispace
-  char allocation_semispace_id;  // id of current semispace
+  char *first_block; // beginning of first block
+  char *block; // where allocations are being made in current block
+  char *block_start; // start of current block
+  char *block_end; // 1 past end of current block
+  char *first_collection_block; // beginning of other semispace
+  size_t num_blocks; // number of blocks in current semispace
+  size_t num_collection_blocks; // number of blocks in other semispace
+  char allocation_semispace_id; // id of current semispace
 };
 
 // Macro to define a new arena with the given ID. Supports IDs ranging from 0 to
@@ -130,7 +130,6 @@ inline void *arena::kore_arena_alloc(size_t requested) {
       requested, block);
   return result;
 }
-
 }
 
 #endif // ARENA_H

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -14,6 +14,15 @@ class arena {
 public:
   arena(char id) : allocation_semispace_id(id) {}
   void fresh_block();
+  
+  // return the total number of allocatable bytes currently in the arena in its
+  // active semispace.
+  size_t arena_size() const;
+  
+  // Clears the current allocation space by setting its start back to its first
+  // block. It is used during garbage collection to effectively collect all of the
+  // arena.
+  void arena_clear();
 
 private:
   char *first_block;
@@ -27,10 +36,8 @@ private:
   //
   //	These functions need to be friends because they are called from LLVM code.
   //
-  friend void arena_clear(arena *arena);
   friend char * arena_start_ptr(const arena *arena);
   friend char **arena_end_ptr(arena *arena);
-  friend size_t arena_size(const arena *arena);
   friend char get_arena_collection_semispace_id(const arena *arena);
   friend void arena_swap_and_clear(arena *arena);
   friend void *kore_arena_alloc(arena *arena, size_t requested);
@@ -105,11 +112,6 @@ void *arena_resize_last_alloc(arena *, ssize_t);
 // It is used before garbage collection.
 void arena_swap_and_clear(arena *);
 
-// Clears the current allocation space by setting its start back to its first
-// block. It is used during garbage collection to effectively collect all of the
-// arena.
-void arena_clear(arena *);
-
 // Returns the address of the first byte that belongs in the given arena.
 // Returns 0 if nothing has been allocated ever in that arena.
 char *arena_start_ptr(const arena *);
@@ -136,10 +138,6 @@ char *move_ptr(char *, size_t, char const *);
 // sentinel bytes. Undefined behavior will result if the pointers belong to
 // different arenas.
 ssize_t ptr_diff(char *, char *);
-
-// return the total number of allocatable bytes currently in the arena in its
-// active semispace.
-size_t arena_size(const arena *);
 
 // Deallocates all the memory allocated for registered arenas.
 void free_all_memory(void);

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -14,6 +14,11 @@ class arena {
 public:
   arena(char id)
       : allocation_semispace_id(id) { }
+
+  // Allocates the requested number of bytes as a contiguous region and returns a
+  // pointer to the first allocated byte.
+  // If called with requested size greater than the maximun single allocation
+  // size, the space is allocated in a general (not garbage collected pool).
   void *kore_arena_alloc(size_t requested);
 
   // Returns the address of the first byte that belongs in the given arena.
@@ -114,10 +119,6 @@ extern thread_local bool time_for_collection;
 
 size_t get_gc_threshold();
 
-// Allocates the requested number of bytes as a contiguous region and returns a
-// pointer to the first allocated byte.
-// If called with requested size greater than the maximun single allocation
-// size, the space is allocated in a general (not garbage collected pool).
 inline void *arena::kore_arena_alloc(size_t requested) {
   if (block + requested > block_end) {
     return do_alloc_slow(requested);
@@ -130,8 +131,6 @@ inline void *arena::kore_arena_alloc(size_t requested) {
   return result;
 }
 
-// Deallocates all the memory allocated for registered arenas.
-void free_all_memory(void);
 }
 
 #endif // ARENA_H

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -14,6 +14,15 @@ class arena {
 public:
   arena(char id) : allocation_semispace_id(id) {}
   void *kore_arena_alloc(size_t requested);
+  
+  // Returns the address of the first byte that belongs in the given arena.
+  // Returns 0 if nothing has been allocated ever in that arena.
+  char *arena_start_ptr() const;
+
+  // Returns a pointer to a location holding the address of last allocated
+  // byte in the given arena plus 1.
+  // This address is 0 if nothing has been allocated ever in that arena.
+  char **arena_end_ptr();
 
   // return the total number of allocatable bytes currently in the arena in its
   // active semispace.
@@ -55,12 +64,6 @@ private:
   size_t num_blocks;
   size_t num_collection_blocks;
   char allocation_semispace_id;
-  //
-  //	These functions need to be friends because they are called from LLVM code.
-  //
-  friend char *arena_start_ptr(const arena *arena);
-  friend char **arena_end_ptr(arena *arena);
-  //friend bool youngspace_almost_full(size_t threshold);
 };
 
 using memory_block_header = struct {
@@ -112,14 +115,6 @@ inline void
   return result;
 }
 
-// Returns the address of the first byte that belongs in the given arena.
-// Returns 0 if nothing has been allocated ever in that arena.
-char *arena_start_ptr(const arena *);
-
-// Returns a pointer to a location holding the address of last allocated
-// byte in the given arena plus 1.
-// This address is 0 if nothing has been allocated ever in that arena.
-char **arena_end_ptr(arena *);
 
 // Given a starting pointer to an address allocated in an arena and a size in
 // bytes, this function returns a pointer to an address allocated in the

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -25,28 +25,18 @@ private:
   size_t num_collection_blocks;
   char allocation_semispace_id;
   //
-  //	First step, make all the functions that look like they should be member
-  //	functions into friends so that they can access the data members.
-  //
-  friend void *kore_arena_alloc(arena *arena, size_t requested);
-
-  friend char get_arena_allocation_semispace_id(const arena *arena);
-  friend char get_arena_collection_semispace_id(const arena *arena);
-
-  friend void *do_alloc_slow(size_t requested, arena *arena);
-  friend void *arena_resize_last_alloc(arena *arena, ssize_t increase);
-  friend void arena_swap_and_clear(arena *arena);
-  //
-  //	These things probably shouldn't be friends but are needed to compile.
-  //
-  friend bool youngspace_almost_full(size_t threshold);
-  //
-  //	Needs to be a friend because called from LLVM code.
+  //	These functions need to be friends because they are called from LLVM code.
   //
   friend void arena_clear(arena *arena);
   friend char * arena_start_ptr(const arena *arena);
   friend char **arena_end_ptr(arena *arena);
   friend size_t arena_size(const arena *arena);
+  friend char get_arena_collection_semispace_id(const arena *arena);
+  friend void arena_swap_and_clear(arena *arena);
+  friend void *kore_arena_alloc(arena *arena, size_t requested);
+  friend void *do_alloc_slow(size_t requested, arena *arena);
+  friend void *arena_resize_last_alloc(arena *arena, ssize_t increase);
+  friend bool youngspace_almost_full(size_t threshold);
 };
 
 using memory_block_header = struct {
@@ -73,9 +63,6 @@ extern thread_local bool time_for_collection;
 #endif
 
 size_t get_gc_threshold();
-
-// Resets the given arena.
-void arena_reset(arena *);
 
 // Returns the given arena's current allocation semispace ID.
 // Each arena has 2 semispace IDs one equal to the arena ID and the other equal

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -13,6 +13,7 @@ extern "C" {
 class arena {
 public:
   arena(char id) : allocation_semispace_id(id) {}
+  void fresh_block();
 
 private:
   char *first_block;
@@ -29,23 +30,23 @@ private:
   //
   friend void *kore_arena_alloc(arena *arena, size_t requested);
 
-  friend void arena_reset(arena *arena);
   friend char get_arena_allocation_semispace_id(const arena *arena);
   friend char get_arena_collection_semispace_id(const arena *arena);
-  friend void fresh_block(arena *arena);
 
-  friend void fresh_block(arena *arena);
   friend void *do_alloc_slow(size_t requested, arena *arena);
   friend void *arena_resize_last_alloc(arena *arena, ssize_t increase);
   friend void arena_swap_and_clear(arena *arena);
-  friend void arena_clear(arena *arena);
-  friend char * arena_start_ptr(const arena *arena);
-  friend char **arena_end_ptr(arena *arena);
-  friend size_t arena_size(const arena *arena);
   //
   //	These things probably shouldn't be friends but are needed to compile.
   //
   friend bool youngspace_almost_full(size_t threshold);
+  //
+  //	Needs to be a friend because called from LLVM code.
+  //
+  friend void arena_clear(arena *arena);
+  friend char * arena_start_ptr(const arena *arena);
+  friend char **arena_end_ptr(arena *arena);
+  friend size_t arena_size(const arena *arena);
 };
 
 using memory_block_header = struct {

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -12,9 +12,10 @@ extern "C" {
 // once.
 class arena {
 public:
-  arena(char id) : allocation_semispace_id(id) {}
+  arena(char id)
+      : allocation_semispace_id(id) { }
   void *kore_arena_alloc(size_t requested);
-  
+
   // Returns the address of the first byte that belongs in the given arena.
   // Returns 0 if nothing has been allocated ever in that arena.
   char *arena_start_ptr() const;
@@ -27,7 +28,7 @@ public:
   // return the total number of allocatable bytes currently in the arena in its
   // active semispace.
   size_t arena_size() const;
-  
+
   // Clears the current allocation space by setting its start back to its first
   // block. It is used during garbage collection to effectively collect all of the
   // arena.
@@ -38,13 +39,13 @@ public:
   // Returns the address of the byte following the last newlly allocated byte when
   // the resize succeeds, returns 0 otherwise.
   void *arena_resize_last_alloc(ssize_t increase);
-  
+
   // Returns the given arena's current collection semispace ID.
   // Each arena has 2 semispace IDs one equal to the arena ID and the other equal
   // to the 1's complement of the arena ID. At any time one of these semispaces
   // is used for allocation and the other is used for collection.
   char get_arena_collection_semispace_id() const;
-  
+
   // Exchanges the current allocation and collection semispaces and clears the new
   // current allocation semispace by setting its start back to its first block.
   // It is used before garbage collection.
@@ -52,7 +53,7 @@ public:
 
 private:
   void fresh_block();
-  
+
   // helper function for `kore_arena_alloc`. Do not call directly.
   void *do_alloc_slow(size_t requested);
 
@@ -74,8 +75,7 @@ using memory_block_header = struct {
 
 // Macro to define a new arena with the given ID. Supports IDs ranging from 0 to
 // 127.
-#define REGISTER_ARENA(name, id)                                               \
-  static thread_local arena name(id)
+#define REGISTER_ARENA(name, id) static thread_local arena name(id)
 
 #define MEM_BLOCK_START(ptr)                                                   \
   ((char *)(((uintptr_t)(ptr)-1) & ~(BLOCK_SIZE - 1)))
@@ -91,19 +91,16 @@ extern thread_local bool time_for_collection;
 
 size_t get_gc_threshold();
 
-
 // Returns the ID of the semispace where the given address was allocated.
 // The behavior is undefined if called with an address that has not been
 // allocated within an arena.
 char get_arena_semispace_id_of_object(void *);
 
-
 // Allocates the requested number of bytes as a contiguous region and returns a
 // pointer to the first allocated byte.
 // If called with requested size greater than the maximun single allocation
 // size, the space is allocated in a general (not garbage collected pool).
-inline void
-*arena::kore_arena_alloc(size_t requested) {
+inline void *arena::kore_arena_alloc(size_t requested) {
   if (block + requested > block_end) {
     return do_alloc_slow(requested);
   }
@@ -114,7 +111,6 @@ inline void
       requested, block);
   return result;
 }
-
 
 // Given a starting pointer to an address allocated in an arena and a size in
 // bytes, this function returns a pointer to an address allocated in the

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -64,14 +64,10 @@ extern thread_local bool time_for_collection;
 
 size_t get_gc_threshold();
 
-// Returns the given arena's current allocation semispace ID.
+// Returns the given arena's current collection semispace ID.
 // Each arena has 2 semispace IDs one equal to the arena ID and the other equal
 // to the 1's complement of the arena ID. At any time one of these semispaces
 // is used for allocation and the other is used for collection.
-char get_arena_allocation_semispace_id(const arena *);
-
-// Returns the given arena's current collection semispace ID.
-// See above for details.
 char get_arena_collection_semispace_id(const arena *);
 
 // Returns the ID of the semispace where the given address was allocated.

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -10,7 +10,11 @@ extern "C" {
 
 // An arena can be used to allocate objects that can then be deallocated all at
 // once.
-struct arena {
+class arena {
+public:
+  arena(char id) : allocation_semispace_id(id) {}
+
+private:
   char *first_block;
   char *block;
   char *block_start;
@@ -19,6 +23,29 @@ struct arena {
   size_t num_blocks;
   size_t num_collection_blocks;
   char allocation_semispace_id;
+  //
+  //	First step, make all the functions that look like they should be member
+  //	functions into friends so that they can access the data members.
+  //
+  friend void *kore_arena_alloc(arena *arena, size_t requested);
+
+  friend void arena_reset(arena *arena);
+  friend char get_arena_allocation_semispace_id(const arena *arena);
+  friend char get_arena_collection_semispace_id(const arena *arena);
+  friend void fresh_block(arena *arena);
+
+  friend void fresh_block(arena *arena);
+  friend void *do_alloc_slow(size_t requested, arena *arena);
+  friend void *arena_resize_last_alloc(arena *arena, ssize_t increase);
+  friend void arena_swap_and_clear(arena *arena);
+  friend void arena_clear(arena *arena);
+  friend char * arena_start_ptr(const arena *arena);
+  friend char **arena_end_ptr(arena *arena);
+  friend size_t arena_size(const arena *arena);
+  //
+  //	These things probably shouldn't be friends but are needed to compile.
+  //
+  friend bool youngspace_almost_full(size_t threshold);
 };
 
 using memory_block_header = struct {
@@ -30,7 +57,7 @@ using memory_block_header = struct {
 // Macro to define a new arena with the given ID. Supports IDs ranging from 0 to
 // 127.
 #define REGISTER_ARENA(name, id)                                               \
-  static thread_local struct arena name = {.allocation_semispace_id = (id)}
+  static thread_local arena name(id)
 
 #define MEM_BLOCK_START(ptr)                                                   \
   ((char *)(((uintptr_t)(ptr)-1) & ~(BLOCK_SIZE - 1)))
@@ -47,17 +74,17 @@ extern thread_local bool time_for_collection;
 size_t get_gc_threshold();
 
 // Resets the given arena.
-void arena_reset(struct arena *);
+void arena_reset(arena *);
 
 // Returns the given arena's current allocation semispace ID.
 // Each arena has 2 semispace IDs one equal to the arena ID and the other equal
 // to the 1's complement of the arena ID. At any time one of these semispaces
 // is used for allocation and the other is used for collection.
-char get_arena_allocation_semispace_id(const struct arena *);
+char get_arena_allocation_semispace_id(const arena *);
 
 // Returns the given arena's current collection semispace ID.
 // See above for details.
-char get_arena_collection_semispace_id(const struct arena *);
+char get_arena_collection_semispace_id(const arena *);
 
 // Returns the ID of the semispace where the given address was allocated.
 // The behavior is undefined if called with an address that has not been
@@ -65,13 +92,13 @@ char get_arena_collection_semispace_id(const struct arena *);
 char get_arena_semispace_id_of_object(void *);
 
 // helper function for `kore_arena_alloc`. Do not call directly.
-void *do_alloc_slow(size_t, struct arena *);
+void *do_alloc_slow(size_t, arena *);
 
 // Allocates the requested number of bytes as a contiguous region and returns a
 // pointer to the first allocated byte.
 // If called with requested size greater than the maximun single allocation
 // size, the space is allocated in a general (not garbage collected pool).
-inline void *kore_arena_alloc(struct arena *arena, size_t requested) {
+inline void *kore_arena_alloc(arena *arena, size_t requested) {
   if (arena->block + requested > arena->block_end) {
     return do_alloc_slow(requested, arena);
   }
@@ -87,26 +114,26 @@ inline void *kore_arena_alloc(struct arena *arena, size_t requested) {
 // block allocation.
 // Returns the address of the byte following the last newlly allocated byte when
 // the resize succeeds, returns 0 otherwise.
-void *arena_resize_last_alloc(struct arena *, ssize_t);
+void *arena_resize_last_alloc(arena *, ssize_t);
 
 // Exchanges the current allocation and collection semispaces and clears the new
 // current allocation semispace by setting its start back to its first block.
 // It is used before garbage collection.
-void arena_swap_and_clear(struct arena *);
+void arena_swap_and_clear(arena *);
 
 // Clears the current allocation space by setting its start back to its first
 // block. It is used during garbage collection to effectively collect all of the
 // arena.
-void arena_clear(struct arena *);
+void arena_clear(arena *);
 
 // Returns the address of the first byte that belongs in the given arena.
 // Returns 0 if nothing has been allocated ever in that arena.
-char *arena_start_ptr(const struct arena *);
+char *arena_start_ptr(const arena *);
 
 // Returns a pointer to a location holding the address of last allocated
 // byte in the given arena plus 1.
 // This address is 0 if nothing has been allocated ever in that arena.
-char **arena_end_ptr(struct arena *);
+char **arena_end_ptr(arena *);
 
 // Given a starting pointer to an address allocated in an arena and a size in
 // bytes, this function returns a pointer to an address allocated in the
@@ -128,7 +155,7 @@ ssize_t ptr_diff(char *, char *);
 
 // return the total number of allocatable bytes currently in the arena in its
 // active semispace.
-size_t arena_size(const struct arena *);
+size_t arena_size(const arena *);
 
 // Deallocates all the memory allocated for registered arenas.
 void free_all_memory(void);

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -189,13 +189,14 @@ __attribute__((always_inline)) void arena::arena_clear() {
 }
 
 __attribute__((always_inline)) char *
-arena_start_ptr(const arena *arena) {
-  return arena->first_block ? arena->first_block + sizeof(memory_block_header)
-                            : nullptr;
+arena::arena_start_ptr() const {
+  return first_block ? first_block + sizeof(memory_block_header)
+                     : nullptr;
 }
 
-__attribute__((always_inline)) char **arena_end_ptr(arena *arena) {
-  return &arena->block;
+__attribute__((always_inline)) char **
+arena::arena_end_ptr() {
+  return &block;
 }
 
 char *move_ptr(char *ptr, size_t size, char const *arena_end_ptr) {

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -20,8 +20,8 @@ mem_block_header(void *ptr) {
 }
 
 __attribute__((always_inline)) char
-get_arena_collection_semispace_id(const arena *arena) {
-  return ~arena->allocation_semispace_id;
+arena::get_arena_collection_semispace_id() const {
+  return ~allocation_semispace_id;
 }
 
 __attribute__((always_inline)) char
@@ -163,10 +163,10 @@ do_alloc_slow(size_t requested, arena *arena) {
 }
 
 __attribute__((always_inline)) void *
-arena_resize_last_alloc(arena *arena, ssize_t increase) {
-  if (arena->block + increase <= arena->block_end) {
-    arena->block += increase;
-    return arena->block;
+arena::arena_resize_last_alloc(ssize_t increase) {
+  if (block + increase <= block_end) {
+    block += increase;
+    return block;
   }
   return nullptr;
 }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -20,11 +20,6 @@ mem_block_header(void *ptr) {
 }
 
 __attribute__((always_inline)) char
-get_arena_allocation_semispace_id(const arena *arena) {
-  return arena->allocation_semispace_id;
-}
-
-__attribute__((always_inline)) char
 get_arena_collection_semispace_id(const arena *arena) {
   return ~arena->allocation_semispace_id;
 }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -105,11 +105,10 @@ void arena::fresh_block() {
     next_block = *(char **)block_start;
     if (block != block_end) {
       if (block_end - block == 8) {
-        *(uint64_t *)block
-            = NOT_YOUNG_OBJECT_BIT; // 8 bit sentinel value
+        *(uint64_t *)block = NOT_YOUNG_OBJECT_BIT; // 8 bit sentinel value
       } else {
-        *(uint64_t *)block = block_end - block
-                                    - 8; // 16-bit or more sentinel value
+        *(uint64_t *)block
+            = block_end - block - 8; // 16-bit or more sentinel value
       }
     }
     if (!next_block) {
@@ -145,8 +144,7 @@ bool gc_enabled = true;
 thread_local bool gc_enabled = true;
 #endif
 
-__attribute__((noinline)) void *
-arena::do_alloc_slow(size_t requested) {
+__attribute__((noinline)) void *arena::do_alloc_slow(size_t requested) {
   MEM_LOG(
       "Block at %p too small, %zd remaining but %zd needed\n", block,
       block_end - block, requested);
@@ -188,14 +186,11 @@ __attribute__((always_inline)) void arena::arena_clear() {
   block_end = first_block ? first_block + BLOCK_SIZE : nullptr;
 }
 
-__attribute__((always_inline)) char *
-arena::arena_start_ptr() const {
-  return first_block ? first_block + sizeof(memory_block_header)
-                     : nullptr;
+__attribute__((always_inline)) char *arena::arena_start_ptr() const {
+  return first_block ? first_block + sizeof(memory_block_header) : nullptr;
 }
 
-__attribute__((always_inline)) char **
-arena::arena_end_ptr() {
+__attribute__((always_inline)) char **arena::arena_end_ptr() {
   return &block;
 }
 
@@ -243,8 +238,7 @@ ssize_t ptr_diff(char *ptr1, char *ptr2) {
 }
 
 size_t arena::arena_size() const {
-  return (num_blocks > num_collection_blocks
-              ? num_blocks
-              : num_collection_blocks)
+  return (num_blocks > num_collection_blocks ? num_blocks
+                                             : num_collection_blocks)
          * (BLOCK_SIZE - sizeof(memory_block_header));
 }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -179,16 +179,13 @@ __attribute__((always_inline)) void arena_swap_and_clear(arena *arena) {
   arena->num_blocks = arena->num_collection_blocks;
   arena->num_collection_blocks = tmp2;
   arena->allocation_semispace_id = ~arena->allocation_semispace_id;
-  arena_clear(arena);
+  arena->arena_clear();
 }
 
-__attribute__((always_inline)) void arena_clear(arena *arena) {
-  arena->block = arena->first_block
-                     ? arena->first_block + sizeof(memory_block_header)
-                     : nullptr;
-  arena->block_start = arena->first_block;
-  arena->block_end
-      = arena->first_block ? arena->first_block + BLOCK_SIZE : nullptr;
+__attribute__((always_inline)) void arena::arena_clear() {
+  block = first_block ? first_block + sizeof(memory_block_header) : nullptr;
+  block_start = first_block;
+  block_end = first_block ? first_block + BLOCK_SIZE : nullptr;
 }
 
 __attribute__((always_inline)) char *
@@ -244,9 +241,9 @@ ssize_t ptr_diff(char *ptr1, char *ptr2) {
   return -ptr_diff(ptr2, ptr1);
 }
 
-size_t arena_size(const arena *arena) {
-  return (arena->num_blocks > arena->num_collection_blocks
-              ? arena->num_blocks
-              : arena->num_collection_blocks)
+size_t arena::arena_size() const {
+  return (num_blocks > num_collection_blocks
+              ? num_blocks
+              : num_collection_blocks)
          * (BLOCK_SIZE - sizeof(memory_block_header));
 }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -33,7 +33,6 @@ arena::get_arena_semispace_id_of_object(void *ptr) {
 //	We will reserve enough address space for 1 million 1MB blocks. Might want to increase this on a > 1TB server.
 //
 size_t const HYPERBLOCK_SIZE = (size_t)BLOCK_SIZE * 1024 * 1024;
-static thread_local void *hyperblock_ptr = nullptr; // only needed for munmap()
 
 static void *megabyte_malloc() {
   //
@@ -64,7 +63,6 @@ static void *megabyte_malloc() {
       perror("mmap()");
       abort();
     }
-    hyperblock_ptr = addr;
     //
     //	We ask for one block worth of address space less than we allocated so alignment will always succeed.
     //	We don't worry about unused address space either side of our aligned address space because there will be no
@@ -74,13 +72,6 @@ static void *megabyte_malloc() {
         std::align(BLOCK_SIZE, HYPERBLOCK_SIZE - BLOCK_SIZE, addr, request));
   }
   return currentblock_ptr;
-}
-
-void free_all_memory() {
-  //
-  //	Frees all memory that was demand paged into this address range.
-  //
-  munmap(hyperblock_ptr, HYPERBLOCK_SIZE);
 }
 
 #ifdef __MACH__

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -19,7 +19,7 @@ mem_block_header(void *ptr) {
       ((uintptr_t)(ptr)-1) & ~(BLOCK_SIZE - 1));
 }
 
-__attribute__((always_inline)) void arena_reset(struct arena *arena) {
+__attribute__((always_inline)) void arena_reset(arena *arena) {
   char id = arena->allocation_semispace_id;
   if (id < 0) {
     id = ~arena->allocation_semispace_id;
@@ -35,12 +35,12 @@ __attribute__((always_inline)) void arena_reset(struct arena *arena) {
 }
 
 __attribute__((always_inline)) char
-get_arena_allocation_semispace_id(const struct arena *arena) {
+get_arena_allocation_semispace_id(const arena *arena) {
   return arena->allocation_semispace_id;
 }
 
 __attribute__((always_inline)) char
-get_arena_collection_semispace_id(const struct arena *arena) {
+get_arena_collection_semispace_id(const arena *arena) {
   return ~arena->allocation_semispace_id;
 }
 
@@ -112,7 +112,7 @@ bool time_for_collection;
 thread_local bool time_for_collection;
 #endif
 
-static void fresh_block(struct arena *arena) {
+void fresh_block(arena *arena) {
   char *next_block = nullptr;
   if (arena->block_start == nullptr) {
     next_block = (char *)megabyte_malloc();
@@ -166,7 +166,7 @@ thread_local bool gc_enabled = true;
 #endif
 
 __attribute__((noinline)) void *
-do_alloc_slow(size_t requested, struct arena *arena) {
+do_alloc_slow(size_t requested, arena *arena) {
   MEM_LOG(
       "Block at %p too small, %zd remaining but %zd needed\n", arena->block,
       arena->block_end - arena->block, requested);
@@ -183,7 +183,7 @@ do_alloc_slow(size_t requested, struct arena *arena) {
 }
 
 __attribute__((always_inline)) void *
-arena_resize_last_alloc(struct arena *arena, ssize_t increase) {
+arena_resize_last_alloc(arena *arena, ssize_t increase) {
   if (arena->block + increase <= arena->block_end) {
     arena->block += increase;
     return arena->block;
@@ -191,7 +191,7 @@ arena_resize_last_alloc(struct arena *arena, ssize_t increase) {
   return nullptr;
 }
 
-__attribute__((always_inline)) void arena_swap_and_clear(struct arena *arena) {
+__attribute__((always_inline)) void arena_swap_and_clear(arena *arena) {
   char *tmp = arena->first_block;
   arena->first_block = arena->first_collection_block;
   arena->first_collection_block = tmp;
@@ -202,7 +202,7 @@ __attribute__((always_inline)) void arena_swap_and_clear(struct arena *arena) {
   arena_clear(arena);
 }
 
-__attribute__((always_inline)) void arena_clear(struct arena *arena) {
+__attribute__((always_inline)) void arena_clear(arena *arena) {
   arena->block = arena->first_block
                      ? arena->first_block + sizeof(memory_block_header)
                      : nullptr;
@@ -212,12 +212,12 @@ __attribute__((always_inline)) void arena_clear(struct arena *arena) {
 }
 
 __attribute__((always_inline)) char *
-arena_start_ptr(const struct arena *arena) {
+arena_start_ptr(const arena *arena) {
   return arena->first_block ? arena->first_block + sizeof(memory_block_header)
                             : nullptr;
 }
 
-__attribute__((always_inline)) char **arena_end_ptr(struct arena *arena) {
+__attribute__((always_inline)) char **arena_end_ptr(arena *arena) {
   return &arena->block;
 }
 
@@ -264,7 +264,7 @@ ssize_t ptr_diff(char *ptr1, char *ptr2) {
   return -ptr_diff(ptr2, ptr1);
 }
 
-size_t arena_size(const struct arena *arena) {
+size_t arena_size(const arena *arena) {
   return (arena->num_blocks > arena->num_collection_blocks
               ? arena->num_blocks
               : arena->num_collection_blocks)

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -172,13 +172,15 @@ __attribute__((always_inline)) void arena::arena_swap_and_clear() {
 }
 
 __attribute__((always_inline)) void arena::arena_clear() {
-  block = first_block ? first_block + sizeof(arena::memory_block_header) : nullptr;
+  block = first_block ? first_block + sizeof(arena::memory_block_header)
+                      : nullptr;
   block_start = first_block;
   block_end = first_block ? first_block + BLOCK_SIZE : nullptr;
 }
 
 __attribute__((always_inline)) char *arena::arena_start_ptr() const {
-  return first_block ? first_block + sizeof(arena::memory_block_header) : nullptr;
+  return first_block ? first_block + sizeof(arena::memory_block_header)
+                     : nullptr;
 }
 
 __attribute__((always_inline)) char **arena::arena_end_ptr() {

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -85,9 +85,9 @@ void migrate_once(block **block_ptr) {
     return;
   }
   if (youngspace_collection_id()
-      == arena::get_arena_semispace_id_of_object((void *)curr_block)
+          == arena::get_arena_semispace_id_of_object((void *)curr_block)
       || oldspace_collection_id()
-      == arena::get_arena_semispace_id_of_object((void *)curr_block)) {
+             == arena::get_arena_semispace_id_of_object((void *)curr_block)) {
     migrate(block_ptr);
   }
 }
@@ -327,7 +327,8 @@ void kore_collect(
       // kore_arena_alloc, which will have allocated a fresh memory block and put
       // the allocation at the start of it. Thus, we use arena::move_ptr with a size
       // of zero to adjust and get the true address of the allocation.
-      scan_ptr = arena::move_ptr(previous_oldspace_alloc_ptr, 0, *old_alloc_ptr());
+      scan_ptr
+          = arena::move_ptr(previous_oldspace_alloc_ptr, 0, *old_alloc_ptr());
     } else {
       scan_ptr = previous_oldspace_alloc_ptr;
     }
@@ -340,7 +341,7 @@ void kore_collect(
   }
 #ifdef GC_DBG
   ssize_t numBytesAllocedSinceLastCollection
-    = arena::ptr_diff(current_alloc_ptr, last_alloc_ptr);
+      = arena::ptr_diff(current_alloc_ptr, last_alloc_ptr);
   assert(numBytesAllocedSinceLastCollection >= 0);
   fwrite(&numBytesAllocedSinceLastCollection, sizeof(ssize_t), 1, stderr);
   last_alloc_ptr = *young_alloc_ptr();

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -85,9 +85,9 @@ void migrate_once(block **block_ptr) {
     return;
   }
   if (youngspace_collection_id()
-          == get_arena_semispace_id_of_object((void *)curr_block)
+      == arena::get_arena_semispace_id_of_object((void *)curr_block)
       || oldspace_collection_id()
-             == get_arena_semispace_id_of_object((void *)curr_block)) {
+      == arena::get_arena_semispace_id_of_object((void *)curr_block)) {
     migrate(block_ptr);
   }
 }
@@ -255,7 +255,7 @@ static char *evacuate(char *scan_ptr, char **alloc_ptr) {
       migrate_child(curr_block, layout_data->args, i, false);
     }
   }
-  return move_ptr(scan_ptr, get_size(hdr, layout_int), *alloc_ptr);
+  return arena::move_ptr(scan_ptr, get_size(hdr, layout_int), *alloc_ptr);
 }
 
 // Contains the decision logic for collecting the old generation.
@@ -325,9 +325,9 @@ void kore_collect(
       // allocation pointer is invalid and does not actually point to the next
       // address that would have been allocated at, according to the logic of
       // kore_arena_alloc, which will have allocated a fresh memory block and put
-      // the allocation at the start of it. Thus, we use move_ptr with a size
+      // the allocation at the start of it. Thus, we use arena::move_ptr with a size
       // of zero to adjust and get the true address of the allocation.
-      scan_ptr = move_ptr(previous_oldspace_alloc_ptr, 0, *old_alloc_ptr());
+      scan_ptr = arena::move_ptr(previous_oldspace_alloc_ptr, 0, *old_alloc_ptr());
     } else {
       scan_ptr = previous_oldspace_alloc_ptr;
     }
@@ -340,7 +340,7 @@ void kore_collect(
   }
 #ifdef GC_DBG
   ssize_t numBytesAllocedSinceLastCollection
-      = ptr_diff(current_alloc_ptr, last_alloc_ptr);
+    = arena::ptr_diff(current_alloc_ptr, last_alloc_ptr);
   assert(numBytesAllocedSinceLastCollection >= 0);
   fwrite(&numBytesAllocedSinceLastCollection, sizeof(ssize_t), 1, stderr);
   last_alloc_ptr = *young_alloc_ptr();

--- a/runtime/collect/migrate_collection.cpp
+++ b/runtime/collect/migrate_collection.cpp
@@ -7,9 +7,9 @@
 void migrate_collection_node(void **node_ptr) {
   string *curr_block = STRUCT_BASE(string, data, *node_ptr);
   if (youngspace_collection_id()
-      != arena::get_arena_semispace_id_of_object((void *)curr_block)
+          != arena::get_arena_semispace_id_of_object((void *)curr_block)
       && oldspace_collection_id()
-      != arena::get_arena_semispace_id_of_object((void *)curr_block)) {
+             != arena::get_arena_semispace_id_of_object((void *)curr_block)) {
     return;
   }
   uint64_t const hdr = curr_block->h.hdr;

--- a/runtime/collect/migrate_collection.cpp
+++ b/runtime/collect/migrate_collection.cpp
@@ -7,9 +7,9 @@
 void migrate_collection_node(void **node_ptr) {
   string *curr_block = STRUCT_BASE(string, data, *node_ptr);
   if (youngspace_collection_id()
-          != get_arena_semispace_id_of_object((void *)curr_block)
+      != arena::get_arena_semispace_id_of_object((void *)curr_block)
       && oldspace_collection_id()
-             != get_arena_semispace_id_of_object((void *)curr_block)) {
+      != arena::get_arena_semispace_id_of_object((void *)curr_block)) {
     return;
   }
   uint64_t const hdr = curr_block->h.hdr;

--- a/runtime/lto/alloc.cpp
+++ b/runtime/lto/alloc.cpp
@@ -49,9 +49,9 @@ bool youngspace_almost_full(size_t threshold) {
 }
 
 void kore_alloc_swap(bool swap_old) {
-  arena_swap_and_clear(&youngspace);
+  youngspace.arena_swap_and_clear();
   if (swap_old) {
-    arena_swap_and_clear(&oldspace);
+    oldspace.arena_swap_and_clear();
   }
 }
 

--- a/runtime/lto/alloc.cpp
+++ b/runtime/lto/alloc.cpp
@@ -43,11 +43,6 @@ size_t youngspace_size(void) {
   return youngspace.arena_size();
 }
 
-bool youngspace_almost_full(size_t threshold) {
-  char *next_block = *(char **)youngspace.block_start;
-  return !next_block;
-}
-
 void kore_alloc_swap(bool swap_old) {
   youngspace.arena_swap_and_clear();
   if (swap_old) {
@@ -64,25 +59,25 @@ void set_kore_memory_functions_for_gmp() {
 }
 
 __attribute__((always_inline)) void *kore_alloc(size_t requested) {
-  return kore_arena_alloc(&youngspace, requested);
+  return youngspace.kore_arena_alloc(requested);
 }
 
 __attribute__((always_inline)) void *kore_alloc_token(size_t requested) {
   size_t size = (requested + 7) & ~7;
-  return kore_arena_alloc(&youngspace, size < 16 ? 16 : size);
+  return youngspace.kore_arena_alloc(size < 16 ? 16 : size);
 }
 
 __attribute__((always_inline)) void *kore_alloc_old(size_t requested) {
-  return kore_arena_alloc(&oldspace, requested);
+  return oldspace.kore_arena_alloc(requested);
 }
 
 __attribute__((always_inline)) void *kore_alloc_token_old(size_t requested) {
   size_t size = (requested + 7) & ~7;
-  return kore_arena_alloc(&oldspace, size < 16 ? 16 : size);
+  return oldspace.kore_arena_alloc(size < 16 ? 16 : size);
 }
 
 __attribute__((always_inline)) void *kore_alloc_always_gc(size_t requested) {
-  return kore_arena_alloc(&alwaysgcspace, requested);
+  return alwaysgcspace.kore_arena_alloc(requested);
 }
 
 void *

--- a/runtime/lto/alloc.cpp
+++ b/runtime/lto/alloc.cpp
@@ -16,19 +16,19 @@ REGISTER_ARENA(oldspace, OLDSPACE_ID);
 REGISTER_ARENA(alwaysgcspace, ALWAYSGCSPACE_ID);
 
 char *youngspace_ptr() {
-  return arena_start_ptr(&youngspace);
+  return youngspace.arena_start_ptr();
 }
 
 char *oldspace_ptr() {
-  return arena_start_ptr(&oldspace);
+  return oldspace.arena_start_ptr();
 }
 
 char **young_alloc_ptr() {
-  return arena_end_ptr(&youngspace);
+  return youngspace.arena_end_ptr();
 }
 
 char **old_alloc_ptr() {
-  return arena_end_ptr(&oldspace);
+  return oldspace.arena_end_ptr();
 }
 
 char youngspace_collection_id() {
@@ -85,7 +85,7 @@ kore_resize_last_alloc(void *oldptr, size_t newrequest, size_t last_size) {
   newrequest = (newrequest + 7) & ~7;
   last_size = (last_size + 7) & ~7;
 
-  if (oldptr != *arena_end_ptr(&youngspace) - last_size) {
+  if (oldptr != *(youngspace.arena_end_ptr()) - last_size) {
     MEM_LOG(
         "May only reallocate last allocation. Tried to reallocate %p to %zd\n",
         oldptr, newrequest);

--- a/runtime/lto/alloc.cpp
+++ b/runtime/lto/alloc.cpp
@@ -40,7 +40,7 @@ char oldspace_collection_id() {
 }
 
 size_t youngspace_size(void) {
-  return arena_size(&youngspace);
+  return youngspace.arena_size();
 }
 
 bool youngspace_almost_full(size_t threshold) {
@@ -56,7 +56,7 @@ void kore_alloc_swap(bool swap_old) {
 }
 
 void kore_clear() {
-  arena_clear(&alwaysgcspace);
+  alwaysgcspace.arena_clear();
 }
 
 void set_kore_memory_functions_for_gmp() {

--- a/runtime/lto/alloc.cpp
+++ b/runtime/lto/alloc.cpp
@@ -32,11 +32,11 @@ char **old_alloc_ptr() {
 }
 
 char youngspace_collection_id() {
-  return get_arena_collection_semispace_id(&youngspace);
+  return youngspace.get_arena_collection_semispace_id();
 }
 
 char oldspace_collection_id() {
-  return get_arena_collection_semispace_id(&oldspace);
+  return oldspace.get_arena_collection_semispace_id();
 }
 
 size_t youngspace_size(void) {
@@ -98,7 +98,7 @@ kore_resize_last_alloc(void *oldptr, size_t newrequest, size_t last_size) {
   }
 
   ssize_t increase = newrequest - last_size;
-  if (arena_resize_last_alloc(&youngspace, increase)) {
+  if (youngspace.arena_resize_last_alloc(increase)) {
     return oldptr;
   }
 


### PR DESCRIPTION
* memory_block_header now a struct member of class arena; next_superblock field deleted

* global function free_all_memory() deleted

* global variable hyperblock_ptr deleted

* global functions make ptr_diff(), move_ptr(), get_arena_semispace_id_of_object(), mem_block_header() now static member functions of class arena
