### PR TITLE
New GC strategy.

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -42,6 +42,7 @@ Options:
                                     (immutable) that are enabled by default.
   --hidden-visibility               Set the visibility of all global symbols in generated code to
                                     "hidden"
+  --use-gcstrategy                  Use GC strategy defined for the LLVM backend.
   --profile-matching                Instrument interpeter to emit a profile of time spent in
                                     top-level rule matching on stderr.
   --verify-ir                       Verify result of IR generation.
@@ -195,6 +196,11 @@ while [[ $# -gt 0 ]]; do
       codegen_flags+=("--hidden-visibility")
       codegen_verify_flags+=("--hidden-visibility")
       kompile_clang_flags+=("--hidden-visibility")
+      shift
+      ;;
+    --use-gcstrategy)
+      codegen_flags+=("--use-gcstrategy")
+      kompile_clang_flags+=("--use-gcstrategy")
       shift
       ;;
     --profile-matching)

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -15,6 +15,7 @@ flags=()
 llc_flags=()
 llc_opt_flags="-O0"
 visibility_hidden=false
+use_gcstrategy=false
 link=true
 export verbose=false
 export profile=false
@@ -99,6 +100,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --hidden-visibility)
       visibility_hidden=true
+      shift
+      ;;
+    --use-gcstrategy)
+      use_gcstrategy=true
       shift
       ;;
     *)
@@ -187,6 +192,9 @@ if [ "$main" != "python_ast" ]; then
         modhidden="$tmpdir/hidden.bc"
         run @OPT@ "$modopt" -load-pass-plugin "$passes" -set-visibility-hidden -o "$modhidden"
         modopt="$modhidden"
+      fi
+      if $use_gcstrategy; then
+        llc_flags+=("-load="$passes"")
       fi
       run @LLC@ \
         "$modopt" -mtriple=@BACKEND_TARGET_TRIPLE@ \

--- a/include/kllvm/codegen/GCStrategy.h
+++ b/include/kllvm/codegen/GCStrategy.h
@@ -18,19 +18,19 @@
 namespace kllvm {
 
 /// The GCStrategy for the LLVM Backend
-class LLVMBackendGCStrategy: public llvm::GCStrategy {
+class LLVMBackendGCStrategy : public llvm::GCStrategy {
 public:
   LLVMBackendGCStrategy();
 
   // Override
 #if LLVM_VERSION_MAJOR == 15
-  Optional<bool> isGCManagedPointer(const llvm::Type *Ty) const override;
+  Optional<bool> isGCManagedPointer(llvm::Type const *Ty) const override;
 #else
-  std::optional<bool> isGCManagedPointer(const llvm::Type *Ty) const override;
+  std::optional<bool> isGCManagedPointer(llvm::Type const *Ty) const override;
 #endif
 };
 
-} // end anonymous namespace
+} // namespace kllvm
 
 #endif // LLVM_BACKEND_GC_STRATEGY_H
 

--- a/include/kllvm/codegen/GCStrategy.h
+++ b/include/kllvm/codegen/GCStrategy.h
@@ -1,0 +1,29 @@
+//===- Extend GCStrategy of llvm/CodeGen/GCStrategy.h ---------------------===//
+//
+// We extend the base GCStrategy as follows:
+// - use gc.safepoints instead of (default) gc.roots.
+// - specify that the RewriteStatepointsForGC pass should rewrite the calls of
+//   this function.
+// - pointers with address space != 0 are pointing to GC-managed memory.
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_BACKEND_GC_STRATEGY_H
+#define LLVM_BACKEND_GC_STRATEGY_H
+
+#include "llvm/IR/GCStrategy.h"
+#include "llvm/IR/Type.h"
+
+namespace kllvm {
+
+/// The GCStrategy for the LLVM Backend
+class LLVMBackendGCStrategy: public llvm::GCStrategy {
+public:
+  LLVMBackendGCStrategy();
+
+  // Override
+  std::optional<bool> isGCManagedPointer(const llvm::Type *Ty) const override;
+};
+
+} // end anonymous namespace
+
+#endif // LLVM_BACKEND_GC_STRATEGY_H

--- a/include/kllvm/codegen/GCStrategy.h
+++ b/include/kllvm/codegen/GCStrategy.h
@@ -23,7 +23,11 @@ public:
   LLVMBackendGCStrategy();
 
   // Override
+#if LLVM_VERSION_MAJOR == 15
+  Optional<bool> isGCManagedPointer(const llvm::Type *Ty) const override;
+#else
   std::optional<bool> isGCManagedPointer(const llvm::Type *Ty) const override;
+#endif
 };
 
 } // end anonymous namespace

--- a/include/kllvm/codegen/GCStrategy.h
+++ b/include/kllvm/codegen/GCStrategy.h
@@ -24,7 +24,7 @@ public:
 
   // Override
 #if LLVM_VERSION_MAJOR == 15
-  Optional<bool> isGCManagedPointer(llvm::Type const *Ty) const override;
+  llvm::Optional<bool> isGCManagedPointer(llvm::Type const *Ty) const override;
 #else
   std::optional<bool> isGCManagedPointer(llvm::Type const *Ty) const override;
 #endif

--- a/include/kllvm/codegen/GCStrategy.h
+++ b/include/kllvm/codegen/GCStrategy.h
@@ -7,6 +7,8 @@
 // - pointers with address space != 0 are pointing to GC-managed memory.
 //===----------------------------------------------------------------------===//
 
+// NOLINTBEGIN
+
 #ifndef LLVM_BACKEND_GC_STRATEGY_H
 #define LLVM_BACKEND_GC_STRATEGY_H
 
@@ -27,3 +29,5 @@ public:
 } // end anonymous namespace
 
 #endif // LLVM_BACKEND_GC_STRATEGY_H
+
+// NOLINTEND

--- a/include/kllvm/codegen/Options.h
+++ b/include/kllvm/codegen/Options.h
@@ -10,6 +10,7 @@ extern llvm::cl::opt<bool> no_optimize;
 extern llvm::cl::opt<bool> emit_object;
 extern llvm::cl::opt<bool> binary_ir;
 extern llvm::cl::opt<bool> force_binary;
+extern llvm::cl::opt<bool> use_gcstrategy;
 extern llvm::cl::opt<bool> proof_hint_instrumentation;
 extern llvm::cl::opt<bool> proof_hint_instrumentation_slow;
 extern llvm::cl::opt<bool> keep_frame_pointer;

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1,6 +1,7 @@
 #include "kllvm/codegen/CreateTerm.h"
 #include "kllvm/codegen/CreateStaticTerm.h"
 #include "kllvm/codegen/Debug.h"
+#include "kllvm/codegen/Options.h"
 #include "kllvm/codegen/ProofEvent.h"
 #include "kllvm/codegen/Util.h"
 
@@ -1224,6 +1225,9 @@ bool make_function(
       = llvm::FunctionType::get(return_type, param_types, false);
   llvm::Function *apply_rule = get_or_insert_function(module, name, func_type);
   apply_rule->setLinkage(llvm::GlobalValue::InternalLinkage);
+  if (use_gcstrategy) {
+    apply_rule->setGC("gcs-llvm-backend");
+  }
   init_debug_axiom(axiom->attributes());
   std::string debug_name = name;
   if (axiom->attributes().contains(attribute_set::key::Label)) {

--- a/lib/codegen/Options.cpp
+++ b/lib/codegen/Options.cpp
@@ -48,6 +48,10 @@ cl::opt<bool> force_binary(
     "f", cl::desc("Force binary bitcode output to stdout"), cl::Hidden,
     cl::cat(codegen_lib_cat));
 
+cl::opt<bool> use_gcstrategy(
+    "use-gcstrategy", cl::desc("Use GC strategy defined for the LLVM backend."),
+    cl::Hidden, cl::init(false), cl::cat(codegen_lib_cat));
+
 namespace kllvm {
 
 void validate_codegen_args(bool is_tty) {

--- a/lib/passes/CMakeLists.txt
+++ b/lib/passes/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(KLLVMPassInternal
   SetVisibilityHidden.cpp
   RemoveDeadKFunctions.cpp
   MustTailDeadArgElimination.cpp
+  GCStrategy.cpp
   PluginInfo.cpp
 )
 
@@ -9,6 +10,7 @@ add_library(KLLVMPass MODULE
   SetVisibilityHidden.cpp
   RemoveDeadKFunctions.cpp
   MustTailDeadArgElimination.cpp
+  GCStrategy.cpp
   PluginInfo.cpp
 )
 

--- a/lib/passes/GCStrategy.cpp
+++ b/lib/passes/GCStrategy.cpp
@@ -7,6 +7,8 @@
 // - pointers with address space != 0 are pointing to GC-managed memory.
 //===----------------------------------------------------------------------===//
 
+// NOLINTBEGIN
+
 #include "kllvm/codegen/GCStrategy.h"
 
 #include "llvm/CodeGen/GCMetadata.h"
@@ -32,11 +34,12 @@ std::optional<bool> LLVMBackendGCStrategy::isGCManagedPointer(const Type *Ty) co
   const PointerType *PTy = dyn_cast<PointerType>(Ty);
   if (PTy->getAddressSpace()) {
     return true;
-  } else {
-      return false;
   }
+  return false;
 }
 
 // Add LLVMBackendGCStrategy to the global GCRegistry
 static GCRegistry::Add<LLVMBackendGCStrategy> X("gcs-llvm-backend",
         "GC Strategy for the LLVM Backend");
+
+// NOLINTEND

--- a/lib/passes/GCStrategy.cpp
+++ b/lib/passes/GCStrategy.cpp
@@ -13,7 +13,6 @@
 
 #include "llvm/CodeGen/GCMetadata.h"
 #include "llvm/IR/DerivedTypes.h"
-#include "llvm/IR/Type.h"
 #include "llvm/Support/Compiler.h"
 
 using namespace llvm;
@@ -21,14 +20,14 @@ using namespace kllvm;
 
 LLVMBackendGCStrategy::LLVMBackendGCStrategy() {
   UseStatepoints = true; // Use gc.statepoints
-#if LLVM_VERSION_MAJOR == 15
+#if LLVM_VERSION_MAJOR != 15
   UseRS4GC = true; // Rewrite the calls of a function that has this GCStrategy
 #endif
 }
 
 // Override
 #if LLVM_VERSION_MAJOR == 15
-Optional<bool> LLVMBackendGCStrategy::isGCManagedPointer(Type const *Ty) const {
+llvm::Optional<bool> LLVMBackendGCStrategy::isGCManagedPointer(Type const *Ty) const {
 #else
 std::optional<bool>
 LLVMBackendGCStrategy::isGCManagedPointer(Type const *Ty) const {

--- a/lib/passes/GCStrategy.cpp
+++ b/lib/passes/GCStrategy.cpp
@@ -1,0 +1,42 @@
+//===- Extend GCStrategy of llvm/CodeGen/GCStrategy.h ---------------------===//
+//
+// We extend the base GCStrategy as follows:
+// - use gc.safepoints instead of (default) gc.roots.
+// - specify that the RewriteStatepointsForGC pass should rewrite the calls of
+//   this function.
+// - pointers with address space != 0 are pointing to GC-managed memory.
+//===----------------------------------------------------------------------===//
+
+#include "kllvm/codegen/GCStrategy.h"
+
+#include "llvm/CodeGen/GCMetadata.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Type.h"
+#include "llvm/Support/Compiler.h"
+
+using namespace llvm;
+using namespace kllvm;
+
+LLVMBackendGCStrategy::LLVMBackendGCStrategy() {
+  UseStatepoints = true; // Use gc.statepoints
+  UseRS4GC = true; // Rewrite the calls of a function that has this GCStrategy
+}
+
+// Override
+std::optional<bool> LLVMBackendGCStrategy::isGCManagedPointer(const Type *Ty) const {
+  // Return false for any non-pointer type
+  if (!Ty->isPointerTy()) {
+    return false;
+  }
+  // Any pointer with address space != 0 is to managed memory.
+  const PointerType *PTy = dyn_cast<PointerType>(Ty);
+  if (PTy->getAddressSpace()) {
+    return true;
+  } else {
+      return false;
+  }
+}
+
+// Add LLVMBackendGCStrategy to the global GCRegistry
+static GCRegistry::Add<LLVMBackendGCStrategy> X("gcs-llvm-backend",
+        "GC Strategy for the LLVM Backend");

--- a/lib/passes/GCStrategy.cpp
+++ b/lib/passes/GCStrategy.cpp
@@ -28,16 +28,17 @@ LLVMBackendGCStrategy::LLVMBackendGCStrategy() {
 
 // Override
 #if LLVM_VERSION_MAJOR == 15
-Optional<bool> LLVMBackendGCStrategy::isGCManagedPointer(const Type *Ty) const {
+Optional<bool> LLVMBackendGCStrategy::isGCManagedPointer(Type const *Ty) const {
 #else
-std::optional<bool> LLVMBackendGCStrategy::isGCManagedPointer(const Type *Ty) const {
+std::optional<bool>
+LLVMBackendGCStrategy::isGCManagedPointer(Type const *Ty) const {
 #endif
   // Return false for any non-pointer type
   if (!Ty->isPointerTy()) {
     return false;
   }
   // Any pointer with address space != 0 is to managed memory.
-  const PointerType *PTy = dyn_cast<PointerType>(Ty);
+  PointerType const *PTy = dyn_cast<PointerType>(Ty);
   if (PTy->getAddressSpace()) {
     return true;
   }
@@ -45,7 +46,7 @@ std::optional<bool> LLVMBackendGCStrategy::isGCManagedPointer(const Type *Ty) co
 }
 
 // Add LLVMBackendGCStrategy to the global GCRegistry
-static GCRegistry::Add<LLVMBackendGCStrategy> X("gcs-llvm-backend",
-        "GC Strategy for the LLVM Backend");
+static GCRegistry::Add<LLVMBackendGCStrategy>
+    X("gcs-llvm-backend", "GC Strategy for the LLVM Backend");
 
 // NOLINTEND

--- a/lib/passes/GCStrategy.cpp
+++ b/lib/passes/GCStrategy.cpp
@@ -21,11 +21,17 @@ using namespace kllvm;
 
 LLVMBackendGCStrategy::LLVMBackendGCStrategy() {
   UseStatepoints = true; // Use gc.statepoints
+#if LLVM_VERSION_MAJOR == 15
   UseRS4GC = true; // Rewrite the calls of a function that has this GCStrategy
+#endif
 }
 
 // Override
+#if LLVM_VERSION_MAJOR == 15
+Optional<bool> LLVMBackendGCStrategy::isGCManagedPointer(const Type *Ty) const {
+#else
 std::optional<bool> LLVMBackendGCStrategy::isGCManagedPointer(const Type *Ty) const {
+#endif
   // Return false for any non-pointer type
   if (!Ty->isPointerTy()) {
     return false;

--- a/lib/passes/GCStrategy.cpp
+++ b/lib/passes/GCStrategy.cpp
@@ -27,7 +27,8 @@ LLVMBackendGCStrategy::LLVMBackendGCStrategy() {
 
 // Override
 #if LLVM_VERSION_MAJOR == 15
-llvm::Optional<bool> LLVMBackendGCStrategy::isGCManagedPointer(Type const *Ty) const {
+llvm::Optional<bool>
+LLVMBackendGCStrategy::isGCManagedPointer(Type const *Ty) const {
 #else
 std::optional<bool>
 LLVMBackendGCStrategy::isGCManagedPointer(Type const *Ty) const {

--- a/test/defn/imp.kore
+++ b/test/defn/imp.kore
@@ -1,6 +1,8 @@
 // RUN: %interpreter
 // RUN: %check-grep
 // RUN: %check-statistics
+// RUN: %gcs-interpreter
+// RUN: %check-grep
 // RUN: %proof-interpreter
 // RUN: %check-proof-out
 [topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/robertorosmaninho/rv/k/llvm-backend/src/main/native/llvm-backend/test/defn/k-files/imp.md)")]

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -98,6 +98,13 @@ config.substitutions.extend([
             exit 1
         fi
     ''')),
+    ('%gcs-interpreter', one_line('''
+        output=$(%kompile %s main --use-gcstrategy -o %t.interpreter 2>&1)
+        if [[ -n "$output" ]]; then
+            echo "llvm-kompile error or warning: $output"
+            exit 1
+        fi
+    ''')),
     ('%proof-interpreter', one_line('''
         output=$(%kompile %s main --proof-hint-instrumentation -o %t.interpreter 2>&1)
         if [[ -n "$output" ]]; then

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -148,6 +148,7 @@ void emit_metadata(llvm::Module &mod) {
 
 // NOLINTNEXTLINE(*-cognitive-complexity)
 int main(int argc, char **argv) {
+  // NOLINTNEXTLINE(*-identifier-naming)
   LLVMBackendGCStrategy _gcs; // Unused. This is needed to ensure linking.
   initialize_llvm();
 

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -1,3 +1,4 @@
+#include "kllvm/codegen/GCStrategy.h"
 #include <kllvm/ast/AST.h>
 #include <kllvm/codegen/ApplyPasses.h>
 #include <kllvm/codegen/CreateTerm.h>
@@ -147,6 +148,7 @@ void emit_metadata(llvm::Module &mod) {
 
 // NOLINTNEXTLINE(*-cognitive-complexity)
 int main(int argc, char **argv) {
+  LLVMBackendGCStrategy _gcs; // Unused. This is needed to ensure linking.
   initialize_llvm();
 
   cl::HideUnrelatedOptions({&codegen_tool_cat, &codegen_lib_cat});


### PR DESCRIPTION
This PR adds a new GCStrategy, that treats any pointer with address space other than 0 as a pointer to managed memory.

We extent class GCStrategy in llvm/IR/GCStrategy.h, and register the new GCStrategy.
