### PR TITLE
Update `free_all_kore_mem` to avoid memory corruption

### DIFF
--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -347,7 +347,6 @@ void free_all_kore_mem() {
   kore_collect(nullptr, 0, nullptr, true);
   kore_clear();
   youngspace.munmap_arena_and_reset();
-  oldspace.munmap_arena_and_reset();
   alwaysgcspace.munmap_arena_and_reset();
 }
 }


### PR DESCRIPTION
Ideally, when we call this function, we want to clean everything, including all semispaces to free the memory for future usage. However, we found a bug com a few `ValidBlocks` tests from Ethereum BlockchainTests that throws an error when collecting the old generation when we had called this `free_all_kore_mem` before. This issue doesn't happen for the GeneralStateTests, that's why we didn't find it before.

This modification is safe and still keeps the benefits of freeing a lot of space, as the majority of allocated memory observed in the tests are stored in the young generation. 

We'll go back to investigate this GC bug soon.