### PR TITLE
Callbacks: Fix side-condition events when arity is non-null

### DIFF
--- a/include/runtime/proof_trace_writer.h
+++ b/include/runtime/proof_trace_writer.h
@@ -334,8 +334,7 @@ public:
     current_rewrite_event_.emplace(ordinal, arity);
     if (arity == 0) {
       rewrite_event_callback(current_rewrite_event_.value());
-    }
-    else {
+    } else {
       rewrite_callback_pending_ = true;
     }
   }
@@ -353,8 +352,7 @@ public:
       if (rewrite_callback_pending_) {
         rewrite_event_callback(current_rewrite_event_.value());
         rewrite_callback_pending_ = false;
-      }
-      else {
+      } else {
         side_condition_event_callback(current_rewrite_event_.value());
       }
     }


### PR DESCRIPTION
This PR fixes a bug in calls to calls to `side_condition_event_callback`. Every time such a call should occur, the `rewrite_event_callback` is invoked instead.

This is due to a bug in the method that builds substitutions, and calls a callback once the substitution has the required size. Instead of conditionally calling either the rewrite callback or the sidecondition callback, it always calls the rewrite one.

This PR fixes the bug.