### PR TITLE
Fixing `munmap_arena_and_reset` issue by reseting `allocation_ptr`

### DIFF
--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -122,6 +122,7 @@ public:
 
     current_addr_ptr = nullptr;
     collection_addr_ptr = nullptr;
+    allocation_ptr = nullptr;
     tripwire = nullptr;
   }
 

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -347,6 +347,7 @@ void free_all_kore_mem() {
   kore_collect(nullptr, 0, nullptr, true);
   kore_clear();
   youngspace.munmap_arena_and_reset();
+  oldspace.munmap_arena_and_reset();
   alwaysgcspace.munmap_arena_and_reset();
 }
 }


### PR DESCRIPTION
The `allocation_ptr` was the missing variable we needed to reset to correctly reset the whole semispace GC strategy. This PR fixes issue #1204 where the `allocation_ptr` kept an old value from a previous GC iteration that was often higher than the current `oldspace` semispace, making it impossible to be allocated or to clean the memory using it on `scan_ptr`