### PR TITLE
make hyperblock size depend on physical memory

### DIFF
--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -11,7 +11,7 @@
 
 extern "C" {
 
-size_t const HYPERBLOCK_SIZE = (size_t)BLOCK_SIZE * 1024 * 1024;
+size_t const hyperblock_size = (size_t)BLOCK_SIZE * 1024 * 1024;
 
 // An arena can be used to allocate objects that can then be deallocated all at
 // once.
@@ -117,6 +117,10 @@ private:
       = nullptr; // pointer to start of collection address space
   size_t num_collection_blocks
       = 0; // notional number of BLOCK_SIZE blocks in collection semispace
+  //
+  //	hyperblock_size is set to non-zero value just once, at runtime, by any thread.
+  //
+  static size_t hyperblock_size;
 };
 
 inline char arena::get_arena_semispace_id_of_object(void *ptr) {
@@ -128,7 +132,7 @@ inline char arena::get_arena_semispace_id_of_object(void *ptr) {
   //	Set the low bits to 1 to get the address of the last byte in the hyperblock.
   //
   uintptr_t end_address
-      = reinterpret_cast<uintptr_t>(ptr) | (HYPERBLOCK_SIZE - 1);
+      = reinterpret_cast<uintptr_t>(ptr) | (hyperblock_size - 1);
   return *reinterpret_cast<char *>(end_address);
 }
 
@@ -159,7 +163,7 @@ inline void *arena::kore_arena_alloc(size_t requested) {
     //	We move the tripwire to 1 past the end of our hyperblock so that we have
     //	a well defined comparison that will always be false until the next arena swap.
     //
-    tripwire = current_addr_ptr + HYPERBLOCK_SIZE;
+    tripwire = current_addr_ptr + hyperblock_size;
   }
   void *result = allocation_ptr;
   allocation_ptr += requested;

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -24,9 +24,9 @@ public:
   }
 
   ~arena() {
-    munmap(current_addr_ptr, HYPERBLOCK_SIZE);
+    munmap(current_addr_ptr, hyperblock_size);
     if (collection_addr_ptr)
-      munmap(collection_addr_ptr, HYPERBLOCK_SIZE);
+      munmap(collection_addr_ptr, hyperblock_size);
   }
 
   char *evacuate(char *scan_ptr);

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -26,32 +26,31 @@ thread_local bool gc_enabled = true;
 size_t arena::hyperblock_size = 0;
 
 void arena::initialize_semispace() {
-  if (hyperblock_size == 0)
-    {
-      //
-      //	No thread has initialized hyperblock_size at this moment so we will.
-      //	We get the size of the memory from the OS as number of physical pages * page size.
-      //
-      size_t pages = sysconf(_SC_PHYS_PAGES);
-      size_t page_size = sysconf(_SC_PAGE_SIZE);
-      size_t v = pages * page_size;
-      //
-      //	We require hyperblock_size to be a power of 2 for bit twiddling, so we
-      //	round up to the next power of 2.
-      //
-      --v;
-      v |= v >> 1;
-      v |= v >> 2;
-      v |= v >> 4;
-      v |= v >> 8;
-      v |= v >> 16;
-      v |= v >> 32;
-      v++;
-      //
-      //	Writing to a class static variable might be a race with another thread.
-      //
-      hyperblock_size = v;
-    }
+  if (hyperblock_size == 0) {
+    //
+    //	No thread has initialized hyperblock_size at this moment so we will.
+    //	We get the size of the memory from the OS as number of physical pages * page size.
+    //
+    size_t pages = sysconf(_SC_PHYS_PAGES);
+    size_t page_size = sysconf(_SC_PAGE_SIZE);
+    size_t v = pages * page_size;
+    //
+    //	We require hyperblock_size to be a power of 2 for bit twiddling, so we
+    //	round up to the next power of 2.
+    //
+    --v;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    v |= v >> 32;
+    v++;
+    //
+    //	Writing to a class static variable might be a race with another thread.
+    //
+    hyperblock_size = v;
+  }
   //
   //	Current semispace is uninitialized so mmap() a big chuck of address space.
   //


### PR DESCRIPTION
hyperblock_size is now a class static variable that is set to the size of physical memory rounded to the next power of 2.
