### PR TITLE
Minor optimization to search

### DIFF
--- a/runtime/util/search.cpp
+++ b/runtime/util/search.cpp
@@ -72,7 +72,11 @@ std::unordered_set<block *, hash_block, k_eq> take_search_steps(
   while (!states.empty() && depth != 0) {
     state = states.front();
     states.pop_front();
-    states_set.erase(state);
+    if (states.size() == 0) {
+      states_set.clear();
+    } else {
+      states_set.erase(state);
+    }
 
     if (depth > 0) {
       depth--;

--- a/runtime/util/search.cpp
+++ b/runtime/util/search.cpp
@@ -72,7 +72,7 @@ std::unordered_set<block *, hash_block, k_eq> take_search_steps(
   while (!states.empty() && depth != 0) {
     state = states.front();
     states.pop_front();
-    if (states.size() == 0) {
+    if (states.empty()) {
       states_set.clear();
     } else {
       states_set.erase(state);


### PR DESCRIPTION
In the final version of the ULM, we want to enforce that semantics are deterministic. We do this using the search feature and the `--execute-to-branch` option which treats all states with more than one successor as final states and does not rewrite them further.

I tested this by running the ethereum test suite with this option and all the tests passed (with a few trivial changes to the semantics). A minor change resulted from this effort: if only a single state is active at a given time, we do not need to do the expensive equality check performed by `erase`. It is sufficient to simply clear the hash set.