### PR TITLE
New allocation algorithm

### DIFF
--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -61,7 +61,7 @@ public:
   // by the blocks of that arena. This difference will include blocks containing
   // sentinel bytes. Undefined behavior will result if the pointers belong to
   // different arenas.
-  static ssize_t ptr_diff(char *ptr1, char *ptr2);
+  static ssize_t ptr_diff(char *ptr1, char *ptr2) { return ptr1 - ptr2; }
 
   // Given a starting pointer to an address allocated in an arena and a size in
   // bytes, this function returns a pointer to an address allocated in the

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -150,9 +150,6 @@ private:
 // 127.
 #define REGISTER_ARENA(name, id) static thread_local arena name(id)
 
-#define MEM_BLOCK_START(ptr)                                                   \
-  ((char *)(((uintptr_t)(ptr)-1) & ~(BLOCK_SIZE - 1)))
-
 #ifdef __MACH__
 //
 //	thread_local disabled for Apple

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -1,11 +1,11 @@
 #ifndef ARENA_H
 #define ARENA_H
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <utility>
-#include <algorithm>
 #include <sys/types.h>
+#include <utility>
 
 #include "runtime/alloc.h"
 
@@ -17,7 +17,10 @@ size_t const HYPERBLOCK_SIZE = (size_t)BLOCK_SIZE * 1024 * 1024;
 // once.
 class arena {
 public:
-  arena(char id) : allocation_semispace_id(id) { initialize_semispace(); }
+  arena(char id)
+      : allocation_semispace_id(id) {
+    initialize_semispace();
+  }
 
   // Allocates the requested number of bytes as a contiguous region and returns a
   // pointer to the first allocated byte.
@@ -25,17 +28,22 @@ public:
 
   // Returns the address of the first byte that belongs in the given arena.
   // Returns 0 if nothing has been allocated ever in that arena.
-  char *arena_start_ptr() const { return current_addr_ptr ?  current_addr_ptr + sizeof(memory_block_header) : nullptr; }
+  char *arena_start_ptr() const {
+    return current_addr_ptr ? current_addr_ptr + sizeof(memory_block_header)
+                            : nullptr;
+  }
 
   // Returns a pointer to a location holding the address of last allocated
   // byte in the given arena plus 1.
   // This address is 0 if nothing has been allocated ever in that arena.
   char **arena_end_ptr() { return &allocation_ptr; }
 
-
   // return the total number of allocatable bytes currently in the arena in its
   // active semispace.
-  size_t arena_size() const { update_num_blocks(); return BLOCK_SIZE * std::max(num_blocks, num_collection_blocks); }
+  size_t arena_size() const {
+    update_num_blocks();
+    return BLOCK_SIZE * std::max(num_blocks, num_collection_blocks);
+  }
 
   // Clears the current allocation space by setting its start back to its first
   // block. It is used during garbage collection to effectively collect all of the
@@ -45,13 +53,17 @@ public:
   // Resizes the last allocation as long as the resize does not require a new
   // block allocation.
   // Returns the address of the byte following the last newlly allocated byte.
-  void *arena_resize_last_alloc(ssize_t increase) { return (allocation_ptr += increase); }
+  void *arena_resize_last_alloc(ssize_t increase) {
+    return (allocation_ptr += increase);
+  }
 
   // Returns the given arena's current collection semispace ID.
   // Each arena has 2 semispace IDs one equal to the arena ID and the other equal
   // to the 1's complement of the arena ID. At any time one of these semispaces
   // is used for allocation and the other is used for collection.
-  char get_arena_collection_semispace_id() const { return ~allocation_semispace_id; }
+  char get_arena_collection_semispace_id() const {
+    return ~allocation_semispace_id;
+  }
 
   // Exchanges the current allocation and collection semispaces and clears the new
   // current allocation semispace by setting its start back to its first block.
@@ -102,31 +114,36 @@ private:
     //
     //	Calculate how many 1M blocks of the current arena we used.
     //
-    size_t num_used_blocks = (allocation_ptr - current_addr_ptr - 1) / BLOCK_SIZE + 1;
+    size_t num_used_blocks
+        = (allocation_ptr - current_addr_ptr - 1) / BLOCK_SIZE + 1;
     if (num_used_blocks > num_blocks)
       num_blocks = num_used_blocks;
   }
 
   void initialize_semispace();
-  
+
   static memory_block_header *mem_block_header(void *ptr) {
     uintptr_t address = reinterpret_cast<uintptr_t>(ptr);
-    return reinterpret_cast<arena::memory_block_header *>((address - 1) & ~(HYPERBLOCK_SIZE - 1));
+    return reinterpret_cast<arena::memory_block_header *>(
+        (address - 1) & ~(HYPERBLOCK_SIZE - 1));
   }
 
   //
   //	Current semispace where allocations are being made.
   //
-  char *current_addr_ptr;  // pointer to start of current address space
-  char *allocation_ptr;  // next available location in current semispace
-  char *tripwire;  // allocating past this triggers slow allocation
-  mutable size_t num_blocks;  // notional number of BLOCK_SIZE blocks in current semispace
-  char allocation_semispace_id;  // id of current semispace
+  char *current_addr_ptr; // pointer to start of current address space
+  char *allocation_ptr; // next available location in current semispace
+  char *tripwire; // allocating past this triggers slow allocation
+  mutable size_t
+      num_blocks; // notional number of BLOCK_SIZE blocks in current semispace
+  char allocation_semispace_id; // id of current semispace
   //
   //	Semispace where allocations will be made during and after garbage collect.
   //
-  char *collection_addr_ptr = nullptr;  // pointer to start of collection address space
-  size_t num_collection_blocks = 0;  // notional number of BLOCK_SIZE blocks in collection semispace
+  char *collection_addr_ptr
+      = nullptr; // pointer to start of collection address space
+  size_t num_collection_blocks
+      = 0; // notional number of BLOCK_SIZE blocks in collection semispace
 };
 
 // Macro to define a new arena with the given ID. Supports IDs ranging from 0 to
@@ -155,11 +172,14 @@ inline void *arena::kore_arena_alloc(size_t requested) {
     //	collect when allowed.
     //
     time_for_collection = true;
-    tripwire = current_addr_ptr + HYPERBLOCK_SIZE;  // won't trigger again until arena swap
+    tripwire = current_addr_ptr
+               + HYPERBLOCK_SIZE; // won't trigger again until arena swap
   }
   void *result = allocation_ptr;
   allocation_ptr += requested;
-  MEM_LOG("Allocation at %p (size %zd), next alloc at %p\n", result, requested, block);
+  MEM_LOG(
+      "Allocation at %p (size %zd), next alloc at %p\n", result, requested,
+      block);
   return result;
 }
 
@@ -174,24 +194,22 @@ inline void arena::arena_clear() {
   //	Otherwise we only want to generate a garbage collect if we allocate off the
   //	end of this area.
   //
-  tripwire = current_addr_ptr + (num_blocks - (num_blocks >= get_gc_threshold())) * BLOCK_SIZE;
+  tripwire = current_addr_ptr
+             + (num_blocks - (num_blocks >= get_gc_threshold())) * BLOCK_SIZE;
 }
 
 inline void arena::arena_swap_and_clear() {
-  update_num_blocks();  // so we save the correct number of touched blocks
+  update_num_blocks(); // so we save the correct number of touched blocks
   std::swap(current_addr_ptr, collection_addr_ptr);
   std::swap(num_blocks, num_collection_blocks);
   allocation_semispace_id = ~allocation_semispace_id;
-  if (current_addr_ptr == nullptr)
-    {
-      //
-      //	The other semispace hasn't be initialized yet.
-      //
-      void initialize_semispace();
-    }
-  else
+  if (current_addr_ptr == nullptr) {
+    //
+    //	The other semispace hasn't be initialized yet.
+    //
+    void initialize_semispace();
+  } else
     arena_clear();
 }
-
 }
 #endif // ARENA_H

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -87,13 +87,8 @@ private:
   };
 
   void *slow_alloc(size_t requested);
-  void *megabyte_malloc();
   
-  void fresh_block();
   static memory_block_header *mem_block_header(void *ptr);
-
-  // helper function for `kore_arena_alloc`. Do not call directly.
-  void *do_alloc_slow(size_t requested);
 
   char *current_addr_ptr = nullptr;  // pointer to start of current address space
   char *collection_addr_ptr = nullptr;  // pointer to start of collection address space

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -154,7 +154,7 @@ inline void *arena::kore_arena_alloc(size_t requested) {
     //	depending on the requested size and tripwire setting. This triggers a garbage
     //	collect when allowed.
     //
-    time_for_collection = true;
+    //time_for_collection = true;
     tripwire = current_addr_ptr + HYPERBLOCK_SIZE;  // won't trigger again until arena swap
   }
   void *result = allocation_ptr;

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -74,8 +74,11 @@ public:
   // 3rd argument: the address of last allocated byte in the arena plus 1
   // Return value: the address allocated in the arena after size bytes from the
   //               starting pointer, or 0 if this is equal to the 3rd argument.
-  static char *move_ptr(char *ptr, size_t size, char const *arena_end_ptr);
-  
+  static char *move_ptr(char *ptr, size_t size, char const *arena_end_ptr) {
+    char *next_ptr = ptr + size;
+    return (next_ptr == arena_end_ptr) ? 0 : next_ptr;
+  }
+
   // Returns the ID of the semispace where the given address was allocated.
   // The behavior is undefined if called with an address that has not been
   // allocated within an arena.

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -73,7 +73,7 @@ public:
   // Return value: the address allocated in the arena after size bytes from the
   //               starting pointer, or 0 if this is equal to the 3rd argument.
   static char *move_ptr(char *ptr, size_t size, char const *arena_end_ptr);
-
+  
   // Returns the ID of the semispace where the given address was allocated.
   // The behavior is undefined if called with an address that has not been
   // allocated within an arena.
@@ -85,20 +85,25 @@ private:
     char semispace;
   };
 
+  void *megabyte_malloc();
+  
   void fresh_block();
   static memory_block_header *mem_block_header(void *ptr);
 
   // helper function for `kore_arena_alloc`. Do not call directly.
   void *do_alloc_slow(size_t requested);
 
-  char *first_block; // beginning of first block
-  char *block; // where allocations are being made in current block
-  char *block_start; // start of current block
-  char *block_end; // 1 past end of current block
-  char *first_collection_block; // beginning of other semispace
-  size_t num_blocks; // number of blocks in current semispace
-  size_t num_collection_blocks; // number of blocks in other semispace
-  char allocation_semispace_id; // id of current semispace
+  char *current_block_ptr = nullptr;  // pointer to current block within hyperblock
+  char *collection_block_ptr = nullptr;  // pointer to current block within collection hyperblock
+  
+  char *first_block = nullptr;  // beginning of first block
+  char *block = nullptr;  // where allocations are being made in current block
+  char *block_start = nullptr;  // start of current block
+  char *block_end = nullptr;  // 1 past end of current block
+  char *first_collection_block = nullptr;  // beginning of other semispace
+  size_t num_blocks = 0;  // number of blocks in current semispace
+  size_t num_collection_blocks = 0;  // number of blocks in other semispace
+  char allocation_semispace_id;  // id of current semispace
 };
 
 // Macro to define a new arena with the given ID. Supports IDs ranging from 0 to
@@ -130,6 +135,7 @@ inline void *arena::kore_arena_alloc(size_t requested) {
       requested, block);
   return result;
 }
+
 }
 
 #endif // ARENA_H

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -204,7 +204,7 @@ inline void arena::arena_swap_and_clear() {
     //
     //	The other semispace hasn't be initialized yet.
     //
-    void initialize_semispace();
+    initialize_semispace();
   } else
     arena_clear();
 }

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -154,7 +154,7 @@ inline void *arena::kore_arena_alloc(size_t requested) {
     //	depending on the requested size and tripwire setting. This triggers a garbage
     //	collect when allowed.
     //
-    //time_for_collection = true;
+    time_for_collection = true;
     tripwire = current_addr_ptr + HYPERBLOCK_SIZE;  // won't trigger again until arena swap
   }
   void *result = allocation_ptr;

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -27,24 +27,6 @@ thread_local bool time_for_collection = false;
 thread_local bool gc_enabled = true;
 #endif
 
-char *arena::move_ptr(char *ptr, size_t size, char const *arena_end_ptr) {
-  return ptr + size;
-  /*
-  char *next_ptr = ptr + size;
-  if (next_ptr == arena_end_ptr) {
-    return nullptr;
-  }
-  if (next_ptr != MEM_BLOCK_START(ptr) + BLOCK_SIZE) {
-    return next_ptr;
-  }
-  char *next_block = *(char **)MEM_BLOCK_START(ptr);
-  if (!next_block) {
-    return nullptr;
-  }
-  return next_block + sizeof(arena::memory_block_header);
-  */
-}
-
 void arena::initialize_semispace() {
   //
   //	Current semispace is uninitialized so mmap() a big chuck of address space.

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -28,6 +28,8 @@ thread_local bool gc_enabled = true;
 #endif
 
 char *arena::move_ptr(char *ptr, size_t size, char const *arena_end_ptr) {
+  return ptr + size;
+  /*
   char *next_ptr = ptr + size;
   if (next_ptr == arena_end_ptr) {
     return nullptr;
@@ -35,12 +37,12 @@ char *arena::move_ptr(char *ptr, size_t size, char const *arena_end_ptr) {
   if (next_ptr != MEM_BLOCK_START(ptr) + BLOCK_SIZE) {
     return next_ptr;
   }
-  //char *next_block = *(char **)MEM_BLOCK_START(ptr);
-  //if (!next_block) {
-  //  return nullptr;
-  //}
-  //return next_block + sizeof(arena::memory_block_header);
-  return MEM_BLOCK_START(ptr) + BLOCK_SIZE;
+  char *next_block = *(char **)MEM_BLOCK_START(ptr);
+  if (!next_block) {
+    return nullptr;
+  }
+  return next_block + sizeof(arena::memory_block_header);
+  */
 }
 
 void arena::initialize_semispace() {

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -11,15 +11,6 @@
 #include "runtime/header.h"
 
 extern size_t const VAR_BLOCK_SIZE = BLOCK_SIZE;
-size_t const HYPERBLOCK_SIZE = (size_t)BLOCK_SIZE * 1024 * 1024;
-
-
-__attribute__((always_inline)) arena::memory_block_header *
-arena::mem_block_header(void *ptr) {
-  // NOLINTNEXTLINE(*-reinterpret-cast)
-  return reinterpret_cast<arena::memory_block_header *>(
-      ((uintptr_t)(ptr)-1) & ~(HYPERBLOCK_SIZE - 1));
-}
 
 __attribute__((always_inline)) char
 arena::get_arena_semispace_id_of_object(void *ptr) {
@@ -45,12 +36,6 @@ bool gc_enabled = true;
 thread_local bool gc_enabled = true;
 #endif
 
-__attribute__((always_inline)) void arena::arena_swap_and_clear() {
-  std::swap(current_addr_ptr, collection_addr_ptr);
-  std::swap(current_tripwire, collection_tripwire);
-  allocation_semispace_id = ~allocation_semispace_id;
-  arena_clear();
-}
 
 char *arena::move_ptr(char *ptr, size_t size, char const *arena_end_ptr) {
   char *next_ptr = ptr + size;
@@ -73,53 +58,53 @@ size_t arena::arena_size() const {
   return std::max(current_size, collection_size);
 }
 
+void arena::initialize_semispace() {
+  //
+  //	Current semispace is uninitialized so mmap() a big chuck of address space.
+  //
+  size_t request = 2 * HYPERBLOCK_SIZE;
+  void *addr = mmap(
+		    nullptr, // let OS choose the address
+		    request, // Linux and MacOS both allow up to 64TB
+		    PROT_READ | PROT_WRITE, // read, write but not execute
+		    MAP_ANONYMOUS | MAP_PRIVATE
+		    | MAP_NORESERVE, // allocate address space only
+		    -1, // no file backing
+		    0); // no offset
+  if (addr == MAP_FAILED) {
+    perror("mmap()");
+    abort();
+  }
+  //
+  //	We allocated 2 * HYPERBLOCK_SIZE worth of address space but we're only going to use 1, aligned on a
+  //	HYPERBLOCK_SIZE boundry. This is so we can get the start of the hyperblock by masking any address within it.
+  //	We don't worry about unused address space either side of our aligned address space because there will be no
+  //	memory mapped to it.
+  //
+  current_addr_ptr = reinterpret_cast<char *>(std::align(HYPERBLOCK_SIZE, HYPERBLOCK_SIZE, addr, request));
+  //
+  //	We put a memory_block_header at the beginning so we can identify the semispace a pointer belongs to
+  //	id by masking off the low bits to access this memory_block_header.
+  //
+  memory_block_header *header = reinterpret_cast<memory_block_header *>(current_addr_ptr);
+  header->semispace = allocation_semispace_id;
+  allocation_ptr = current_addr_ptr + sizeof(arena::memory_block_header);
+  //
+  //	We set the tripwire for this space so we get a slow_alloc() when we pass BLOCK_SIZE of memory
+  //	allocated from this space.
+  //
+  current_tripwire = current_addr_ptr + BLOCK_SIZE;
+}
+
 void *arena::slow_alloc(size_t requested) {
   //
-  //	This allocation will push the allocation_ptr beyond the tripwire
-  //	into or past the cushion area between allocation_ptr and the furthest
-  //	allocated location.
+  //	Need a garbage collection. We also move the tripwire so we don't hit it repeatedly.
+  //	We always move the tripwire to a BLOCK_SIZE boundry.
   //
-  if (current_tripwire == nullptr) {
-    //
-    //	No address space has been reserved for this semispace.
-    //
-    size_t request = 2 * HYPERBLOCK_SIZE;
-    void *addr = mmap(
-		      nullptr, // let OS choose the address
-		      request, // Linux and MacOS both allow up to 64TB
-		      PROT_READ | PROT_WRITE, // read, write but not execute
-		      MAP_ANONYMOUS | MAP_PRIVATE
-		      | MAP_NORESERVE, // allocate address space only
-		      -1, // no file backing
-		      0); // no offset
-    if (addr == MAP_FAILED) {
-      perror("mmap()");
-      abort();
-    }
-    //
-    //	We allocated 2 * HYPERBLOCK_SIZE worth of address space but we're only going to use 1, aligned on a
-    //	HYPERBLOCK_SIZE boundry. This is so we can get the start of the hyperblock by masking any address within it.
-    //	We don't worry about unused address space either side of our aligned address space because there will be no
-    //	memory mapped to it.
-    //
-    current_addr_ptr = reinterpret_cast<char *>(
-        std::align(HYPERBLOCK_SIZE, HYPERBLOCK_SIZE, addr, request));
-    memory_block_header *header = reinterpret_cast<memory_block_header *>(current_addr_ptr);
-    header->next_block = nullptr;
-    header->semispace = allocation_semispace_id;
-    allocation_ptr = current_addr_ptr + sizeof(arena::memory_block_header);
-    current_tripwire = current_addr_ptr + BLOCK_SIZE;
-  }
-  else {
-    //
-    //	Need a garbage collection. We also move the tripwire so we don't hit it repeatedly.
-    //	We always move the tripwire to a BLOCK_SIZE boundry.
-    //
-    time_for_collection = true;
-    while (allocation_ptr + requested >= current_tripwire)
-      current_tripwire += BLOCK_SIZE;
-  }
-
+  time_for_collection = true;
+  while (allocation_ptr + requested >= current_tripwire)
+    current_tripwire += BLOCK_SIZE;
+  
   void *result = allocation_ptr;
   allocation_ptr += requested;
   MEM_LOG("Slow allocation at %p (size %zd), next alloc at %p\n", result, requested, block);

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -35,11 +35,12 @@ char *arena::move_ptr(char *ptr, size_t size, char const *arena_end_ptr) {
   if (next_ptr != MEM_BLOCK_START(ptr) + BLOCK_SIZE) {
     return next_ptr;
   }
-  char *next_block = *(char **)MEM_BLOCK_START(ptr);
-  if (!next_block) {
-    return nullptr;
-  }
-  return next_block + sizeof(arena::memory_block_header);
+  //char *next_block = *(char **)MEM_BLOCK_START(ptr);
+  //if (!next_block) {
+  //  return nullptr;
+  //}
+  //return next_block + sizeof(arena::memory_block_header);
+  return MEM_BLOCK_START(ptr) + BLOCK_SIZE;
 }
 
 void arena::initialize_semispace() {
@@ -74,28 +75,9 @@ void arena::initialize_semispace() {
   header->semispace = allocation_semispace_id;
   allocation_ptr = current_addr_ptr + sizeof(arena::memory_block_header);
   //
-  //	We set the tripwire for this space so we get a slow_alloc() when we pass BLOCK_SIZE of memory
+  //	We set the tripwire for this space so we get trigger a garbage collection when we pass BLOCK_SIZE of memory
   //	allocated from this space.
   //
   tripwire = current_addr_ptr + BLOCK_SIZE;
-  num_blocks = 2;
-}
-
-void *arena::slow_alloc(size_t requested) {
-  //
-  //	Need a garbage collection. We also move the tripwire so we don't hit it repeatedly.
-  //	We always move the tripwire to a BLOCK_SIZE boundry.
-  //
-  time_for_collection = true;
-  tripwire = current_addr_ptr + num_blocks * BLOCK_SIZE;  // won't trigger again until after gc
-  
-  void *result = allocation_ptr;
-  allocation_ptr += requested;
-  //
-  //	Set number of notional blocks that will have be written to after memory is used.
-  //
-  num_blocks = (allocation_ptr - current_addr_ptr - 1) / BLOCK_SIZE + 1;
-  
-  MEM_LOG("Slow allocation at %p (size %zd), next alloc at %p\n", result, requested, block);
-  return result;
+  num_blocks = 1;
 }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -33,13 +33,13 @@ void arena::initialize_semispace() {
   //
   size_t request = 2 * HYPERBLOCK_SIZE;
   void *addr = mmap(
-		    nullptr, // let OS choose the address
-		    request, // Linux and MacOS both allow up to 64TB
-		    PROT_READ | PROT_WRITE, // read, write but not execute
-		    MAP_ANONYMOUS | MAP_PRIVATE
-		    | MAP_NORESERVE, // allocate address space only
-		    -1, // no file backing
-		    0); // no offset
+      nullptr, // let OS choose the address
+      request, // Linux and MacOS both allow up to 64TB
+      PROT_READ | PROT_WRITE, // read, write but not execute
+      MAP_ANONYMOUS | MAP_PRIVATE
+          | MAP_NORESERVE, // allocate address space only
+      -1, // no file backing
+      0); // no offset
   if (addr == MAP_FAILED) {
     perror("mmap()");
     abort();
@@ -50,12 +50,14 @@ void arena::initialize_semispace() {
   //	We don't worry about unused address space either side of our aligned address space because there will be no
   //	memory mapped to it.
   //
-  current_addr_ptr = reinterpret_cast<char *>(std::align(HYPERBLOCK_SIZE, HYPERBLOCK_SIZE, addr, request));
+  current_addr_ptr = reinterpret_cast<char *>(
+      std::align(HYPERBLOCK_SIZE, HYPERBLOCK_SIZE, addr, request));
   //
   //	We put a memory_block_header at the beginning so we can identify the semispace a pointer belongs to
   //	id by masking off the low bits to access this memory_block_header.
   //
-  memory_block_header *header = reinterpret_cast<memory_block_header *>(current_addr_ptr);
+  memory_block_header *header
+      = reinterpret_cast<memory_block_header *>(current_addr_ptr);
   header->semispace = allocation_semispace_id;
   allocation_ptr = current_addr_ptr + sizeof(arena::memory_block_header);
   //

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -161,26 +161,20 @@ arena::arena_resize_last_alloc(ssize_t increase) {
 }
 
 __attribute__((always_inline)) void arena::arena_swap_and_clear() {
-  char *tmp = first_block;
-  first_block = first_collection_block;
-  first_collection_block = tmp;
-  size_t tmp2 = num_blocks;
-  num_blocks = num_collection_blocks;
-  num_collection_blocks = tmp2;
+  std::swap(first_block, first_collection_block);
+  std::swap(num_blocks, num_collection_blocks);
   allocation_semispace_id = ~allocation_semispace_id;
   arena_clear();
 }
 
 __attribute__((always_inline)) void arena::arena_clear() {
-  block = first_block ? first_block + sizeof(arena::memory_block_header)
-                      : nullptr;
+  block = first_block ? first_block + sizeof(arena::memory_block_header) : nullptr;
   block_start = first_block;
   block_end = first_block ? first_block + BLOCK_SIZE : nullptr;
 }
 
 __attribute__((always_inline)) char *arena::arena_start_ptr() const {
-  return first_block ? first_block + sizeof(arena::memory_block_header)
-                     : nullptr;
+  return first_block ? first_block + sizeof(arena::memory_block_header) : nullptr;
 }
 
 __attribute__((always_inline)) char **arena::arena_end_ptr() {

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -56,8 +56,7 @@ void arena::initialize_semispace() {
   //	We put a memory_block_header at the beginning so we can identify the semispace a pointer belongs to
   //	id by masking off the low bits to access this memory_block_header.
   //
-  memory_block_header *header
-      = reinterpret_cast<memory_block_header *>(current_addr_ptr);
+  auto *header = reinterpret_cast<memory_block_header *>(current_addr_ptr);
   header->semispace = allocation_semispace_id;
   allocation_ptr = current_addr_ptr + sizeof(arena::memory_block_header);
   //

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -195,34 +195,6 @@ char *arena::move_ptr(char *ptr, size_t size, char const *arena_end_ptr) {
   return next_block + sizeof(arena::memory_block_header);
 }
 
-ssize_t arena::ptr_diff(char *ptr1, char *ptr2) {
-  if (MEM_BLOCK_START(ptr1) == MEM_BLOCK_START(ptr2)) {
-    return ptr1 - ptr2;
-  }
-  arena::memory_block_header *hdr = mem_block_header(ptr2);
-  ssize_t result = 0;
-  while (hdr != mem_block_header(ptr1) && hdr->next_block) {
-    if (ptr2) {
-      result += ((char *)hdr + BLOCK_SIZE) - ptr2;
-      ptr2 = nullptr;
-    } else {
-      result += (BLOCK_SIZE - sizeof(arena::memory_block_header));
-    }
-    hdr = (arena::memory_block_header *)hdr->next_block;
-  }
-  if (hdr == mem_block_header(ptr1)) {
-    result += ptr1 - (char *)(hdr + 1);
-    return result;
-  } // reached the end of the arena and didn't find the block
-  // it's possible that the result should be negative, in which
-  // case the block will have been prior to the block we started
-  // at. To handle this, we recurse with reversed arguments and
-  // negate the result. This means that the code might not
-  // terminate if the two pointers do not belong to the same
-  // arena.
-  return -ptr_diff(ptr2, ptr1);
-}
-
 size_t arena::arena_size() const {
   return (num_blocks > num_collection_blocks ? num_blocks
                                              : num_collection_blocks)

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -104,7 +104,7 @@ void *arena::slow_alloc(size_t requested) {
     //
     current_addr_ptr = reinterpret_cast<char *>(
         std::align(HYPERBLOCK_SIZE, HYPERBLOCK_SIZE, addr, request));
-    auto *header = (arena::memory_block_header *) current_addr_ptr;
+    memory_block_header *header = reinterpret_cast<memory_block_header *>(current_addr_ptr);
     header->next_block = nullptr;
     header->semispace = allocation_semispace_id;
     allocation_ptr = current_addr_ptr + sizeof(arena::memory_block_header);

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -316,22 +316,7 @@ void kore_collect(
   if (collect_old || !previous_oldspace_alloc_ptr) {
     scan_ptr = oldspace_ptr();
   } else {
-    if (MEM_BLOCK_START(previous_oldspace_alloc_ptr + 1)
-        == previous_oldspace_alloc_ptr) {
-      // this means that the previous oldspace allocation pointer points to an
-      // address that is megabyte-aligned. This can only happen if we have just
-      // filled up a block but have not yet allocated the next block in the
-      // sequence at the start of the collection cycle. This means that the
-      // allocation pointer is invalid and does not actually point to the next
-      // address that would have been allocated at, according to the logic of
-      // kore_arena_alloc, which will have allocated a fresh memory block and put
-      // the allocation at the start of it. Thus, we use arena::move_ptr with a size
-      // of zero to adjust and get the true address of the allocation.
-      scan_ptr
-          = arena::move_ptr(previous_oldspace_alloc_ptr, 0, *old_alloc_ptr());
-    } else {
-      scan_ptr = previous_oldspace_alloc_ptr;
-    }
+    scan_ptr = previous_oldspace_alloc_ptr;
   }
   if (scan_ptr != *old_alloc_ptr()) {
     MEM_LOG("Evacuating old generation\n");


### PR DESCRIPTION
Replaced algorithm in class arena with one that uses mmap()'d address spaces and demand paging for each semispace and initializes the current semispace of each arena at start time to avoid and the second semispace of each arena at swap time to avoid relying on Undefined Behavior or having an extra test in kore_arena_alloc().