### PR TITLE
do not garbage collect empty map/list/set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,8 @@ jobs:
         include:
           - runner: [self-hosted, linux, normal]
             os: ubuntu-24.04
-          - runner: MacM1
-            os: self-macos-12
+          - runner: [self-hosted, self-macos-latest]
+            os: self-macos-latest
 
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
         include:
           - runner: [self-hosted, linux, normal]
             os: ubuntu-24.04
-          - runner: MacM1
-            os: self-macos-12
+          - runner: [self-hosted, self-macos-latest]
+            os: self-macos-latest
     runs-on: ${{ matrix.runner }}
     steps:
       - name: 'Check out code'

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -91,7 +91,10 @@ struct kore_alloc_heap {
   template <typename... Tags>
   static void *allocate(size_t size, Tags...) {
     if (during_gc()) {
-      return ::operator new(size);
+      auto *result = (string *)::operator new(size + sizeof(blockheader));
+      init_with_len(result, size);
+      result->h.hdr |= NOT_YOUNG_OBJECT_BIT;
+      return result->data;
     }
     bool enabled = gc_enabled;
     gc_enabled = false;
@@ -103,7 +106,7 @@ struct kore_alloc_heap {
 
   static void deallocate(size_t size, void *data) {
     if (during_gc()) {
-      ::operator delete(data);
+      ::operator delete((char *)data - sizeof(blockheader));
     }
   }
 };

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -274,9 +274,11 @@ static bool should_collect_old_gen() {
 }
 
 void init_static_objects(void) {
+  is_gc = true;
   map m = map();
   list l = list();
   set s = set();
+  is_gc = false;
   set_kore_memory_functions_for_gmp();
 }
 

--- a/runtime/collect/migrate_collection.cpp
+++ b/runtime/collect/migrate_collection.cpp
@@ -6,6 +6,9 @@
 
 void migrate_collection_node(void **node_ptr) {
   string *curr_block = STRUCT_BASE(string, data, *node_ptr);
+  if (!is_heap_block(curr_block)) {
+    return;
+  }
   if (youngspace_collection_id()
           != arena::get_arena_semispace_id_of_object((void *)curr_block)
       && oldspace_collection_id()

--- a/runtime/collect/migrate_static_roots.cpp
+++ b/runtime/collect/migrate_static_roots.cpp
@@ -10,14 +10,6 @@ extern thread_local bool kllvm_rand_state_initialized;
 extern "C" {
 
 void migrate_static_roots() {
-  auto &l1 = list_impl::empty_root();
-  migrate_collection_node((void **)&l1);
-  auto &l2 = list_impl::empty_tail();
-  migrate_collection_node((void **)&l2);
-  auto &s = set_impl::empty();
-  migrate_collection_node((void **)&s);
-  auto &m = map_impl::empty();
-  migrate_collection_node((void **)&m);
   if (kllvm_rand_state_initialized) {
     auto &rand = kllvm_rand_state->_mp_seed->_mp_d;
     string *limbs = STRUCT_BASE(string, data, rand);


### PR DESCRIPTION
We move the empty map/list/set allocations to be allocated using `new` and never deallocated or relocated in order to assist in the thread safety of the llvm backend. When we make each allocation arena thread-local, this change will be required, otherwise garbage collection in one thread will corrupt collections in other threads.