### PR TITLE
add cases for MInt{8}, MInt{16}, and MInt{128}

### DIFF
--- a/config/llvm_header.inc
+++ b/config/llvm_header.inc
@@ -251,6 +251,16 @@ entry:
   ret i64 %steps
 }
 
+define i1 @hook_MINT_eq_8(i8 %0, i8 %1) {
+  %ret = icmp eq i8 %0, %1
+  ret i1 %ret
+}
+
+define i1 @hook_MINT_eq_16(i16 %0, i16 %1) {
+  %ret = icmp eq i16 %0, %1
+  ret i1 %ret
+}
+
 define i1 @hook_MINT_eq_32(i32 %0, i32 %1) {
   %ret = icmp eq i32 %0, %1
   ret i1 %ret
@@ -258,6 +268,11 @@ define i1 @hook_MINT_eq_32(i32 %0, i32 %1) {
 
 define i1 @hook_MINT_eq_64(i64 %0, i64 %1) {
   %ret = icmp eq i64 %0, %1
+  ret i1 %ret
+}
+
+define i1 @hook_MINT_eq_128(i128 %0, i128 %1) {
+  %ret = icmp eq i128 %0, %1
   ret i1 %ret
 }
 

--- a/debug/kgdb.py
+++ b/debug/kgdb.py
@@ -647,10 +647,16 @@ class termPrinter:
                 self.result += "\\dv{" + sort + "}(\"" + string + "\")"
             elif cat == @STRINGBUFFER_LAYOUT@:
                 self.appendStringBuffer(arg.cast(self.stringbuffer_ptr_ptr).dereference(), sort)
+            elif cat == @MINT_LAYOUT@ + 8:
+                self.appendMInt(arg, 1, sort)
+            elif cat == @MINT_LAYOUT@ + 16:
+                self.appendMInt(arg, 2, sort)
             elif cat == @MINT_LAYOUT@ + 32:
                 self.appendMInt(arg, 4, sort)
             elif cat == @MINT_LAYOUT@ + 64:
                 self.appendMInt(arg, 8, sort)
+            elif cat == @MINT_LAYOUT@ + 128:
+                self.appendMInt(arg, 16, sort)
             elif cat == @MINT_LAYOUT@ + 160:
                 self.appendMInt(arg, 20, sort)
             elif cat == @MINT_LAYOUT@ + 256:

--- a/runtime/collections/hash.cpp
+++ b/runtime/collections/hash.cpp
@@ -19,6 +19,12 @@ __attribute__((always_inline)) void add_hash8(void *h, uint8_t data) {
   hash_length++;
 }
 
+__attribute__((always_inline)) void add_hash16(void *h, uint16_t data) {
+  auto *buf = (uint8_t *)&data;
+  add_hash8(h, buf[0]);
+  add_hash8(h, buf[1]);
+}
+
 __attribute__((always_inline)) void add_hash32(void *h, uint32_t data) {
   auto *buf = (uint8_t *)&data;
   add_hash8(h, buf[0]);
@@ -122,6 +128,16 @@ void k_hash(block *arg, void *h) {
           case VARIABLE_LAYOUT: {
             auto **childptrptr = (block **)(argintptr + offset);
             k_hash(*childptrptr, h);
+            break;
+          }
+          case MINT_LAYOUT + 8: {
+            auto *intptr = (uint8_t *)(argintptr + offset);
+            add_hash8(h, *intptr);
+            break;
+          }
+          case MINT_LAYOUT + 16: {
+            auto *intptr = (uint16_t *)(argintptr + offset);
+            add_hash16(h, *intptr);
             break;
           }
           case MINT_LAYOUT + 32: {

--- a/runtime/collections/kelemle.cpp
+++ b/runtime/collections/kelemle.cpp
@@ -125,6 +125,24 @@ bool hook_KEQUAL_eq(block *arg1, block *arg2) {
           }
           break;
         }
+        case MINT_LAYOUT + 8: {
+          auto *child1ptr = (int8_t *)(child1intptr);
+          auto *child2ptr = (int8_t *)(child2intptr);
+          bool cmp = *child1ptr == *child2ptr;
+          if (!cmp) {
+            return false;
+          }
+          break;
+        }
+        case MINT_LAYOUT + 16: {
+          auto *child1ptr = (int16_t *)(child1intptr);
+          auto *child2ptr = (int16_t *)(child2intptr);
+          bool cmp = *child1ptr == *child2ptr;
+          if (!cmp) {
+            return false;
+          }
+          break;
+        }
         case MINT_LAYOUT + 32: {
           auto *child1ptr = (int32_t *)(child1intptr);
           auto *child2ptr = (int32_t *)(child2intptr);


### PR DESCRIPTION
This is intended to fix crashes when the llvm backend manipulates machine integers of sizes 8, 16, and 128.