### PR TITLE
make many global variables constant

### DIFF
--- a/config/llvm_header.inc
+++ b/config/llvm_header.inc
@@ -82,8 +82,8 @@ declare void @print_configuration(ptr, ptr)
 
 declare i64 @__gmpz_get_ui(ptr)
 
-@exit_int_0 = global %mpz { i32 0, i32 0, ptr getelementptr inbounds ([0 x i64], ptr @exit_int_0_limbs, i32 0, i32 0) }
-@exit_int_0_limbs = global [0 x i64] zeroinitializer
+@exit_int_0 = constant %mpz { i32 0, i32 0, ptr getelementptr inbounds ([0 x i64], ptr @exit_int_0_limbs, i32 0, i32 0) }
+@exit_int_0_limbs = constant [0 x i64] zeroinitializer
 
 define tailcc ptr @"eval_LblgetExitCode{SortGeneratedTopCell{}}"(ptr) {
   ret ptr @exit_int_0
@@ -110,8 +110,8 @@ declare ptr @hook_INT_add(ptr, ptr)
 declare ptr @evaluate_function_symbol(i32, ptr)
 declare ptr @get_terminated_string(ptr)
 
-@fresh_int_1 = global %mpz { i32 1, i32 1, ptr getelementptr inbounds ([1 x i64], ptr @fresh_int_1_limbs, i32 0, i32 0) }
-@fresh_int_1_limbs = global [1 x i64] [i64 1]
+@fresh_int_1 = constant %mpz { i32 1, i32 1, ptr getelementptr inbounds ([1 x i64], ptr @fresh_int_1_limbs, i32 0, i32 0) }
+@fresh_int_1_limbs = constant [1 x i64] [i64 1]
 
 define ptr @get_fresh_constant(ptr %sort, ptr %top) {
 entry:

--- a/include/runtime/types.h
+++ b/include/runtime/types.h
@@ -1,6 +1,7 @@
 #ifndef RUNTIME_TYPES_H
 #define RUNTIME_TYPES_H
 
+#include <cstdint>
 #include <gmp.h>
 #include <mpfr.h>
 

--- a/lib/codegen/CreateStaticTerm.cpp
+++ b/lib/codegen/CreateStaticTerm.cpp
@@ -39,6 +39,7 @@ llvm::Constant *create_static_term::not_injection_case(
   llvm::Constant *block
       = module_->getOrInsertGlobal(kore_string.str(), block_type);
   auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(block);
+  global_var->setConstant(true);
 
   if (!global_var->hasInitializer()) {
     std::vector<llvm::Constant *> block_vals;
@@ -151,6 +152,7 @@ create_static_term::create_token(value_type sort, std::string contents) {
         "int_" + contents, llvm::StructType::getTypeByName(
                                module_->getContext(), int_wrapper_struct));
     auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    global_var->setConstant(true);
     if (!global_var->hasInitializer()) {
       mpz_t value;
       char const *data_start
@@ -163,6 +165,7 @@ create_static_term::create_token(value_type sort, std::string contents) {
       llvm::Constant *limbs = module_->getOrInsertGlobal(
           "int_" + contents + "_limbs", limbs_type);
       auto *limbs_var = llvm::dyn_cast<llvm::GlobalVariable>(limbs);
+      limbs_var->setConstant(true);
       std::vector<llvm::Constant *> allocd_limbs;
       for (size_t i = 0; i < size; i++) {
         allocd_limbs.push_back(llvm::ConstantInt::get(
@@ -205,6 +208,7 @@ create_static_term::create_token(value_type sort, std::string contents) {
         "float_" + contents, llvm::StructType::getTypeByName(
                                  module_->getContext(), float_wrapper_struct));
     auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    global_var->setConstant(true);
     if (!global_var->hasInitializer()) {
       size_t prec = 0;
       size_t exp = 0;
@@ -246,6 +250,7 @@ create_static_term::create_token(value_type sort, std::string contents) {
       llvm::Constant *limbs = module_->getOrInsertGlobal(
           "float_" + contents + "_limbs", limbs_type);
       auto *limbs_var = llvm::dyn_cast<llvm::GlobalVariable>(limbs);
+      limbs_var->setConstant(true);
       std::vector<llvm::Constant *> allocd_limbs;
       for (size_t i = 0; i < size; i++) {
         allocd_limbs.push_back(llvm::ConstantInt::get(
@@ -317,6 +322,7 @@ create_static_term::create_token(value_type sort, std::string contents) {
     llvm::Constant *global
         = module_->getOrInsertGlobal("token_" + escape(contents), string_type);
     auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    global_var->setConstant(true);
     if (!global_var->hasInitializer()) {
       llvm::StructType *block_header_type = llvm::StructType::getTypeByName(
           module_->getContext(), blockheader_struct);

--- a/lib/codegen/CreateStaticTerm.cpp
+++ b/lib/codegen/CreateStaticTerm.cpp
@@ -39,7 +39,9 @@ llvm::Constant *create_static_term::not_injection_case(
   llvm::Constant *block
       = module_->getOrInsertGlobal(kore_string.str(), block_type);
   auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(block);
-  global_var->setConstant(true);
+  // this is technically not a constant because functions which return fresh constants
+  // will mutate a block in this circumstance. Probably best not to rely on this actually
+  // being mutable any other way.
 
   if (!global_var->hasInitializer()) {
     std::vector<llvm::Constant *> block_vals;

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -694,6 +694,7 @@ llvm::Constant *decision::string_literal(std::string const &str) {
   auto *global
       = module_->getOrInsertGlobal("str_lit_" + str, str_cst->getType());
   auto *global_var = llvm::cast<llvm::GlobalVariable>(global);
+  global_var->setConstant(true);
   if (!global_var->hasInitializer()) {
     global_var->setInitializer(str_cst);
   }
@@ -1091,6 +1092,7 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> step_function_header(
   auto *layout = module->getOrInsertGlobal(
       "layout_item_rule_" + std::to_string(ordinal), layout_arr->getType());
   auto *global_var = llvm::cast<llvm::GlobalVariable>(layout);
+  global_var->setConstant(true);
   if (!global_var->hasInitializer()) {
     global_var->setInitializer(layout_arr);
   }

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -55,6 +55,7 @@ static llvm::Constant *get_symbol_name_ptr(
     auto *global = module->getOrInsertGlobal(
         fmt::format("sym_name_{}", name), str->getType());
     auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    global_var->setConstant(true);
     if (!global_var->hasInitializer()) {
       global_var->setInitializer(str);
     }
@@ -144,6 +145,7 @@ static void emit_data_table_for_symbol(
   auto *table_type = llvm::ArrayType::get(ty, syms.size());
   auto *table = module->getOrInsertGlobal("table_" + name, table_type);
   auto *global_var = llvm::cast<llvm::GlobalVariable>(table);
+  global_var->setConstant(true);
   init_debug_global(
       "table_" + name,
       get_array_debug_type(
@@ -437,6 +439,7 @@ emit_get_tag_for_fresh_sort(kore_definition *definition, llvm::Module *module) {
     auto *global
         = module->getOrInsertGlobal("sort_name_" + name, str->getType());
     auto *global_var = llvm::cast<llvm::GlobalVariable>(global);
+    global_var->setConstant(true);
     if (!global_var->hasInitializer()) {
       global_var->setInitializer(str);
     }
@@ -504,6 +507,7 @@ static void emit_get_token(kore_definition *definition, llvm::Module *module) {
     auto *global
         = module->getOrInsertGlobal("sort_name_" + name, str->getType());
     auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    global_var->setConstant(true);
     if (!global_var->hasInitializer()) {
       global_var->setInitializer(str);
     }
@@ -531,6 +535,7 @@ static void emit_get_token(kore_definition *definition, llvm::Module *module) {
       auto *str = llvm::ConstantDataArray::getString(ctx, "true", false);
       auto *global = module->getOrInsertGlobal("bool_true", str->getType());
       auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+      global_var->setConstant(true);
       if (!global_var->hasInitializer()) {
         global_var->setInitializer(str);
       }
@@ -625,6 +630,8 @@ static void emit_get_token(kore_definition *definition, llvm::Module *module) {
       string_type, block, {zero, zero32, zero32}, "", current_block);
   auto *block_size = module->getOrInsertGlobal(
       "VAR_BLOCK_SIZE", llvm::Type::getInt64Ty(ctx));
+  auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(block_size);
+  global_var->setConstant(true);
   auto *block_size_val = new llvm::LoadInst(
       llvm::Type::getInt64Ty(ctx), block_size, "", current_block);
   auto *block_alloc_size = llvm::BinaryOperator::Create(
@@ -904,6 +911,7 @@ static void get_visitor(
       auto *global = module->getOrInsertGlobal(
           fmt::format("sort_name_{}", sort_name), str->getType());
       auto *global_var = llvm::dyn_cast<llvm::GlobalVariable>(global);
+      global_var->setConstant(true);
       if (!global_var->hasInitializer()) {
         global_var->setInitializer(str);
       }
@@ -1097,6 +1105,7 @@ static llvm::Constant *get_layout_data(
   auto *global = module->getOrInsertGlobal(
       "layout_item_" + std::to_string(layout), arr->getType());
   auto *global_var = llvm::cast<llvm::GlobalVariable>(global);
+  global_var->setConstant(true);
   if (!global_var->hasInitializer()) {
     global_var->setInitializer(arr);
   }
@@ -1109,6 +1118,7 @@ static llvm::Constant *get_layout_data(
       name,
       llvm::StructType::getTypeByName(module->getContext(), layout_struct));
   auto *global_var2 = llvm::cast<llvm::GlobalVariable>(global2);
+  global_var2->setConstant(true);
   init_debug_global(name, get_forward_decl(layout_struct), global_var2);
   if (!global_var2->hasInitializer()) {
     global_var2->setInitializer(llvm::ConstantStruct::get(
@@ -1201,6 +1211,7 @@ static void emit_sort_table_for_proof_trace_serialization(
     auto *subtable = module->getOrInsertGlobal(
         fmt::format("sort_tags_{}", ast_to_string(*symbol)), subtable_type);
     auto *subtable_var = llvm::dyn_cast<llvm::GlobalVariable>(subtable);
+    subtable_var->setConstant(true);
     init_debug_global(
         "sort_tags_" + symbol->get_name(),
         get_array_debug_type(
@@ -1246,6 +1257,7 @@ static void emit_sort_table(kore_definition *def, llvm::Module *mod) {
     auto *subtable = module->getOrInsertGlobal(
         fmt::format("sorts_{}", ast_to_string(*symbol)), subtable_type);
     auto *subtable_var = llvm::dyn_cast<llvm::GlobalVariable>(subtable);
+    subtable_var->setConstant(true);
     init_debug_global(
         "sorts_" + symbol->get_name(),
         get_array_debug_type(
@@ -1304,6 +1316,7 @@ static void emit_return_sort_table(kore_definition *def, llvm::Module *mod) {
     auto *sort_name
         = module->getOrInsertGlobal("sort_name_" + sort_str, str_type);
     auto *global_var = llvm::cast<llvm::GlobalVariable>(sort_name);
+    global_var->setConstant(true);
     if (!global_var->hasInitializer()) {
       global_var->setInitializer(str);
     }

--- a/lib/codegen/Metadata.cpp
+++ b/lib/codegen/Metadata.cpp
@@ -24,6 +24,7 @@ void add_boolean_flag(
 
   auto *global = mod.getOrInsertGlobal(name, i1_ty);
   auto *global_var = llvm::cast<llvm::GlobalVariable>(global);
+  global_var->setConstant(true);
 
   if (!global_var->hasInitializer()) {
     global_var->setInitializer(enabled_cst);
@@ -44,6 +45,7 @@ void add_kompiled_dir_symbol(
 
   auto *global = mod.getOrInsertGlobal(kompiled_dir, str->getType());
   auto *global_var = llvm::cast<llvm::GlobalVariable>(global);
+  global_var->setConstant(true);
 
   if (!global_var->hasInitializer()) {
     global_var->setInitializer(str);


### PR DESCRIPTION
This PR is a preparation to improve the thread safety of the llvm backend which attempts to reduce the number of global variables that need to be considered by marking as many of them as read only as possible.