### PR TITLE
use kore_alloc_always_gc instead of malloc when building config

### DIFF
--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -389,7 +389,7 @@ static std::pair<llvm::Value *, llvm::BasicBlock *> get_eval(
     auto *malloc = create_malloc(
         creator.get_current_block(),
         llvm::ConstantExpr::getSizeOf(result->getType()),
-        get_or_insert_function(mod, "malloc", ptr_ty, ptr_ty));
+        get_or_insert_function(mod, "kore_alloc_always_gc", ptr_ty, ptr_ty));
     new llvm::StoreInst(result, malloc, creator.get_current_block());
     retval = malloc;
     break;
@@ -563,7 +563,8 @@ static void emit_get_token(kore_definition *definition, llvm::Module *module) {
           case_block);
       auto *malloc = create_malloc(
           case_block, llvm::ConstantExpr::getSizeOf(compare->getType()),
-          get_or_insert_function(module, "malloc", ptr_ty, ptr_ty));
+          get_or_insert_function(
+              module, "kore_alloc_always_gc", ptr_ty, ptr_ty));
       new llvm::StoreInst(compare, malloc, case_block);
       phi->addIncoming(malloc, case_block);
       llvm::BranchInst::Create(merge_block, case_block);

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -29,7 +29,7 @@ void *get_mint_token(size_t size, char const *c_str) {
   std::string precision_str = str.substr(idx + 1);
   long long precision = std::stoll(precision_str);
   long long precision_in_bytes = (precision + 7) / 8;
-  char *token = (char *)malloc(precision_in_bytes);
+  char *token = (char *)kore_alloc_always_gc(precision_in_bytes);
   std::string val_str = str.substr(0, idx);
   mpz_t z;
   mpz_init_set_str(z, val_str.c_str(), 10);


### PR DESCRIPTION
Making this change prevents a memory leak because `free` was never being called previously on this memory.