### PR TITLE
bytes2hexstring hook

### DIFF
--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -9,7 +9,8 @@ expanded_input_file="$(mktemp tmp.in.XXXXXXXXXX)"
 parser_file="$(mktemp tmp.parse.XXXXXXXXXX)"
 temp_inputs=()
 
-cleanup () { # shellcheck disable=SC2329
+# shellcheck disable=SC2329
+cleanup () {
   # shellcheck disable=SC2317
   rm -rf "$input_file" "$expanded_input_file" "$output_file" "$parser_file" "${temp_inputs[@]}"
 }

--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -9,7 +9,7 @@ expanded_input_file="$(mktemp tmp.in.XXXXXXXXXX)"
 parser_file="$(mktemp tmp.parse.XXXXXXXXXX)"
 temp_inputs=()
 
-cleanup () {
+cleanup () { # shellcheck disable=SC2329
   # shellcheck disable=SC2317
   rm -rf "$input_file" "$expanded_input_file" "$output_file" "$parser_file" "${temp_inputs[@]}"
 }

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -148,37 +148,34 @@ hook_BYTES_int2bytes(SortInt len, SortInt i, SortEndianness endianness_ptr) {
   return result;
 }
 
-string *bytes2string(string *b, size_t len) {
-  auto *result = static_cast<string *>(kore_alloc_token(sizeof(string) + len));
-  memcpy(result->data, b->data, len);
-  init_with_len(result, len);
-  return result;
-}
-
 SortString hook_BYTES_bytes2string(SortBytes b) {
-  return bytes2string(b, len(b));
+  auto len_b = len(b);
+  auto *result = static_cast<string *>(kore_alloc_token(sizeof(string) + len_b));
+  memcpy(result->data, b->data, len_b);
+  init_with_len(result, len_b);
+  return result;
 }
 
 SortBytes hook_BYTES_string2bytes(SortString s) {
   return hook_BYTES_bytes2string(s);
 }
 
-string *bytes2hexstring(string *b, size_t len) {
+// Convert a bytes array to its hexadecimal string representation
+// For example, the bytes array b'\x01\xef' becomes the string "01ef"
+// syntax String ::= Bytes2Hex( Bytes )
+SortString hook_BYTES_bytes2hex(SortBytes b) {
   static const std::array<char, 16> hexchars
       = {'0', '1', '2', '3', '4', '5', '6', '7',
          '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+  auto len_b = len(b);
   auto *result
-      = static_cast<string *>(kore_alloc_token(sizeof(string) + len * 2));
-  for (size_t i = 0; i < len; i++) {
+      = static_cast<string *>(kore_alloc_token(sizeof(string) + len_b * 2));
+  for (size_t i = 0; i < len_b; i++) {
     result->data[i * 2] = hexchars.at((b->data[i] >> 4) & 0xf);
     result->data[i * 2 + 1] = hexchars.at(b->data[i] & 0xf);
   }
-  init_with_len(result, len * 2);
+  init_with_len(result, len_b * 2);
   return result;
-}
-
-SortString hook_BYTES_bytes2hexstring(SortBytes b) {
-  return bytes2hexstring(b, len(b));
 }
 
 SortBytes hook_BYTES_substr(SortBytes input, SortInt start, SortInt end) {

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -150,7 +150,8 @@ hook_BYTES_int2bytes(SortInt len, SortInt i, SortEndianness endianness_ptr) {
 
 SortString hook_BYTES_bytes2string(SortBytes b) {
   auto len_b = len(b);
-  auto *result = static_cast<string *>(kore_alloc_token(sizeof(string) + len_b));
+  auto *result
+      = static_cast<string *>(kore_alloc_token(sizeof(string) + len_b));
   memcpy(result->data, b->data, len_b);
   init_with_len(result, len_b);
   return result;

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -5,6 +5,7 @@
 #include <gmp.h>
 #include <stdexcept>
 #include <unordered_set>
+#include <array> // Add this include for std::array
 
 #include "runtime/alloc.h"
 #include "runtime/header.h"
@@ -163,12 +164,12 @@ SortBytes hook_BYTES_string2bytes(SortString s) {
 }
 
 string *bytes2hexstring(string *b, size_t len) {
-  static char const hexchars[] = "0123456789abcdef";
-  auto *result
-      = static_cast<string *>(kore_alloc_token(sizeof(string) + len * 2));
+  static const std::array<char, 16> hexchars = {'0', '1', '2', '3', '4', '5', '6', '7',
+                                                '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+  auto *result = static_cast<string *>(kore_alloc_token(sizeof(string) + len * 2));
   for (size_t i = 0; i < len; i++) {
-    result->data[i * 2] = hexchars[(*(b->data + i) >> 4) & 0xf];
-    result->data[i * 2 + 1] = hexchars[(*(b->data + i)) & 0xf];
+    result->data[i * 2] = hexchars.at((b->data[i] >> 4) & 0xf);
+    result->data[i * 2 + 1] = hexchars.at(b->data[i] & 0xf);
   }
   init_with_len(result, len * 2);
   return result;

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -167,8 +167,8 @@ string *bytes2hexstring(string *b, size_t len) {
   auto *result
       = static_cast<string *>(kore_alloc_token(sizeof(string) + len * 2));
   for (size_t i = 0; i < len; i++) {
-    result->data[i * 2] = hexchars[(b->data[i] >> 4) & 0xf];
-    result->data[i * 2 + 1] = hexchars[b->data[i] & 0xf];
+    result->data[i * 2] = hexchars[(*(b->data + i) >> 4) & 0xf];
+    result->data[i * 2 + 1] = hexchars[(*(b->data + i)) & 0xf];
   }
   init_with_len(result, len * 2);
   return result;

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -1,5 +1,5 @@
 #include <algorithm>
-#include <array> // Add this include for std::array
+#include <array>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -163,8 +163,9 @@ SortBytes hook_BYTES_string2bytes(SortString s) {
 }
 
 string *bytes2hexstring(string *b, size_t len) {
-  static const char hexchars[] = "0123456789abcdef";
-  auto *result = static_cast<string *>(kore_alloc_token(sizeof(string) + len * 2));
+  static char const hexchars[] = "0123456789abcdef";
+  auto *result
+      = static_cast<string *>(kore_alloc_token(sizeof(string) + len * 2));
   for (size_t i = 0; i < len; i++) {
     result->data[i * 2] = hexchars[(b->data[i] >> 4) & 0xf];
     result->data[i * 2 + 1] = hexchars[b->data[i] & 0xf];

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -1,11 +1,11 @@
 #include <algorithm>
+#include <array> // Add this include for std::array
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <gmp.h>
 #include <stdexcept>
 #include <unordered_set>
-#include <array> // Add this include for std::array
 
 #include "runtime/alloc.h"
 #include "runtime/header.h"
@@ -164,9 +164,11 @@ SortBytes hook_BYTES_string2bytes(SortString s) {
 }
 
 string *bytes2hexstring(string *b, size_t len) {
-  static const std::array<char, 16> hexchars = {'0', '1', '2', '3', '4', '5', '6', '7',
-                                                '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
-  auto *result = static_cast<string *>(kore_alloc_token(sizeof(string) + len * 2));
+  static const std::array<char, 16> hexchars
+      = {'0', '1', '2', '3', '4', '5', '6', '7',
+         '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+  auto *result
+      = static_cast<string *>(kore_alloc_token(sizeof(string) + len * 2));
   for (size_t i = 0; i < len; i++) {
     result->data[i * 2] = hexchars.at((b->data[i] >> 4) & 0xf);
     result->data[i * 2 + 1] = hexchars.at(b->data[i] & 0xf);

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -162,6 +162,21 @@ SortBytes hook_BYTES_string2bytes(SortString s) {
   return hook_BYTES_bytes2string(s);
 }
 
+string *bytes2hexstring(string *b, size_t len) {
+  static const char hexchars[] = "0123456789abcdef";
+  auto *result = static_cast<string *>(kore_alloc_token(sizeof(string) + len * 2));
+  for (size_t i = 0; i < len; i++) {
+    result->data[i * 2] = hexchars[(b->data[i] >> 4) & 0xf];
+    result->data[i * 2 + 1] = hexchars[b->data[i] & 0xf];
+  }
+  init_with_len(result, len * 2);
+  return result;
+}
+
+SortString hook_BYTES_bytes2hexstring(SortBytes b) {
+  return bytes2hexstring(b, len(b));
+}
+
 SortBytes hook_BYTES_substr(SortBytes input, SortInt start, SortInt end) {
   uint64_t ustart = GET_UI(start);
   uint64_t uend = GET_UI(end);

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -148,13 +148,15 @@ hook_BYTES_int2bytes(SortInt len, SortInt i, SortEndianness endianness_ptr) {
   return result;
 }
 
-SortString hook_BYTES_bytes2string(SortBytes b) {
-  auto len_b = len(b);
-  auto *result
-      = static_cast<string *>(kore_alloc_token(sizeof(string) + len_b));
-  memcpy(result->data, b->data, len_b);
-  init_with_len(result, len_b);
+string *bytes2string(string *b, size_t len) {
+  auto *result = static_cast<string *>(kore_alloc_token(sizeof(string) + len));
+  memcpy(result->data, b->data, len);
+  init_with_len(result, len);
   return result;
+}
+
+SortString hook_BYTES_bytes2string(SortBytes b) {
+  return bytes2string(b, len(b));
 }
 
 SortBytes hook_BYTES_string2bytes(SortString s) {

--- a/unittests/runtime-strings/bytestest.cpp
+++ b/unittests/runtime-strings/bytestest.cpp
@@ -20,7 +20,7 @@ mpz_ptr
 hook_BYTES_bytes2int(string *b, uint64_t endianness, uint64_t signedness);
 string *hook_BYTES_int2bytes(mpz_t len, mpz_t i, uint64_t endianness);
 string *hook_BYTES_bytes2string(string *b);
-string *hook_BYTES_bytes2hexstring(string *b);
+string *hook_BYTES_bytes2hex(string *b);
 string *hook_BYTES_string2bytes(string *s);
 string *hook_BYTES_substr(string *b, mpz_t start, mpz_t end);
 string *hook_BYTES_replaceAt(string *b, mpz_t start, string *b2);
@@ -172,17 +172,17 @@ BOOST_AUTO_TEST_CASE(bytes2string) {
   BOOST_CHECK_EQUAL(0, memcmp(_1234->data, "1234", 4));
 }
 
-BOOST_AUTO_TEST_CASE(bytes2hexstring) {
+BOOST_AUTO_TEST_CASE(bytes2hex) {
   auto empty = make_string("");
-  auto res = hook_BYTES_bytes2hexstring(empty);
+  auto res = hook_BYTES_bytes2hex(empty);
   BOOST_CHECK(res != empty);
   BOOST_CHECK_EQUAL(len(res), 0);
 
-  auto _00ff = make_string("\x00\xff", 2);
-  res = hook_BYTES_bytes2hexstring(_00ff);
-  BOOST_CHECK(res != _00ff);
+  auto _01ef = make_string("\x01\xef", 2);
+  res = hook_BYTES_bytes2hex(_01ef);
+  BOOST_CHECK(res != _01ef);
   BOOST_CHECK_EQUAL(len(res), 4);
-  BOOST_CHECK_EQUAL(0, memcmp(res->data, "00ff", 4));
+  BOOST_CHECK_EQUAL(0, memcmp(res->data, "01ef", 4));
 }
 
 BOOST_AUTO_TEST_CASE(string2bytes) {

--- a/unittests/runtime-strings/bytestest.cpp
+++ b/unittests/runtime-strings/bytestest.cpp
@@ -20,6 +20,7 @@ mpz_ptr
 hook_BYTES_bytes2int(string *b, uint64_t endianness, uint64_t signedness);
 string *hook_BYTES_int2bytes(mpz_t len, mpz_t i, uint64_t endianness);
 string *hook_BYTES_bytes2string(string *b);
+string *hook_BYTES_bytes2hexstring(string *b);
 string *hook_BYTES_string2bytes(string *s);
 string *hook_BYTES_substr(string *b, mpz_t start, mpz_t end);
 string *hook_BYTES_replaceAt(string *b, mpz_t start, string *b2);
@@ -169,6 +170,19 @@ BOOST_AUTO_TEST_CASE(bytes2string) {
   BOOST_CHECK(res != _1234);
   BOOST_CHECK_EQUAL(len(_1234), 4);
   BOOST_CHECK_EQUAL(0, memcmp(_1234->data, "1234", 4));
+}
+
+BOOST_AUTO_TEST_CASE(bytes2hexstring) {
+  auto empty = make_string("");
+  auto res = hook_BYTES_bytes2hexstring(empty);
+  BOOST_CHECK(res != empty);
+  BOOST_CHECK_EQUAL(len(res), 0);
+
+  auto _00ff = make_string("\x00\xff", 2);
+  res = hook_BYTES_bytes2hexstring(_00ff);
+  BOOST_CHECK(res != _00ff);
+  BOOST_CHECK_EQUAL(len(res), 4);
+  BOOST_CHECK_EQUAL(0, memcmp(res->data, "00ff", 4));
 }
 
 BOOST_AUTO_TEST_CASE(string2bytes) {


### PR DESCRIPTION
This PR adds a new hook implementation for converting byte arrays into hex strings.
This is needed by the kontrol-node to encode memory as JSON strings efficiently.
