### PR TITLE
Release address space on thread exit

### DIFF
--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <sys/mman.h>
 #include <sys/types.h>
 #include <utility>
 
@@ -20,6 +21,12 @@ public:
   arena(char id)
       : allocation_semispace_id(id) {
     initialize_semispace();
+  }
+
+  ~arena() {
+    munmap(current_addr_ptr, HYPERBLOCK_SIZE);
+    if (collection_addr_ptr)
+      munmap(collection_addr_ptr, HYPERBLOCK_SIZE);
   }
 
   char *evacuate(char *scan_ptr);


### PR DESCRIPTION
The destructor for arena now munmap()s any mapped address space. This is aimed at threads that may exit while the address space remains active for other threads.