### PR TITLE
Adding `munmap_arena_and_reset` and calling it to all semispaces when `free_all_kore_mem`

### DIFF
--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -111,6 +111,20 @@ public:
   // allocated within an arena.
   static char get_arena_semispace_id_of_object(void *ptr);
 
+  // Unmaps the current and collection address spaces and resets them and the tripwire.
+  // This is needed when the client switches thread contexts without properly deallocating
+  // them. This is not a common use case and shoul be used carefully.
+  void munmap_arena_and_reset() {
+    if (current_addr_ptr)
+      munmap(current_addr_ptr, HYPERBLOCK_SIZE);
+    if (collection_addr_ptr)
+      munmap(collection_addr_ptr, HYPERBLOCK_SIZE);
+
+    current_addr_ptr = nullptr;
+    collection_addr_ptr = nullptr;
+    tripwire = nullptr;
+  }
+
 private:
   void initialize_semispace();
   //

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -12,6 +12,7 @@
 extern "C" {
 extern thread_local arena youngspace;
 extern thread_local arena oldspace;
+extern thread_local arena alwaysgcspace;
 
 char *youngspace_ptr(void);
 char *oldspace_ptr(void);
@@ -345,5 +346,8 @@ void kore_collect(
 void free_all_kore_mem() {
   kore_collect(nullptr, 0, nullptr, true);
   kore_clear();
+  youngspace.munmap_arena_and_reset();
+  oldspace.munmap_arena_and_reset();
+  alwaysgcspace.munmap_arena_and_reset();
 }
 }


### PR DESCRIPTION
This is needed as in Pi2 we discovered that our GEth client, switches threads and not reuses the arena's mapped size in by other thread, instead, allocate the same amount at every switching making it pretty easy to overflow the memory usage.