### PR TITLE
Third attempt at refactoring garbage collector

### DIFF
--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -30,12 +30,12 @@ public:
 
   // Returns the address of the first byte that belongs in the given arena.
   // Returns nullptr if nothing has been allocated ever in that arena.
-  char *arena_start_ptr() const { return current_addr_ptr; }
+  char *start_ptr() const { return current_addr_ptr; }
 
   // Returns a pointer to a location holding the address of last allocated
   // byte in the given arena plus 1.
   // This address is nullptr if nothing has been allocated ever in that arena.
-  char *arena_end_ptr() { return allocation_ptr; }
+  char *end_ptr() { return allocation_ptr; }
 
   // Clears the current allocation space by setting its start back to its first
   // block. It is used during garbage collection to effectively collect all of the
@@ -173,7 +173,7 @@ inline void arena::arena_clear() {
   //
   //	We set the allocation pointer to the first available address.
   //
-  allocation_ptr = arena_start_ptr();
+  allocation_ptr = current_addr_ptr;
   //
   //	If the number of blocks we've touched is >= threshold, we want to trigger
   //	a garbage collection if we get within 1 block of the end of this area.

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -104,20 +104,6 @@ public:
   static char get_arena_semispace_id_of_object(void *ptr);
 
 private:
-  //
-  //	We update the number of 1MB blocks actually written to, only when we need this value,
-  //	or before a garbage collection rather than trying to determine when we write to a fresh block.
-  //
-  void update_num_blocks() const {
-    //
-    //	Calculate how many 1M blocks of the current arena we used.
-    //
-    size_t num_used_blocks
-        = (allocation_ptr - current_addr_ptr - 1) / BLOCK_SIZE + 1;
-    if (num_used_blocks > num_blocks)
-      num_blocks = num_used_blocks;
-  }
-
   void initialize_semispace();
   //
   //	Current semispace where allocations are being made.
@@ -125,16 +111,12 @@ private:
   char *current_addr_ptr; // pointer to start of current address space
   char *allocation_ptr; // next available location in current semispace
   char *tripwire; // allocating past this sets flag for collection
-  mutable size_t
-      num_blocks; // notional number of BLOCK_SIZE blocks in current semispace
   char allocation_semispace_id; // id of current semispace
   //
   //	Semispace where allocations will be made during and after garbage collect.
   //
   char *collection_addr_ptr
       = nullptr; // pointer to start of collection address space
-  size_t num_collection_blocks
-      = 0; // notional number of BLOCK_SIZE blocks in collection semispace
 };
 
 inline char arena::get_arena_semispace_id_of_object(void *ptr) {
@@ -188,16 +170,11 @@ inline void *arena::kore_arena_alloc(size_t requested) {
 }
 
 inline void arena::arena_swap_and_clear() {
-  update_num_blocks(); // so we save the correct number of touched blocks
   std::swap(current_addr_ptr, collection_addr_ptr);
-  std::swap(num_blocks, num_collection_blocks);
   allocation_semispace_id = ~allocation_semispace_id;
-  if (current_addr_ptr == nullptr) {
-    //
-    //	The other semispace hasn't be initialized yet.
-    //
-    initialize_semispace();
-  } else
+  if (current_addr_ptr == nullptr)
+    initialize_semispace();  // not yet initialized
+  else
     arena_clear();
 }
 }

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -27,9 +27,11 @@ size_t const MIN_SPACE = 1024 * 1024;
 // once.
 class arena {
 public:
-  arena(char id)
+  arena(char id, bool trigger_collection)
       : allocation_semispace_id(id) {
     initialize_semispace();
+    if (!trigger_collection)
+      tripwire = current_addr_ptr + HYPERBLOCK_SIZE;
   }
 
   char *evacuate(char *scan_ptr);
@@ -131,10 +133,6 @@ inline char arena::get_arena_semispace_id_of_object(void *ptr) {
       = reinterpret_cast<uintptr_t>(ptr) | (HYPERBLOCK_SIZE - 1);
   return *reinterpret_cast<char *>(end_address);
 }
-
-// Macro to define a new arena with the given ID. Supports IDs ranging from 0 to
-// 127.
-#define REGISTER_ARENA(name, id) thread_local arena name(id)
 
 #ifdef __MACH__
 //

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -22,13 +22,13 @@ size_t const EXPAND_FACTOR = 2;
 // been allocated, to avoid collections near startup when there is little garbage.
 size_t const MIN_SPACE = 1024 * 1024;
 
-  
 // An arena can be used to allocate objects that can then be deallocated all at
 // once.
 class arena {
 public:
   arena(char id, bool trigger_collection)
-    : allocation_semispace_id(id), trigger_collection(trigger_collection) {
+      : allocation_semispace_id(id)
+      , trigger_collection(trigger_collection) {
     initialize_semispace();
   }
 
@@ -112,7 +112,7 @@ private:
   char *allocation_ptr; // next available location in current semispace
   char *tripwire; // allocating past this sets flag for collection
   char allocation_semispace_id; // id of current semispace
-  const bool trigger_collection; // request collections?
+  bool const trigger_collection; // request collections?
   //
   //	Semispace where allocations will be made during and after garbage collect.
   //
@@ -170,7 +170,7 @@ inline void arena::arena_swap_and_clear() {
   std::swap(current_addr_ptr, collection_addr_ptr);
   allocation_semispace_id = ~allocation_semispace_id;
   if (current_addr_ptr == nullptr)
-    initialize_semispace();  // not yet initialized
+    initialize_semispace(); // not yet initialized
   else
     arena_clear();
 }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -56,9 +56,7 @@ void arena::initialize_semispace() {
   current_addr_ptr[HYPERBLOCK_SIZE - 1] = allocation_semispace_id;
   allocation_ptr = current_addr_ptr;
   //
-  //	We set the tripwire for this space so we get trigger a garbage collection when we pass MIN_SPACE of memory
-  //	allocated from this space.
+  //	Trigger a garbage collection for the first time when we pass MIN_SPACE of allocations
   //
   tripwire = current_addr_ptr + MIN_SPACE;
-  num_blocks = 1;
 }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -56,7 +56,8 @@ void arena::initialize_semispace() {
   current_addr_ptr[HYPERBLOCK_SIZE - 1] = allocation_semispace_id;
   allocation_ptr = current_addr_ptr;
   //
-  //	Trigger a garbage collection for the first time when we pass MIN_SPACE of allocations
+  //	If we're set to trigger garbage collections, set the tripwire for MIN_SPACE of allocations otherwise
+  //	set it out-of-bounds (but still legal for comparison).
   //
-  tripwire = current_addr_ptr + MIN_SPACE;
+  tripwire = current_addr_ptr + (trigger_collection ? MIN_SPACE : HYPERBLOCK_SIZE);
 }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -59,5 +59,6 @@ void arena::initialize_semispace() {
   //	If we're set to trigger garbage collections, set the tripwire for MIN_SPACE of allocations otherwise
   //	set it out-of-bounds (but still legal for comparison).
   //
-  tripwire = current_addr_ptr + (trigger_collection ? MIN_SPACE : HYPERBLOCK_SIZE);
+  tripwire
+      = current_addr_ptr + (trigger_collection ? MIN_SPACE : HYPERBLOCK_SIZE);
 }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -56,9 +56,9 @@ void arena::initialize_semispace() {
   current_addr_ptr[HYPERBLOCK_SIZE - 1] = allocation_semispace_id;
   allocation_ptr = current_addr_ptr;
   //
-  //	We set the tripwire for this space so we get trigger a garbage collection when we pass BLOCK_SIZE of memory
+  //	We set the tripwire for this space so we get trigger a garbage collection when we pass MIN_SPACE of memory
   //	allocated from this space.
   //
-  tripwire = current_addr_ptr + BLOCK_SIZE;
+  tripwire = current_addr_ptr + MIN_SPACE;
   num_blocks = 1;
 }

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -337,6 +337,7 @@ void kore_collect(
       sizeof(numBytesLiveAtCollection) / sizeof(numBytesLiveAtCollection[0]),
       stderr);
 #endif
+  youngspace.update_tripwire();
   MEM_LOG("Finishing garbage collection\n");
   is_gc = false;
 }

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -255,7 +255,7 @@ char *arena::evacuate(char *scan_ptr) {
       migrate_child(curr_block, layout_data->args, i, false);
     }
   }
-  return move_ptr(scan_ptr, get_size(hdr, layout_int), arena_end_ptr());
+  return move_ptr(scan_ptr, get_size(hdr, layout_int), end_ptr());
 }
 
 // Contains the decision logic for collecting the old generation.
@@ -295,7 +295,7 @@ void kore_collect(
   if (!last_alloc_ptr) {
     last_alloc_ptr = youngspace_ptr();
   }
-  char *current_alloc_ptr = youngspace.arena_end_ptr();
+  char *current_alloc_ptr = youngspace.end_ptr();
 #endif
   kore_alloc_swap(collect_old);
 #ifdef GC_DBG
@@ -303,13 +303,13 @@ void kore_collect(
     numBytesLiveAtCollection[i] = 0;
   }
 #endif
-  char *previous_oldspace_alloc_ptr = oldspace.arena_end_ptr();
+  char *previous_oldspace_alloc_ptr = oldspace.end_ptr();
   for (int i = 0; i < nroots; i++) {
     migrate_root(roots, type_info, i);
   }
   migrate_static_roots();
   char *scan_ptr = youngspace_ptr();
-  if (scan_ptr != youngspace.arena_end_ptr()) {
+  if (scan_ptr != youngspace.end_ptr()) {
     MEM_LOG("Evacuating young generation\n");
     while (scan_ptr) {
       scan_ptr = youngspace.evacuate(scan_ptr);
@@ -320,7 +320,7 @@ void kore_collect(
   } else {
     scan_ptr = previous_oldspace_alloc_ptr;
   }
-  if (scan_ptr != oldspace.arena_end_ptr()) {
+  if (scan_ptr != oldspace.end_ptr()) {
     MEM_LOG("Evacuating old generation\n");
     while (scan_ptr) {
       scan_ptr = oldspace.evacuate(scan_ptr);
@@ -331,7 +331,7 @@ void kore_collect(
       = arena::ptr_diff(current_alloc_ptr, last_alloc_ptr);
   assert(numBytesAllocedSinceLastCollection >= 0);
   fwrite(&numBytesAllocedSinceLastCollection, sizeof(ssize_t), 1, stderr);
-  last_alloc_ptr = youngspace.arena_end_ptr();
+  last_alloc_ptr = youngspace.end_ptr();
   fwrite(
       numBytesLiveAtCollection, sizeof(numBytesLiveAtCollection[0]),
       sizeof(numBytesLiveAtCollection) / sizeof(numBytesLiveAtCollection[0]),

--- a/runtime/lto/alloc.cpp
+++ b/runtime/lto/alloc.cpp
@@ -16,7 +16,7 @@ extern "C" {
 // New data in allocated in the youngspace, which requests a
 // collection when is gets too full.
 thread_local arena youngspace(YOUNGSPACE_ID, true);
-  
+
 // Data that is old enough is migrated to the oldspace. The
 // migrated data is always live at this point so it never
 // requests a collection.

--- a/runtime/lto/alloc.cpp
+++ b/runtime/lto/alloc.cpp
@@ -11,9 +11,19 @@
 
 extern "C" {
 
-REGISTER_ARENA(youngspace, YOUNGSPACE_ID);
-REGISTER_ARENA(oldspace, OLDSPACE_ID);
-REGISTER_ARENA(alwaysgcspace, ALWAYSGCSPACE_ID);
+// class arena supports ID from  0 to 127
+
+// New data in allocated in the youngspace, which requests a
+// collection when is gets too full.
+thread_local arena youngspace(YOUNGSPACE_ID, true);
+  
+// Data that is old enough is migrated to the oldspace. The
+// migrated data is always live at this point so it never
+// requests a collection.
+thread_local arena oldspace(OLDSPACE_ID, false);
+
+// Temporary data is doesn't use the garbage collector.
+thread_local arena alwaysgcspace(ALWAYSGCSPACE_ID, false);
 
 char *youngspace_ptr() {
   return youngspace.start_ptr();

--- a/runtime/lto/alloc.cpp
+++ b/runtime/lto/alloc.cpp
@@ -16,11 +16,11 @@ REGISTER_ARENA(oldspace, OLDSPACE_ID);
 REGISTER_ARENA(alwaysgcspace, ALWAYSGCSPACE_ID);
 
 char *youngspace_ptr() {
-  return youngspace.arena_start_ptr();
+  return youngspace.start_ptr();
 }
 
 char *oldspace_ptr() {
-  return oldspace.arena_start_ptr();
+  return oldspace.start_ptr();
 }
 
 char youngspace_collection_id() {
@@ -73,7 +73,7 @@ kore_resize_last_alloc(void *oldptr, size_t newrequest, size_t last_size) {
   newrequest = (newrequest + 7) & ~7;
   last_size = (last_size + 7) & ~7;
 
-  if (oldptr != youngspace.arena_end_ptr() - last_size) {
+  if (oldptr != youngspace.end_ptr() - last_size) {
     MEM_LOG(
         "May only reallocate last allocation. Tried to reallocate %p to %zd\n",
         oldptr, newrequest);

--- a/runtime/main/main.ll
+++ b/runtime/main/main.ll
@@ -21,6 +21,7 @@ declare void @print_proof_hint_header(ptr)
 @proof_out.flag = private constant [15 x i8] c"--proof-output\00"
 @proof_chunk.flag = private constant [19 x i8] c"--proof-chunk-size\00"
 
+@input_filename = external global ptr
 @proof_writer = external global ptr
 @statistics = external global i1
 @binary_output = external global i1
@@ -119,6 +120,7 @@ if:
   call void @print_proof_hint_header(ptr %proof_writer)
   br label %else
 else:
+  store ptr %filename, ptr @input_filename
   %ret = call ptr @parse_configuration(ptr %filename)
   %result = call ptr @take_steps(i64 %depth, ptr %ret)
   call void @finish_rewriting(ptr %result, i1 0)

--- a/runtime/util/finish_rewriting.cpp
+++ b/runtime/util/finish_rewriting.cpp
@@ -9,6 +9,7 @@
 
 extern "C" {
 
+char *input_filename;
 FILE *output_file = nullptr;
 void *proof_writer = nullptr;
 bool statistics = false;


### PR DESCRIPTION
The condition for requesting collections is replaced by requesting a collection
if an allocation passes a tripwire. This tripwire is initially set at MIN_SPACE
and is recalculated after each garbage collation as max(MIN_SPACE, |live data|).

This avoids a potential issue with the old behavior where collections were
trigged by allocating in the last 1 MB of previously allocated semispace, even
if little garbage is being generated, or not collecting frequently enough if
a period of low garbage generation is followed by a period of high garbage
generation, affecting cache performance.

Furthermore, garbage collections are only trigged by allocations in youngspace.
Allocations in oldspace no longer trigger collections since oldspace collections
are handled during a youngspace collection.
Allocations in alwaysgcspace no longer trigger collections since collection
of this space is handled outside of the main garbage collector.

Some class arena member functions have the arena_ component removed as superfluous.
