### PR TITLE
Implementing reset_munmap_all_arenas

### DIFF
--- a/include/runtime/collect.h
+++ b/include/runtime/collect.h
@@ -40,6 +40,7 @@ void migrate_collection_node(void **node_ptr);
 void set_kore_memory_functions_for_gmp(void);
 void kore_collect(void **, uint8_t, layoutitem *, bool force = false);
 void free_all_kore_mem();
+void reset_munmap_all_arenas();
 }
 
 #ifdef GC_DBG

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -346,6 +346,9 @@ void kore_collect(
 void free_all_kore_mem() {
   kore_collect(nullptr, 0, nullptr, true);
   kore_clear();
+}
+
+void reset_munmap_all_arenas() {
   youngspace.munmap_arena_and_reset();
   oldspace.munmap_arena_and_reset();
   alwaysgcspace.munmap_arena_and_reset();


### PR DESCRIPTION
This PR splits the implementation of `free_all_kore_mem` between 2 functions:
 - `free_all_kore_mem`
 - `reset_munmap_all_arenas`

The idea is only to use the second one when necessary, instead of executing its content every time we call the first.